### PR TITLE
QUnit.reset() can cause assertions to run after the test has finished

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -128,12 +128,6 @@ var QUnit = {
 	    });
 	
 	    synchronize(function() {
-			try {
-				QUnit.reset();
-			} catch(e) {
-				fail("reset() failed, following Test " + name + ", exception and reset fn follows", e, reset);
-			}
-
 			if ( config.expected && config.expected != config.assertions.length ) {
 				QUnit.ok( false, "Expected " + config.expected + " assertions, but " + config.assertions.length + " were run" );
 			}
@@ -209,6 +203,12 @@ var QUnit = {
 						config.moduleStats.bad++;
 					}
 				}
+			}
+
+			try {
+				QUnit.reset();
+			} catch(e) {
+				fail("reset() failed, following Test " + name + ", exception and reset fn follows", e, reset);
 			}
 
 			QUnit.testDone( testName, bad, config.assertions.length );

--- a/test/test.js
+++ b/test/test.js
@@ -194,6 +194,23 @@ test("each test can extend the module testEnvironment", {
 	equal( makeurl(), 'http://google.com/?q=hamstersoup', 'url from module, q from test');	
 });
 
+(function() {
+	var reset = QUnit.reset;
+	function afterTest() {
+		ok( false, "reset should not modify test status" );
+	}
+	module("reset");
+	test("reset runs assertions", function() {
+		QUnit.reset = function() {
+			afterTest();
+			reset.apply( this, arguments );
+		};
+	});
+	test("reset runs assertions2", function() {
+		QUnit.reset = reset;
+	});
+})();
+
 module("jsDump");
 test("jsDump output", function() {
 	equals( QUnit.jsDump.parse([1, 2]), "[ 1, 2 ]" );


### PR DESCRIPTION
I ran into a problem with the following test for jQuery UI:

test( "auto-destroy - .remove() on child", function() {
    $.widget( "ui.testWidget", {
        _create: function() {},
        destroy: function() {
            ok( false, "destroyed from .remove() on child" );
        }
    });
    $( "#widget" ).testWidget().children().remove();
});

The problem is that QUnit.reset() clears the test fixture, which causes jQuery.cleanData() to run on all the elements, which causes the widget to destroy itself. Since the reset occurs after the test has completed, this seems wrong. I've moved the reset further down, but I don't know if this will have any strange side effects in some weird edge cases.
