### PR TITLE
Using node-qunit port, the start/stop function are not exposed so we need

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -112,7 +112,7 @@ Test.prototype = {
 
 			// Restart the tests if they're blocking
 			if ( config.blocking ) {
-				start();
+				QUnit.start();
 			}
 		}
 	},


### PR DESCRIPTION
Using node-qunit port, the start/stop function are not exposed so we need to prefix any call to them with 'QUnit'. Aka: start() -> QUnit.start()
