### PR TITLE
Adding a QUnit.config.noaltertitle flag

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -444,7 +444,7 @@ var config = {
 	reorder: true,
 
 	// by default, modify document.title when suite is done
-	altertitle: false,
+	altertitle: true,
 
 	noglobals: false,
 	notrycatch: false


### PR DESCRIPTION
Adding a QUnit.config.noaltertitle flag which will allow users to opt-out of the functionality introduced in 60147ca0164e3d810b8a9bf46981c3d9cc569efc
