### PR TITLE
Fixed filtering logic when double clicking a test

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -172,7 +172,7 @@ Test.prototype = {
 					target = target.parentNode;
 				}
 				if ( window.location && target.nodeName.toLowerCase() === "strong" ) {
-					window.location = QUnit.url({ filter: getText([target]).replace(/\(.+\)$/, "").replace(/(^\s*|\s*$)/g, "") });
+					window.location = QUnit.url({ filter: getText([target]).replace(/\([^)]+\)$/, "").replace(/(^\s*|\s*$)/g, "") });
 				}
 			});
 


### PR DESCRIPTION
The regex that was being used to remove the test counts was too greedy and matched parentheses in the test name.
