### PR TITLE
Fox for Issue #165 - Fixed IE compatibility issues with using toString on NodeList objects

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -1268,9 +1268,12 @@ QUnit.jsDump = (function() {
 				type = "document";
 			} else if (obj.nodeType) {
 				type = "node";
-			} else if (Object.prototype.toString.call( obj ) === "[object Array]") {
-				type = "array";
-			} else if (Object.prototype.toString.call( obj ) === "[object NodeList]") {
+			} else if (
+				// native arrays
+				Object.prototype.toString.call( obj ) === "[object Array]" ||
+				// NodeList objects
+				( typeof obj.length === "number" && typeof obj.item !== "undefined" && ( obj.length ? obj.item(0) === obj[0] : ( obj.item( 0 ) === null && typeof obj[0] === "undefined" ) ) )
+			) {
 				type = "array";
 			} else {
 				type = typeof obj;


### PR DESCRIPTION
In some browsers results in [object Object] rather than [object NodeList]. Now using duck typing for NodeList objects based on the presence of length, length being a number, presence of item method (which will be typeof string in IE and function in others, so we just check that it's not undefined) and that item(0) returns the same value as [0], unless it's empty, in which case item(0) will return null, while [0] would return undefined. Tested in IE6, IE8, Firefox 6, Safari 5 and Chrome 16.
