### PR TITLE
Create configuration setting for default stop() timeout (issue #123)

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -416,6 +416,9 @@ var QUnit = {
 	stop: function(timeout) {
 		config.semaphore++;
 		config.blocking = true;
+		if ( timeout === undefined ) {
+			timeout = config.timeoutDuration;
+		}
 
 		if ( timeout && defined.setTimeout ) {
 			clearTimeout(config.timeout);


### PR DESCRIPTION
Let stop() timeout default to config.timeoutDuration is none is given. Fixes issue #123
