### PR TITLE
Added a pixelEquals function that checks if a given pixel of a canvas is equal to a provided rgba value

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -342,6 +342,11 @@ var QUnit = {
 		QUnit.push(expected !== actual, actual, expected, message);
 	},
 
+	pixelEquals: function(canvas, x, y, r, g, b, a, message) {
+		var actual = Array.prototype.slice.apply(canvas.getContext('2d').getImageData(x, y, 1, 1).data), expected = [r, g, b, a];
+		QUnit.push(QUnit.equiv(actual, expected), actual, expected, message);
+	},
+
 	raises: function(block, expected, message) {
 		var actual, ok = false;
 	

--- a/test/index.html
+++ b/test/index.html
@@ -14,5 +14,6 @@
 	<h2 id="qunit-userAgent"></h2>
 	<ol id="qunit-tests"></ol>
 	<div id="qunit-fixture">test markup</div>
+    <canvas id="qunit-canvas" width="5" height="5"></canvas>
 </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -312,3 +312,81 @@ module("custom assertions");
 		QUnit.reset = reset;
 	});
 })();
+
+
+test("Canvas pixels", function () {
+	var canvas = document.getElementById('qunit-canvas'), context;
+	try {
+		context = canvas.getContext('2d');
+	} catch(e) {
+		// propably no canvas support, just exit
+		return;
+	}
+	context.fillStyle = 'rgba(0, 0, 0, 0)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 0, 0, 0, 0, 0, 0);
+	context.clearRect(0,0,5,5);
+	context.fillStyle = 'rgba(255, 0, 0, 0)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 0, 0, 0, 0, 0, 0);
+	context.clearRect(0,0,5,5);
+	context.fillStyle = 'rgba(0, 255, 0, 0)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 0, 0, 0, 0, 0, 0);
+	context.clearRect(0,0,5,5);
+	context.fillStyle = 'rgba(0, 0, 255, 0)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 0, 0, 0, 0, 0, 0);
+	context.clearRect(0,0,5,5);
+
+	context.fillStyle = 'rgba(0, 0, 0, 0.5)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 0, 0, 0, 0, 0, 127);
+	context.clearRect(0,0,5,5);
+	context.fillStyle = 'rgba(255, 0, 0, 0.5)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 0, 0, 255, 0, 0, 127);
+	context.clearRect(0,0,5,5);
+	context.fillStyle = 'rgba(0, 255, 0, 0.5)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 0, 0, 0, 255, 0, 127);
+	context.clearRect(0,0,5,5);
+	context.fillStyle = 'rgba(0, 0, 255, 0.5)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 0, 0, 0, 0, 255, 127);
+	context.clearRect(0,0,5,5);
+
+	context.fillStyle = 'rgba(0, 0, 0, 0.5)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 2, 2, 0, 0, 0, 127);
+	context.clearRect(0,0,5,5);
+	context.fillStyle = 'rgba(255, 0, 0, 0.5)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 2, 2, 255, 0, 0, 127);
+	context.clearRect(0,0,5,5);
+	context.fillStyle = 'rgba(0, 255, 0, 0.5)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 2, 2, 0, 255, 0, 127);
+	context.clearRect(0,0,5,5);
+	context.fillStyle = 'rgba(0, 0, 255, 0.5)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 2, 2, 0, 0, 255, 127);
+	context.clearRect(0,0,5,5);
+
+	context.fillStyle = 'rgba(0, 0, 0, 1)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 4, 4, 0, 0, 0, 255);
+	context.clearRect(0,0,5,5);
+	context.fillStyle = 'rgba(255, 0, 0, 1)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 4, 4, 255, 0, 0, 255);
+	context.clearRect(0,0,5,5);
+	context.fillStyle = 'rgba(0, 255, 0, 1)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 4, 4, 0, 255, 0, 255);
+	context.clearRect(0,0,5,5);
+	context.fillStyle = 'rgba(0, 0, 255, 1)';
+	context.fillRect(0, 0, 5, 5);
+	pixelEquals(canvas, 4, 4, 0, 0, 255, 255);
+	context.clearRect(0,0,5,5);
+});


### PR DESCRIPTION
The title pretty much says everything. I needed the test function for a project of mine and implemented it. I thought I might aswell share it with the qunit project.
Howto use pixelEquals:

```
var canvas = document.getElementById('myCanvas');
// draw something to the canvas that will set the pixel 
// at x = 50, y = 100 to fully red, 50% transparency

pixelEquals(canvas, 50, 100, 255, 0, 0, 127); // will yield a successfull test
```

I also added a testcase to the test suite. However, I wasn't sure where to actually put it, so I just added it to the end of test.js. Of course a canvas element is required for the test. I added it to the test's index.html.

If you like it, use it :)

Best regards,
Daniel
