### PR TITLE
"Hide passed tests" selection not respected for new results

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -188,6 +188,7 @@ var QUnit = {
 				var li = id("current-test-output");
 				li.id = "";
 				li.className = bad ? "fail" : "pass";
+				li.style.display = resultDisplayStyle(!bad);
 				li.removeChild( li.firstChild );
 				li.appendChild( b );
 				li.appendChild( ol );
@@ -632,6 +633,10 @@ function validTest( name ) {
 	}
 
 	return run;
+}
+
+function resultDisplayStyle(passed) {
+	return passed && id("qunit-filter-pass").checked ? 'none' : '';
 }
 
 function escapeHtml(s) {


### PR DESCRIPTION
If you select "Hide passed tests" while the test suite is still running, it hides the currently displayed results but not new ones being written out. I made a simple change to hide new passed results as well if that option is selected.
