### PR TITLE
Fix for Issue #163 (jsDump treats any object with a length property as an array)

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -1268,9 +1268,9 @@ QUnit.jsDump = (function() {
 				type = "document";
 			} else if (obj.nodeType) {
 				type = "node";
-			} else if (Object.prototype.toString.call( obj ) == "[object Array]") {
+			} else if (Object.prototype.toString.call( obj ) === "[object Array]") {
 				type = "array";
-			} else if (Object.prototype.toString.call( obj ) == "[object NodeList]") {
+			} else if (Object.prototype.toString.call( obj ) === "[object NodeList]") {
 				type = "array";
 			} else {
 				type = typeof obj;


### PR DESCRIPTION
Added more strict array type detection for dump output, and allowed NodeList objects to be output as arrays

This helps prevent treating any object with a length property as an array, while maintaining the ability to render NodeList objects as arrays. jsDump output tests still pass after this patch is applied.

Fixes https://github.com/qunitjs/qunit/issues/163.