### PR TITLE
Addition of start/stop count parameter

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -389,8 +389,8 @@ var QUnit = {
 		QUnit.ok(ok, message);
 	},
 
-	start: function() {
-		config.semaphore--;
+	start: function(count) {
+		config.semaphore -= count || 1;
 		if (config.semaphore > 0) {
 			// don't start until equal number of stop-calls
 			return;
@@ -418,16 +418,17 @@ var QUnit = {
 		}
 	},
 
-	stop: function(timeout) {
-		config.semaphore++;
+	stop: function(count) {
+		config.semaphore += count || 1;
 		config.blocking = true;
 
-		if ( timeout && defined.setTimeout ) {
+		if ( config.testTimeout && defined.setTimeout ) {
 			clearTimeout(config.timeout);
 			config.timeout = window.setTimeout(function() {
 				QUnit.ok( false, "Test timed out" );
+				config.semaphore = 1;
 				QUnit.start();
-			}, timeout);
+			}, config.testTimeout);
 		}
 	}
 };

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,28 @@ test("teardown must be called after test ended", function() {
 	}, 13);
 });
 
+test("parameter passed to stop increments semaphore n times", function() {
+	expect(1);
+	stop(3);
+	setTimeout(function() {
+		state = "not enough starts";
+		start(), start();
+	}, 13);
+	setTimeout(function() {
+		state = "done";
+		start();
+	}, 15);
+});
+
+test("parameter passed to start decrements semaphore n times", function() {
+	expect(1);
+	stop(), stop(), stop();
+	setTimeout(function() {
+		state = "done";
+		start(3);
+	}, 18);
+});
+
 module("async setup test", {
 	setup: function() {
 		stop();


### PR DESCRIPTION
In response to the discussion in issue #123, I've added a parameter to stop and star that allows the user to decrement/increment the semaphore more than once per call.

``` JavaScript
start(3);
//Same as calling 
start(),start(),start();
```
