### PR TITLE
Escape stacktrace output before setting it as innerHTML

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -625,7 +625,7 @@ extend(QUnit, {
 			var source = sourceFromStacktrace();
 			if (source) {
 				details.source = source;
-				output += '<tr class="test-source"><th>Source: </th><td><pre>' + source +'</pre></td></tr>';
+				output += '<tr class="test-source"><th>Source: </th><td><pre>' + escapeHtml(source) + '</pre></td></tr>';
 			}
 		}
 		output += "</table>";


### PR DESCRIPTION
Escape the stacktrace output before setting it as innerHTML, since it tends to contain `<` and `>` characters.

Before: 

![](http://i.imgur.com/LfcoX.png)

After:

![](http://i.imgur.com/HKhd9.png)
