### PR TITLE
Dies on circular references

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -204,6 +204,9 @@ test("jsDump output", function() {
 		equals( QUnit.jsDump.parse(document.getElementById("qunit-header")), "<h1 id=\"qunit-header\"></h1>" );
 		equals( QUnit.jsDump.parse(document.getElementsByTagName("h1")), "[\n  <h1 id=\"qunit-header\"></h1>\n]" );
 	}
+	var obj = {};
+	obj.a = obj;
+	equals( QUnit.jsDump.parse(obj), '{\n  "a": #\n}' );
 });
 
 module("assertions");


### PR DESCRIPTION
```
RangeError: Maximum call stack size exceeded
```

Just broken test for now. Mine [console.js](https://github.com/NV/console.js/) handles [circular references](http://nv.github.com/console.js/tests/?dir:%20Recursive%20objects) well. Might want to get a fix from it.
