### PR TITLE
Fix IE8 "Member not found" error

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -1000,7 +1000,9 @@ function extend(a, b) {
 	for ( var prop in b ) {
 		if ( b[prop] === undefined ) {
 			delete a[prop];
-		} else {
+
+		// Avoid "Member not found" error in IE8 caused by setting window.constructor
+		} else if ( prop !== "constructor" || a !== window ) {
 			a[prop] = b[prop];
 		}
 	}


### PR DESCRIPTION
This fixes #154.

Line 513 extends `window` with `QUnit`, which changes `window.constructor` and triggers an error in IE8 only.  I added a check to prevent `window.constructor` from being changed.
