### PR TITLE
Async tests run after initial page load causes assertions to move between tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -469,3 +469,65 @@ test("let teardown clean up globals", function() {
 	// this test will always pass if run without ?noglobals=true
 	window.badGlobalVariableIntroducedInTest = true;
 });
+
+if (typeof setTimeout !== 'undefined') {
+function testAfterDone(){
+	var testName = "ensure has correct number of assertions";
+
+	function secondAfterDoneTest(){
+		QUnit.config.done = [];
+		//QUnit.done = function(){};
+		//because when this does happen, the assertion count parameter doesn't actually 
+		//work we use this test to check the assertion count.
+		module("check previous test's assertion counts");
+		test('count previous two test\'s assertions', function(){
+			var spans = document.getElementsByTagName('span'),
+			tests = [],
+			countNodes;
+		
+			//find these two tests
+			for (var i = 0; i < spans.length; i++) {
+				if (spans[i].innerHTML.indexOf(testName) !== -1) {
+					tests.push(spans[i]);
+				}
+			}
+		
+			//walk dom to counts
+			countNodes = tests[0].nextSibling.nextSibling.getElementsByTagName('b');
+			equal(countNodes[1].innerHTML, "99");
+			countNodes = tests[1].nextSibling.nextSibling.getElementsByTagName('b');
+			equal(countNodes[1].innerHTML, "99");
+		});
+	}
+	QUnit.config.done = [];
+	QUnit.done(secondAfterDoneTest);
+	
+	module("Synchronous test after load of page");
+
+	asyncTest('Async test', function(){
+		start();
+		for (i=1;i<100;i++) {
+			ok(i);
+		}
+	});
+		
+	test(testName, 99, function(){
+		for (i=1;i<100;i++) {
+			ok(i);
+		}
+	});
+	
+	//we need two of these types of tests in order to ensure that assertions
+	//don't move between tests.
+	test(testName + ' 2', 99, function(){
+		for (i=1;i<100;i++) {
+			ok(i);
+		}
+	});
+	
+
+}
+
+QUnit.done(testAfterDone);
+
+}


### PR DESCRIPTION
Bug #82 shows the behavior fixed by this patch nicely. In the gist provided inside Bug #82 we see that the user wants to be able to load a page, then after it's been loaded call a method in order to make tests start.

Four problems occur because of this:
- Assertions move between tests
- config.current points to the wrong test for much of the testing.
- QUnit.done() is called multiple times before tests are actually finished running.
- Tests are run out of order.

I go into detail on how exactly this happens below. It's fairly involved so don't bother reading it if you can avoid it.

So far I think the pull request fixes the problem nicely and I've created a regression test that shows the problem happening prior to the fix.

---

Within QUnit there is a method bound to the load event. Launching tests after this event causes some internal state to be different than standard QUnit tests. The important factor is that config.autorun is set to true.

Once this becomes the case all calls to synchronize inside of synchronous tests causes a call to process. This isn't a problem so long as all the tests are synchronous, but if an async test is introduced and multiple calls a pushed on config.queue we run into a case where config.current can point to the wrong test causing assertions to move between tests. I'll try to give a simple example below.

launchTests(); //this is called after load event, config.autorun is true
asyncTest(...); //this sets up a setTimeout we'll come back to this timeout later

At this point config.queue has nothing on it as all calls to synchronize have lead to process calls and the which was just put on was executed inside of process. So currently we are inside of a call to Test.run() which has stopped with a call to stop() and will continue with a later call to start() after some timeout.
config.blocking == true
config.queue == empty array

From here execution flows back out to the next test. Because we are blocking the remaining 2 tests are queued, leading to the following state.
config.blocking == true
config.queue == [
    init(),
    Test.queue.run(),
    init(),
    Test.queue.run()
];

This completes execution of the launchTests() method. From here, driving is up to QUnit.

The setTimeout function is executed causing the completion of the asyncTest's callback the last line of which is a call to QUnit.start(). Start sets another setTimeout but since all other execution is complete, we wait for this to be triggered, which leads to a call to process().
config.blocking == false
config.queue == same as above

This is where things get interesting.
Within process() we go into a while loop that calles each of the things waiting inside of config.queue
First up is init() on the first synchronous test, this runs without negative side effect.
Next is Test.queue.run() on the first synchronous test. Within run are 4 calls to synchronize, however because config.autorun is set to true the very first call to synchronize leads to a call to process()

We have recursed. 
We are currently inside of a call to Test.queue.run() and state is as follows:
config.blocking == false
config.queue == [
    init(),
    run(),
    setup()
];

Inside of the process(), we jump back into the while loop leading to a call to the second tests init() and Test.queue.run(). init() runs as expected. Test.queue.run() is called, the first line of Test.queue.run() is another call to synchronize() which again leads to a call to process(). This is our second recursion.
State is as follows:
config.blocking == false
config.queue == [
    setup(), //first tests's setup
    setup(), //second test's setup
]

Here is where the first bug that this patch fixes occurs. This while loop process both callbacks within config.queue leading to two synchronous calls to setup(), the second of which sets config.curren to the second synchronous test.
State is as follows:
config.current == sync test 2
config.blocking == false
config.queue == empty Array()

The second bug occurs right after. Because we aren't blocking and there is nothing left on the queue, a call to done() occurs. This causes the top banner to be painted in such a way that suggests that tests have finished running even though that is very clearly not the case.

From here we go back up the callstack to synchronize() then to Test.queue.run(). From here execution continues through Test.queue.run() each call to synchronize() executing it's callback immediately along with a call to done().
State is as follows:
config.current == sync tests 2
config.blocking == false
config.queue == empty Array()

Here comes bug number three, and what this is all really about. After the second synchronous test is finished running, control flows out of this recursion and back into the first synchronous test's Test.queue.run(). Leading to calls to it's run, teardown and finish methods. All of these methods are run with config.current pointing to the wrong test, a test that has already finished.
