### PR TITLE
Added match/notMatch methods

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -325,6 +325,14 @@ var QUnit = {
 	notEqual: function(actual, expected, message) {
 		QUnit.push(expected != actual, actual, expected, message);
 	},
+
+	match: function(actual, regexp, message) {
+	        QUnit.push(regexp.test(actual), actual, 'Match with: ' + regexp, message);
+	},
+
+	notMatch: function(actual, regexp, message) {
+	        QUnit.push(!regexp.test(actual), actual, 'No match with: ' + regexp, message);
+	},
 	
 	deepEqual: function(actual, expected, message) {
 		QUnit.push(QUnit.equiv(actual, expected), actual, expected, message);


### PR DESCRIPTION
Hi,

I've added to simple methods in qUnit to test a value against a regular expression. It basically works like equal/notEqual, except that the second parameter is a regular expression.

The reason for not using ok(myexp.test(myresult) is to be able to have the nice output you get with equal, so you know what went wrong (well, depending on the complexity of your regexp of course).

Vincent
