### PR TITLE
Synchronous calls to stop cause test failures Issue 118

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -400,6 +400,9 @@ var QUnit = {
 		// A slight delay, to avoid any current callbacks
 		if ( defined.setTimeout ) {
 			window.setTimeout(function() {
+				if(config.semaphore > 0){
+					return;
+				}
 				if ( config.timeout ) {
 					clearTimeout(config.timeout);
 				}

--- a/test/test.js
+++ b/test/test.js
@@ -135,6 +135,19 @@ test("sync", 2, function() {
 		start();
 	}, 125);
 });
+
+test("test synchronous calls to stop", 2, function() {
+    stop();
+    setTimeout(function(){
+        ok(true, 'first');
+        start();
+        stop();
+        setTimeout(function(){
+            ok(true, 'second');
+            start();
+        }, 150);
+    }, 150);
+});
 }
 
 module("save scope", {


### PR DESCRIPTION
Issues #118
Fixes a bug where synchronous calls to stop would cause tests to end before start was called again

https://gist.github.com/1055426
