### PR TITLE
Adds the 'close enough' addon to compare numbers within a given tolerance.

### DIFF
--- a/addons/close-enough/qunit-close-enough-test.js
+++ b/addons/close-enough/qunit-close-enough-test.js
@@ -1,0 +1,37 @@
+test("Close Numbers", function () {
+
+	QUnit.close(7, 7, 0);
+	QUnit.close(7, 7.1, 0.1);
+	QUnit.close(7, 7.1, 0.2);
+	
+	QUnit.close(3.141, Math.PI, 0.001);
+	QUnit.close(3.1, Math.PI, 0.1);
+	
+	var halfPi = Math.PI / 2;
+	QUnit.close(halfPi, 1.57, 0.001);
+	
+	var sqrt2 = Math.sqrt(2);
+	QUnit.close(sqrt2, 1.4142, 0.0001);
+	
+	QUnit.close(Infinity, Infinity, 1);	
+	
+});
+
+test("Distant Numbers", function () {
+
+	QUnit.notClose(6, 7, 0);
+	QUnit.notClose(7, 7.2, 0.1);
+	QUnit.notClose(7, 7.2, 0.19999999999);
+	
+	QUnit.notClose(3.141, Math.PI, 0.0001);
+	QUnit.notClose(3.1, Math.PI, 0.001);
+	
+	var halfPi = Math.PI / 2;
+	QUnit.notClose(halfPi, 1.57, 0.0001);
+	
+	var sqrt2 = Math.sqrt(2);
+	QUnit.notClose(sqrt2, 1.4142, 0.00001);
+	
+	QUnit.notClose(Infinity, -Infinity, 5);
+
+});

--- a/addons/close-enough/qunit-close-enough.html
+++ b/addons/close-enough/qunit-close-enough.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8" />
+	<title>QUnit Test Suite - Close Enough Addon</title>
+	<link rel="stylesheet" href="../../qunit/qunit.css" type="text/css" media="screen">
+	<script type="text/javascript" src="../../qunit/qunit.js"></script>
+	<script type="text/javascript" src="qunit-close-enough.js"></script>
+	<script type="text/javascript" src="qunit-close-enough-test.js"></script>
+</head>
+<body>
+	<h1 id="qunit-header">QUnit Test Suite - Close Enough</h1>
+	<h2 id="qunit-banner"></h2>
+	<div id="qunit-testrunner-toolbar"></div>
+	<h2 id="qunit-userAgent"></h2>
+	<ol id="qunit-tests"></ol>
+</body>
+</html>

--- a/addons/close-enough/qunit-close-enough.js
+++ b/addons/close-enough/qunit-close-enough.js
@@ -1,0 +1,32 @@
+QUnit.extend( QUnit, {
+	/**
+	 * Checks that the first two arguments are equal, or are numbers close enough to be considered equal
+	 * based on a specified maximum allowable difference.
+	 *
+	 * @example close(3.141, Math.PI, 0.001);
+	 *
+	 * @param Number actual
+	 * @param Number expected
+	 * @param Number maxDifference (the maximum inclusive difference allowed between the actual and expected numbers)
+	 * @param String message (optional)
+	 */
+	close: function(actual, expected, maxDifference, message) {
+		var passes = (actual === expected) || Math.abs(actual - expected) <= maxDifference;
+		QUnit.push(passes, actual, expected, message);
+	},
+	
+	/**
+	 * Checks that the first two arguments are numbers with differences greater than the specified 
+	 * minimum difference.
+	 *
+	 * @example notClose(3.1, Math.PI, 0.001);
+	 *
+	 * @param Number actual
+	 * @param Number expected
+	 * @param Number minDifference (the minimum exclusive difference allowed between the actual and expected numbers)
+	 * @param String message (optional)
+	 */
+	notClose: function(actual, expected, minDifference, message) {
+		QUnit.push(Math.abs(actual - expected) > minDifference, actual, expected, message);
+	}
+});


### PR DESCRIPTION
Adds the 'close enough' addon to determine if numbers are acceptably close enough in value.  It also allows for the opposite comparison 'not close'.

Example Usage:

QUnit.close(3.141, Math.PI, 0.001, "Close enough to Pi");

QUnit.notClose(accountBalance, 0, 100, "Not broke yet");

Note: This doesn't change the HTML output as I first proposed in the forums: https://forum.jquery.com/topic/acceptable-delta-when-comparing-numbers

If a test passes with numbers that are acceptably different, the output will still contain the green/red diff.  I played with a few ways to alter the output from within the addon structure but I decided that none of my solutions were non-invasive enough to warrant their benefit.
