### PR TITLE
Handle expect(0) as expected

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -122,7 +122,7 @@ Test.prototype = {
 		}
 	},
 	finish: function() {
-		if (this.expected !== undefined && this.expected !== null && this.expected != this.assertions.length ) {
+		if ( this.expected != null && this.expected != this.assertions.length ) {
 			QUnit.ok( false, "Expected " + this.expected + " assertions, but " + this.assertions.length + " were run" );
 		}
 


### PR DESCRIPTION
I think that if something like the following fails

```
test("foo", function() {
    expect(1); ok(true, "foo"); ok(true, "bar");
});
```

then the following should fail too

```
test("foo", function() {
    expect(0); ok(true, "foo");
});
```
