### PR TITLE
Fix syntax error and commonjs incompat in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,17 @@
 		"name": "Jörn Zaefferer",
 		"email": "joern.zaefferer@googlemail.com",
 		"url": "http://bassistance.de/"
-	},
+	}],
 	"url": "http://docs.jquery.com/QUnit",
+	"repositories"	: [{
+		"type": "git", 
+		"url": "https://github.com/jquery/qunit.git"
+	}],
 	"license": {
 		"name": "MIT",
 		"url": "http://www.opensource.org/licenses/mit-license.php"
 	},
 	"description": "An easy-to-use JavaScript Unit Testing framework.",
 	"keywords": [ "testing", "unit", "jquery" ],
-	"lib": "qunit"
+	"main": "qunit/qunit.js"
 }


### PR DESCRIPTION
Hi jQuery devs, 

Some minor changes to the package.json. It's still missing a 'version' as I couldn't find a version somewhere in the docs.

Thanks and would appreciate the merge.
