### PR TITLE
small usability fix in css

### DIFF
--- a/qunit/qunit.css
+++ b/qunit/qunit.css
@@ -186,6 +186,7 @@
 	color: #710909;
 	background-color: #fff;
 	border-left: 26px solid #EE5757;
+	white-space: pre;
 }
 
 #qunit-tests > li:last-child {


### PR DESCRIPTION
Tracebacks in error output was rather unhelpfully smashed into one
line, discarding line breaks.  This fixes that to use whitespace: pre
for the output of tests.
