### PR TITLE
remove uses of equals(), as it's deprecated in favor of equal()

### DIFF
--- a/test/same.js
+++ b/test/same.js
@@ -2,133 +2,133 @@ module("equiv");
 
 
 test("Primitive types and constants", function () {
-    equals(QUnit.equiv(null, null), true, "null");
-    equals(QUnit.equiv(null, {}), false, "null");
-    equals(QUnit.equiv(null, undefined), false, "null");
-    equals(QUnit.equiv(null, 0), false, "null");
-    equals(QUnit.equiv(null, false), false, "null");
-    equals(QUnit.equiv(null, ''), false, "null");
-    equals(QUnit.equiv(null, []), false, "null");
+    equal(QUnit.equiv(null, null), true, "null");
+    equal(QUnit.equiv(null, {}), false, "null");
+    equal(QUnit.equiv(null, undefined), false, "null");
+    equal(QUnit.equiv(null, 0), false, "null");
+    equal(QUnit.equiv(null, false), false, "null");
+    equal(QUnit.equiv(null, ''), false, "null");
+    equal(QUnit.equiv(null, []), false, "null");
 
-    equals(QUnit.equiv(undefined, undefined), true, "undefined");
-    equals(QUnit.equiv(undefined, null), false, "undefined");
-    equals(QUnit.equiv(undefined, 0), false, "undefined");
-    equals(QUnit.equiv(undefined, false), false, "undefined");
-    equals(QUnit.equiv(undefined, {}), false, "undefined");
-    equals(QUnit.equiv(undefined, []), false, "undefined");
-    equals(QUnit.equiv(undefined, ""), false, "undefined");
+    equal(QUnit.equiv(undefined, undefined), true, "undefined");
+    equal(QUnit.equiv(undefined, null), false, "undefined");
+    equal(QUnit.equiv(undefined, 0), false, "undefined");
+    equal(QUnit.equiv(undefined, false), false, "undefined");
+    equal(QUnit.equiv(undefined, {}), false, "undefined");
+    equal(QUnit.equiv(undefined, []), false, "undefined");
+    equal(QUnit.equiv(undefined, ""), false, "undefined");
 
     // Nan usually doest not equal to Nan using the '==' operator.
     // Only isNaN() is able to do it.
-    equals(QUnit.equiv(0/0, 0/0), true, "NaN"); // NaN VS NaN
-    equals(QUnit.equiv(1/0, 2/0), true, "Infinity"); // Infinity VS Infinity
-    equals(QUnit.equiv(-1/0, 2/0), false, "-Infinity, Infinity"); // -Infinity VS Infinity
-    equals(QUnit.equiv(-1/0, -2/0), true, "-Infinity, -Infinity"); // -Infinity VS -Infinity
-    equals(QUnit.equiv(0/0, 1/0), false, "NaN, Infinity"); // Nan VS Infinity
-    equals(QUnit.equiv(1/0, 0/0), false, "NaN, Infinity"); // Nan VS Infinity
-    equals(QUnit.equiv(0/0, null), false, "NaN");
-    equals(QUnit.equiv(0/0, undefined), false, "NaN");
-    equals(QUnit.equiv(0/0, 0), false, "NaN");
-    equals(QUnit.equiv(0/0, false), false, "NaN");
-    equals(QUnit.equiv(0/0, function () {}), false, "NaN");
-    equals(QUnit.equiv(1/0, null), false, "NaN, Infinity");
-    equals(QUnit.equiv(1/0, undefined), false, "NaN, Infinity");
-    equals(QUnit.equiv(1/0, 0), false, "NaN, Infinity");
-    equals(QUnit.equiv(1/0, 1), false, "NaN, Infinity");
-    equals(QUnit.equiv(1/0, false), false, "NaN, Infinity");
-    equals(QUnit.equiv(1/0, true), false, "NaN, Infinity");
-    equals(QUnit.equiv(1/0, function () {}), false, "NaN, Infinity");
+    equal(QUnit.equiv(0/0, 0/0), true, "NaN"); // NaN VS NaN
+    equal(QUnit.equiv(1/0, 2/0), true, "Infinity"); // Infinity VS Infinity
+    equal(QUnit.equiv(-1/0, 2/0), false, "-Infinity, Infinity"); // -Infinity VS Infinity
+    equal(QUnit.equiv(-1/0, -2/0), true, "-Infinity, -Infinity"); // -Infinity VS -Infinity
+    equal(QUnit.equiv(0/0, 1/0), false, "NaN, Infinity"); // Nan VS Infinity
+    equal(QUnit.equiv(1/0, 0/0), false, "NaN, Infinity"); // Nan VS Infinity
+    equal(QUnit.equiv(0/0, null), false, "NaN");
+    equal(QUnit.equiv(0/0, undefined), false, "NaN");
+    equal(QUnit.equiv(0/0, 0), false, "NaN");
+    equal(QUnit.equiv(0/0, false), false, "NaN");
+    equal(QUnit.equiv(0/0, function () {}), false, "NaN");
+    equal(QUnit.equiv(1/0, null), false, "NaN, Infinity");
+    equal(QUnit.equiv(1/0, undefined), false, "NaN, Infinity");
+    equal(QUnit.equiv(1/0, 0), false, "NaN, Infinity");
+    equal(QUnit.equiv(1/0, 1), false, "NaN, Infinity");
+    equal(QUnit.equiv(1/0, false), false, "NaN, Infinity");
+    equal(QUnit.equiv(1/0, true), false, "NaN, Infinity");
+    equal(QUnit.equiv(1/0, function () {}), false, "NaN, Infinity");
 
-    equals(QUnit.equiv(0, 0), true, "number");
-    equals(QUnit.equiv(0, 1), false, "number");
-    equals(QUnit.equiv(1, 0), false, "number");
-    equals(QUnit.equiv(1, 1), true, "number");
-    equals(QUnit.equiv(1.1, 1.1), true, "number");
-    equals(QUnit.equiv(0.0000005, 0.0000005), true, "number");
-    equals(QUnit.equiv(0, ''), false, "number");
-    equals(QUnit.equiv(0, '0'), false, "number");
-    equals(QUnit.equiv(1, '1'), false, "number");
-    equals(QUnit.equiv(0, false), false, "number");
-    equals(QUnit.equiv(1, true), false, "number");
+    equal(QUnit.equiv(0, 0), true, "number");
+    equal(QUnit.equiv(0, 1), false, "number");
+    equal(QUnit.equiv(1, 0), false, "number");
+    equal(QUnit.equiv(1, 1), true, "number");
+    equal(QUnit.equiv(1.1, 1.1), true, "number");
+    equal(QUnit.equiv(0.0000005, 0.0000005), true, "number");
+    equal(QUnit.equiv(0, ''), false, "number");
+    equal(QUnit.equiv(0, '0'), false, "number");
+    equal(QUnit.equiv(1, '1'), false, "number");
+    equal(QUnit.equiv(0, false), false, "number");
+    equal(QUnit.equiv(1, true), false, "number");
 
-    equals(QUnit.equiv(true, true), true, "boolean");
-    equals(QUnit.equiv(true, false), false, "boolean");
-    equals(QUnit.equiv(false, true), false, "boolean");
-    equals(QUnit.equiv(false, 0), false, "boolean");
-    equals(QUnit.equiv(false, null), false, "boolean");
-    equals(QUnit.equiv(false, undefined), false, "boolean");
-    equals(QUnit.equiv(true, 1), false, "boolean");
-    equals(QUnit.equiv(true, null), false, "boolean");
-    equals(QUnit.equiv(true, undefined), false, "boolean");
+    equal(QUnit.equiv(true, true), true, "boolean");
+    equal(QUnit.equiv(true, false), false, "boolean");
+    equal(QUnit.equiv(false, true), false, "boolean");
+    equal(QUnit.equiv(false, 0), false, "boolean");
+    equal(QUnit.equiv(false, null), false, "boolean");
+    equal(QUnit.equiv(false, undefined), false, "boolean");
+    equal(QUnit.equiv(true, 1), false, "boolean");
+    equal(QUnit.equiv(true, null), false, "boolean");
+    equal(QUnit.equiv(true, undefined), false, "boolean");
 
-    equals(QUnit.equiv('', ''), true, "string");
-    equals(QUnit.equiv('a', 'a'), true, "string");
-    equals(QUnit.equiv("foobar", "foobar"), true, "string");
-    equals(QUnit.equiv("foobar", "foo"), false, "string");
-    equals(QUnit.equiv('', 0), false, "string");
-    equals(QUnit.equiv('', false), false, "string");
-    equals(QUnit.equiv('', null), false, "string");
-    equals(QUnit.equiv('', undefined), false, "string");
+    equal(QUnit.equiv('', ''), true, "string");
+    equal(QUnit.equiv('a', 'a'), true, "string");
+    equal(QUnit.equiv("foobar", "foobar"), true, "string");
+    equal(QUnit.equiv("foobar", "foo"), false, "string");
+    equal(QUnit.equiv('', 0), false, "string");
+    equal(QUnit.equiv('', false), false, "string");
+    equal(QUnit.equiv('', null), false, "string");
+    equal(QUnit.equiv('', undefined), false, "string");
 
     // Short annotation VS new annotation
-    equals(QUnit.equiv(0, new Number()), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(new Number(), 0), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(1, new Number(1)), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(new Number(1), 1), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(new Number(0), 1), false, "short annotation VS new annotation");
-    equals(QUnit.equiv(0, new Number(1)), false, "short annotation VS new annotation");
+    equal(QUnit.equiv(0, new Number()), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(new Number(), 0), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(1, new Number(1)), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(new Number(1), 1), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(new Number(0), 1), false, "short annotation VS new annotation");
+    equal(QUnit.equiv(0, new Number(1)), false, "short annotation VS new annotation");
 
-    equals(QUnit.equiv(new String(), ""), true, "short annotation VS new annotation");
-    equals(QUnit.equiv("", new String()), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(new String("My String"), "My String"), true, "short annotation VS new annotation");
-    equals(QUnit.equiv("My String", new String("My String")), true, "short annotation VS new annotation");
-    equals(QUnit.equiv("Bad String", new String("My String")), false, "short annotation VS new annotation");
-    equals(QUnit.equiv(new String("Bad String"), "My String"), false, "short annotation VS new annotation");
+    equal(QUnit.equiv(new String(), ""), true, "short annotation VS new annotation");
+    equal(QUnit.equiv("", new String()), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(new String("My String"), "My String"), true, "short annotation VS new annotation");
+    equal(QUnit.equiv("My String", new String("My String")), true, "short annotation VS new annotation");
+    equal(QUnit.equiv("Bad String", new String("My String")), false, "short annotation VS new annotation");
+    equal(QUnit.equiv(new String("Bad String"), "My String"), false, "short annotation VS new annotation");
 
-    equals(QUnit.equiv(false, new Boolean()), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(new Boolean(), false), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(true, new Boolean(true)), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(new Boolean(true), true), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(true, new Boolean(1)), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(false, new Boolean(false)), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(new Boolean(false), false), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(false, new Boolean(0)), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(true, new Boolean(false)), false, "short annotation VS new annotation");
-    equals(QUnit.equiv(new Boolean(false), true), false, "short annotation VS new annotation");
+    equal(QUnit.equiv(false, new Boolean()), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(new Boolean(), false), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(true, new Boolean(true)), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(new Boolean(true), true), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(true, new Boolean(1)), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(false, new Boolean(false)), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(new Boolean(false), false), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(false, new Boolean(0)), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(true, new Boolean(false)), false, "short annotation VS new annotation");
+    equal(QUnit.equiv(new Boolean(false), true), false, "short annotation VS new annotation");
 
-    equals(QUnit.equiv(new Object(), {}), true, "short annotation VS new annotation");
-    equals(QUnit.equiv({}, new Object()), true, "short annotation VS new annotation");
-    equals(QUnit.equiv(new Object(), {a:1}), false, "short annotation VS new annotation");
-    equals(QUnit.equiv({a:1}, new Object()), false, "short annotation VS new annotation");
-    equals(QUnit.equiv({a:undefined}, new Object()), false, "short annotation VS new annotation");
-    equals(QUnit.equiv(new Object(), {a:undefined}), false, "short annotation VS new annotation");
+    equal(QUnit.equiv(new Object(), {}), true, "short annotation VS new annotation");
+    equal(QUnit.equiv({}, new Object()), true, "short annotation VS new annotation");
+    equal(QUnit.equiv(new Object(), {a:1}), false, "short annotation VS new annotation");
+    equal(QUnit.equiv({a:1}, new Object()), false, "short annotation VS new annotation");
+    equal(QUnit.equiv({a:undefined}, new Object()), false, "short annotation VS new annotation");
+    equal(QUnit.equiv(new Object(), {a:undefined}), false, "short annotation VS new annotation");
 });
 
 test("Objects Basics.", function() {
-    equals(QUnit.equiv({}, {}), true);
-    equals(QUnit.equiv({}, null), false);
-    equals(QUnit.equiv({}, undefined), false);
-    equals(QUnit.equiv({}, 0), false);
-    equals(QUnit.equiv({}, false), false);
+    equal(QUnit.equiv({}, {}), true);
+    equal(QUnit.equiv({}, null), false);
+    equal(QUnit.equiv({}, undefined), false);
+    equal(QUnit.equiv({}, 0), false);
+    equal(QUnit.equiv({}, false), false);
 
     // This test is a hard one, it is very important
     // REASONS:
     //      1) They are of the same type "object"
     //      2) [] instanceof Object is true
     //      3) Their properties are the same (doesn't exists)
-    equals(QUnit.equiv({}, []), false);
+    equal(QUnit.equiv({}, []), false);
 
-    equals(QUnit.equiv({a:1}, {a:1}), true);
-    equals(QUnit.equiv({a:1}, {a:"1"}), false);
-    equals(QUnit.equiv({a:[]}, {a:[]}), true);
-    equals(QUnit.equiv({a:{}}, {a:null}), false);
-    equals(QUnit.equiv({a:1}, {}), false);
-    equals(QUnit.equiv({}, {a:1}), false);
+    equal(QUnit.equiv({a:1}, {a:1}), true);
+    equal(QUnit.equiv({a:1}, {a:"1"}), false);
+    equal(QUnit.equiv({a:[]}, {a:[]}), true);
+    equal(QUnit.equiv({a:{}}, {a:null}), false);
+    equal(QUnit.equiv({a:1}, {}), false);
+    equal(QUnit.equiv({}, {a:1}), false);
 
     // Hard ones
-    equals(QUnit.equiv({a:undefined}, {}), false);
-    equals(QUnit.equiv({}, {a:undefined}), false);
-    equals(QUnit.equiv(
+    equal(QUnit.equiv({a:undefined}, {}), false);
+    equal(QUnit.equiv({}, {a:undefined}), false);
+    equal(QUnit.equiv(
         {
             a: [{ bar: undefined }]
         },
@@ -140,56 +140,56 @@ test("Objects Basics.", function() {
     // Objects with no prototype, created via Object.create(null), are used e.g. as dictionaries.
     // Being able to test equivalence against object literals is quite useful.
     if (typeof Object.create === 'function') {
-        equals(QUnit.equiv(Object.create(null), {}), true, "empty object without prototype VS empty object");
+        equal(QUnit.equiv(Object.create(null), {}), true, "empty object without prototype VS empty object");
 
         var nonEmptyWithNoProto = Object.create(null);
         nonEmptyWithNoProto.foo = "bar";
 
-        equals(QUnit.equiv(nonEmptyWithNoProto, { foo: "bar" }), true, "object without prototype VS object");
+        equal(QUnit.equiv(nonEmptyWithNoProto, { foo: "bar" }), true, "object without prototype VS object");
     }
 });
 
 
 test("Arrays Basics.", function() {
 
-    equals(QUnit.equiv([], []), true);
+    equal(QUnit.equiv([], []), true);
 
     // May be a hard one, can invoke a crash at execution.
     // because their types are both "object" but null isn't
     // like a true object, it doesn't have any property at all.
-    equals(QUnit.equiv([], null), false);
+    equal(QUnit.equiv([], null), false);
 
-    equals(QUnit.equiv([], undefined), false);
-    equals(QUnit.equiv([], false), false);
-    equals(QUnit.equiv([], 0), false);
-    equals(QUnit.equiv([], ""), false);
+    equal(QUnit.equiv([], undefined), false);
+    equal(QUnit.equiv([], false), false);
+    equal(QUnit.equiv([], 0), false);
+    equal(QUnit.equiv([], ""), false);
 
     // May be a hard one, but less hard
     // than {} with [] (note the order)
-    equals(QUnit.equiv([], {}), false);
+    equal(QUnit.equiv([], {}), false);
 
-    equals(QUnit.equiv([null],[]), false);
-    equals(QUnit.equiv([undefined],[]), false);
-    equals(QUnit.equiv([],[null]), false);
-    equals(QUnit.equiv([],[undefined]), false);
-    equals(QUnit.equiv([null],[undefined]), false);
-    equals(QUnit.equiv([[]],[[]]), true);
-    equals(QUnit.equiv([[],[],[]],[[],[],[]]), true);
-    equals(QUnit.equiv(
+    equal(QUnit.equiv([null],[]), false);
+    equal(QUnit.equiv([undefined],[]), false);
+    equal(QUnit.equiv([],[null]), false);
+    equal(QUnit.equiv([],[undefined]), false);
+    equal(QUnit.equiv([null],[undefined]), false);
+    equal(QUnit.equiv([[]],[[]]), true);
+    equal(QUnit.equiv([[],[],[]],[[],[],[]]), true);
+    equal(QUnit.equiv(
                             [[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
                             [[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]),
                             true);
-    equals(QUnit.equiv(
+    equal(QUnit.equiv(
                             [[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
                             [[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]), // shorter
                             false);
-    equals(QUnit.equiv(
+    equal(QUnit.equiv(
                             [[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[{}]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
                             [[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]), // deepest element not an array
                             false);
 
     // same multidimensional
-    equals(QUnit.equiv(
+    equal(QUnit.equiv(
                             [1,2,3,4,5,6,7,8,9, [
                                 1,2,3,4,5,6,7,8,9, [
                                     1,2,3,4,5,[
@@ -235,7 +235,7 @@ test("Arrays Basics.", function() {
                             true, "Multidimensional");
 
     // different multidimensional
-    equals(QUnit.equiv(
+    equal(QUnit.equiv(
                             [1,2,3,4,5,6,7,8,9, [
                                 1,2,3,4,5,6,7,8,9, [
                                     1,2,3,4,5,[
@@ -281,7 +281,7 @@ test("Arrays Basics.", function() {
                             false, "Multidimensional");
 
     // different multidimensional
-    equals(QUnit.equiv(
+    equal(QUnit.equiv(
                             [1,2,3,4,5,6,7,8,9, [
                                 1,2,3,4,5,6,7,8,9, [
                                     1,2,3,4,5,[
@@ -337,17 +337,17 @@ test("Functions.", function() {
         var i = 0 // this comment and no semicoma as difference
     };
 
-    equals(QUnit.equiv(function() {}, function() {}), false, "Anonymous functions"); // exact source code
-    equals(QUnit.equiv(function() {}, function() {return true;}), false, "Anonymous functions");
+    equal(QUnit.equiv(function() {}, function() {}), false, "Anonymous functions"); // exact source code
+    equal(QUnit.equiv(function() {}, function() {return true;}), false, "Anonymous functions");
 
-    equals(QUnit.equiv(f0, f0), true, "Function references"); // same references
-    equals(QUnit.equiv(f0, f1), false, "Function references"); // exact source code, different references
-    equals(QUnit.equiv(f2, f3), false, "Function references"); // equivalent source code, different references
-    equals(QUnit.equiv(f1, f2), false, "Function references"); // different source code, different references
-    equals(QUnit.equiv(function() {}, true), false);
-    equals(QUnit.equiv(function() {}, undefined), false);
-    equals(QUnit.equiv(function() {}, null), false);
-    equals(QUnit.equiv(function() {}, {}), false);
+    equal(QUnit.equiv(f0, f0), true, "Function references"); // same references
+    equal(QUnit.equiv(f0, f1), false, "Function references"); // exact source code, different references
+    equal(QUnit.equiv(f2, f3), false, "Function references"); // equivalent source code, different references
+    equal(QUnit.equiv(f1, f2), false, "Function references"); // different source code, different references
+    equal(QUnit.equiv(function() {}, true), false);
+    equal(QUnit.equiv(function() {}, undefined), false);
+    equal(QUnit.equiv(function() {}, null), false);
+    equal(QUnit.equiv(function() {}, {}), false);
 });
 
 
@@ -365,11 +365,11 @@ test("Date instances.", function() {
     var d3 = new Date(); // The very now
 
     // Anyway their types differs, just in case the code fails in the order in which it deals with date
-    equals(QUnit.equiv(d1, 0), false); // d1.valueOf() returns 0, but d1 and 0 are different
+    equal(QUnit.equiv(d1, 0), false); // d1.valueOf() returns 0, but d1 and 0 are different
     // test same values date and different instances equality
-    equals(QUnit.equiv(d1, d2), true);
+    equal(QUnit.equiv(d1, d2), true);
     // test different date and different instances difference
-    equals(QUnit.equiv(d1, d3), false);
+    equal(QUnit.equiv(d1, d3), false);
 });
 
 
@@ -395,40 +395,40 @@ test("RegExp.", function() {
     var rg1 = /foo/g;
     var rg2 = /foo/g;
 
-    equals(QUnit.equiv(r5, r6), true, "Modifier order");
-    equals(QUnit.equiv(r5, r7), true, "Modifier order");
-    equals(QUnit.equiv(r5, r8), true, "Modifier order");
-    equals(QUnit.equiv(r5, r9), true, "Modifier order");
-    equals(QUnit.equiv(r5, r10), true, "Modifier order");
-    equals(QUnit.equiv(r, r5), false, "Modifier");
+    equal(QUnit.equiv(r5, r6), true, "Modifier order");
+    equal(QUnit.equiv(r5, r7), true, "Modifier order");
+    equal(QUnit.equiv(r5, r8), true, "Modifier order");
+    equal(QUnit.equiv(r5, r9), true, "Modifier order");
+    equal(QUnit.equiv(r5, r10), true, "Modifier order");
+    equal(QUnit.equiv(r, r5), false, "Modifier");
 
-    equals(QUnit.equiv(ri1, ri2), true, "Modifier");
-    equals(QUnit.equiv(r, ri1), false, "Modifier");
-    equals(QUnit.equiv(ri1, rm1), false, "Modifier");
-    equals(QUnit.equiv(r, rm1), false, "Modifier");
-    equals(QUnit.equiv(rm1, ri1), false, "Modifier");
-    equals(QUnit.equiv(rm1, rm2), true, "Modifier");
-    equals(QUnit.equiv(rg1, rm1), false, "Modifier");
-    equals(QUnit.equiv(rm1, rg1), false, "Modifier");
-    equals(QUnit.equiv(rg1, rg2), true, "Modifier");
+    equal(QUnit.equiv(ri1, ri2), true, "Modifier");
+    equal(QUnit.equiv(r, ri1), false, "Modifier");
+    equal(QUnit.equiv(ri1, rm1), false, "Modifier");
+    equal(QUnit.equiv(r, rm1), false, "Modifier");
+    equal(QUnit.equiv(rm1, ri1), false, "Modifier");
+    equal(QUnit.equiv(rm1, rm2), true, "Modifier");
+    equal(QUnit.equiv(rg1, rm1), false, "Modifier");
+    equal(QUnit.equiv(rm1, rg1), false, "Modifier");
+    equal(QUnit.equiv(rg1, rg2), true, "Modifier");
 
     // Different regex, same modifiers
     var r11 = /[a-z]/gi;
     var r13 = /[0-9]/gi; // oops! different
-    equals(QUnit.equiv(r11, r13), false, "Regex pattern");
+    equal(QUnit.equiv(r11, r13), false, "Regex pattern");
 
     var r14 = /0/ig;
     var r15 = /"0"/ig; // oops! different
-    equals(QUnit.equiv(r14, r15), false, "Regex pattern");
+    equal(QUnit.equiv(r14, r15), false, "Regex pattern");
 
     var r1 = /[\n\r\u2028\u2029]/g;
     var r2 = /[\n\r\u2028\u2029]/g;
     var r3 = /[\n\r\u2028\u2028]/g; // differs from r1
     var r4 = /[\n\r\u2028\u2029]/;  // differs from r1
 
-    equals(QUnit.equiv(r1, r2), true, "Regex pattern");
-    equals(QUnit.equiv(r1, r3), false, "Regex pattern");
-    equals(QUnit.equiv(r1, r4), false, "Regex pattern");
+    equal(QUnit.equiv(r1, r2), true, "Regex pattern");
+    equal(QUnit.equiv(r1, r3), false, "Regex pattern");
+    equal(QUnit.equiv(r1, r4), false, "Regex pattern");
 
     // More complex regex
     var regex1 = "^[-_.a-z0-9]+@([-_a-z0-9]+\\.)+([A-Za-z][A-Za-z]|[A-Za-z][A-Za-z][A-Za-z])|(([0-9][0-9]?|[0-1][0-9][0-9]|[2][0-4][0-9]|[2][5][0-5]))$";
@@ -442,15 +442,15 @@ test("RegExp.", function() {
     var r23a = new RegExp(regex3, "gi"); // diff from r23, not same modifier
     var r24a = new RegExp(regex3, "ig"); // same as r23a
 
-    equals(QUnit.equiv(r21, r22), true, "Complex Regex");
-    equals(QUnit.equiv(r21, r23), false, "Complex Regex");
-    equals(QUnit.equiv(r23, r23a), false, "Complex Regex");
-    equals(QUnit.equiv(r23a, r24a), true, "Complex Regex");
+    equal(QUnit.equiv(r21, r22), true, "Complex Regex");
+    equal(QUnit.equiv(r21, r23), false, "Complex Regex");
+    equal(QUnit.equiv(r23, r23a), false, "Complex Regex");
+    equal(QUnit.equiv(r23a, r24a), true, "Complex Regex");
 
     // typeof r1 is "function" in some browsers and "object" in others so we must cover this test
     var re = / /;
-    equals(QUnit.equiv(re, function () {}), false, "Regex internal");
-    equals(QUnit.equiv(re, {}), false, "Regex internal");
+    equal(QUnit.equiv(re, function () {}), false, "Regex internal");
+    equal(QUnit.equiv(re, {}), false, "Regex internal");
 });
 
 
@@ -465,7 +465,7 @@ test("Complex Objects.", function() {
 
     // Try to invert the order of some properties to make sure it is covered.
     // It can failed when properties are compared between unsorted arrays.
-    equals(QUnit.equiv(
+    equal(QUnit.equiv(
         {
             a: 1,
             b: null,
@@ -560,7 +560,7 @@ test("Complex Objects.", function() {
         }
     ), true);
 
-    equals(QUnit.equiv(
+    equal(QUnit.equiv(
         {
             a: 1,
             b: null,
@@ -655,7 +655,7 @@ test("Complex Objects.", function() {
         }
     ), false);
 
-    equals(QUnit.equiv(
+    equal(QUnit.equiv(
         {
             a: 1,
             b: null,
@@ -750,7 +750,7 @@ test("Complex Objects.", function() {
         }
     ), false);
 
-    equals(QUnit.equiv(
+    equal(QUnit.equiv(
         {
             a: 1,
             b: null,
@@ -851,9 +851,9 @@ test("Complex Objects.", function() {
                 prop: null,
                 foo: [1,2,null,{}, [], [1,2,3]],
                 bar: undefined
-            }, 3, "Hey!", "Κάνε πάντα γνωρίζουμε ας των, μηχανής επιδιόρθωσης επιδιορθώσεις ώς μια. Κλπ ας"
-        ],
-        unicode: "老 汉语中存在 港澳和海外的华人圈中 贵州 我去了书店 现在尚有争",
+            }, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+        ], 
+        unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
         b: "b",
         c: fn1
     };
@@ -864,9 +864,9 @@ test("Complex Objects.", function() {
                 prop: null,
                 foo: [1,2,null,{}, [], [1,2,3]],
                 bar: undefined
-            }, 3, "Hey!", "Κάνε πάντα γνωρίζουμε ας των, μηχανής επιδιόρθωσης επιδιορθώσεις ώς μια. Κλπ ας"
+            }, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
         ],
-        unicode: "老 汉语中存在 港澳和海外的华人圈中 贵州 我去了书店 现在尚有争",
+        unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
         b: "b",
         c: fn1
     };
@@ -877,9 +877,9 @@ test("Complex Objects.", function() {
                 prop: null,
                 foo: [1,2,null,{}, [], [1,2,3,4]], // different: 4 was add to the array
                 bar: undefined
-            }, 3, "Hey!", "Κάνε πάντα γνωρίζουμε ας των, μηχανής επιδιόρθωσης επιδιορθώσεις ώς μια. Κλπ ας"
+            }, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
         ],
-        unicode: "老 汉语中存在 港澳和海外的华人圈中 贵州 我去了书店 现在尚有争",
+        unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
         b: "b",
         c: fn1
     };
@@ -891,9 +891,9 @@ test("Complex Objects.", function() {
                 foo: [1,2,null,{}, [], [1,2,3]],
                 newprop: undefined, // different: newprop was added
                 bar: undefined
-            }, 3, "Hey!", "Κάνε πάντα γνωρίζουμε ας των, μηχανής επιδιόρθωσης επιδιορθώσεις ώς μια. Κλπ ας"
+            }, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
         ],
-        unicode: "老 汉语中存在 港澳和海外的华人圈中 贵州 我去了书店 现在尚有争",
+        unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
         b: "b",
         c: fn1
     };
@@ -904,9 +904,9 @@ test("Complex Objects.", function() {
                 prop: null,
                 foo: [1,2,null,{}, [], [1,2,3]],
                 bar: undefined
-            }, 3, "Hey!", "Κάνε πάντα γνωρίζουμε ας των, μηχανής επιδιόρθωσης επιδιορθώσεις ώς μια. Κλπ α" // different: missing last char
+            }, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±" // different: missing last char
         ],
-        unicode: "老 汉语中存在 港澳和海外的华人圈中 贵州 我去了书店 现在尚有争",
+        unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
         b: "b",
         c: fn1
     };
@@ -917,9 +917,9 @@ test("Complex Objects.", function() {
                 prop: null,
                 foo: [1,2,undefined,{}, [], [1,2,3]], // different: undefined instead of null
                 bar: undefined
-            }, 3, "Hey!", "Κάνε πάντα γνωρίζουμε ας των, μηχανής επιδιόρθωσης επιδιορθώσεις ώς μια. Κλπ ας"
+            }, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
         ],
-        unicode: "老 汉语中存在 港澳和海外的华人圈中 贵州 我去了书店 现在尚有争",
+        unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
         b: "b",
         c: fn1
     };
@@ -930,25 +930,25 @@ test("Complex Objects.", function() {
                 prop: null,
                 foo: [1,2,null,{}, [], [1,2,3]],
                 bat: undefined // different: property name not "bar"
-            }, 3, "Hey!", "Κάνε πάντα γνωρίζουμε ας των, μηχανής επιδιόρθωσης επιδιορθώσεις ώς μια. Κλπ ας"
+            }, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
         ],
-        unicode: "老 汉语中存在 港澳和海外的华人圈中 贵州 我去了书店 现在尚有争",
+        unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
         b: "b",
         c: fn1
     };
 
-    equals(QUnit.equiv(same1, same2), true);
-    equals(QUnit.equiv(same2, same1), true);
-    equals(QUnit.equiv(same2, diff1), false);
-    equals(QUnit.equiv(diff1, same2), false);
+    equal(QUnit.equiv(same1, same2), true);
+    equal(QUnit.equiv(same2, same1), true);
+    equal(QUnit.equiv(same2, diff1), false);
+    equal(QUnit.equiv(diff1, same2), false);
 
-    equals(QUnit.equiv(same1, diff1), false);
-    equals(QUnit.equiv(same1, diff2), false);
-    equals(QUnit.equiv(same1, diff3), false);
-    equals(QUnit.equiv(same1, diff3), false);
-    equals(QUnit.equiv(same1, diff4), false);
-    equals(QUnit.equiv(same1, diff5), false);
-    equals(QUnit.equiv(diff5, diff1), false);
+    equal(QUnit.equiv(same1, diff1), false);
+    equal(QUnit.equiv(same1, diff2), false);
+    equal(QUnit.equiv(same1, diff3), false);
+    equal(QUnit.equiv(same1, diff3), false);
+    equal(QUnit.equiv(same1, diff4), false);
+    equal(QUnit.equiv(same1, diff5), false);
+    equal(QUnit.equiv(diff5, diff1), false);
 });
 
 
@@ -957,7 +957,7 @@ test("Complex Arrays.", function() {
     function fn() {
     }
 
-    equals(QUnit.equiv(
+    equal(QUnit.equiv(
                 [1, 2, 3, true, {}, null, [
                     {
                         a: ["", '1', 0]
@@ -972,7 +972,7 @@ test("Complex Arrays.", function() {
                 ], "foo"]),
             true);
 
-    equals(QUnit.equiv(
+    equal(QUnit.equiv(
                 [1, 2, 3, true, {}, null, [
                     {
                         a: ["", '1', 0]
@@ -1011,7 +1011,7 @@ test("Complex Arrays.", function() {
         }
     }, {}]]];
 
-    equals(QUnit.equiv(a,
+    equal(QUnit.equiv(a,
             [{
                 b: fn,
                 c: false,
@@ -1036,7 +1036,7 @@ test("Complex Arrays.", function() {
                 }
             }, {}]]]), true);
 
-    equals(QUnit.equiv(a,
+    equal(QUnit.equiv(a,
             [{
                 b: fn,
                 c: false,
@@ -1061,7 +1061,7 @@ test("Complex Arrays.", function() {
                 }
             }, {}]]]), false);
 
-    equals(QUnit.equiv(a,
+    equal(QUnit.equiv(a,
             [{
                 b: fn,
                 c: false,
@@ -1086,7 +1086,7 @@ test("Complex Arrays.", function() {
                 }
             }, {}]]]), false);
 
-    equals(QUnit.equiv(a,
+    equal(QUnit.equiv(a,
             [{
                 b: fn,
                 c: false,
@@ -1111,7 +1111,7 @@ test("Complex Arrays.", function() {
                 }
             }, {}]]]), false);
 
-    equals(QUnit.equiv(a,
+    equal(QUnit.equiv(a,
             [{
                 b: fn,
                 c: false,
@@ -1153,26 +1153,26 @@ test("Prototypal inheritance", function() {
 
     // Try this test many times after test on instances that hold function
     // to make sure that our code does not mess with last object constructor memoization.
-    equals(QUnit.equiv(function () {}, function () {}), false);
+    equal(QUnit.equiv(function () {}, function () {}), false);
 
     // Hoozit inherit from Gizmo
     // hoozit instanceof Hoozit; // true
     // hoozit instanceof Gizmo; // true
-    equals(QUnit.equiv(hoozit, gizmo), true);
+    equal(QUnit.equiv(hoozit, gizmo), true);
 
     Gizmo.prototype.bar = true; // not a function just in case we skip them
 
     // Hoozit inherit from Gizmo
     // They are equivalent
-    equals(QUnit.equiv(hoozit, gizmo), true);
+    equal(QUnit.equiv(hoozit, gizmo), true);
 
     // Make sure this is still true !important
     // The reason for this is that I forgot to reset the last
     // caller to where it were called from.
-    equals(QUnit.equiv(function () {}, function () {}), false);
+    equal(QUnit.equiv(function () {}, function () {}), false);
 
     // Make sure this is still true !important
-    equals(QUnit.equiv(hoozit, gizmo), true);
+    equal(QUnit.equiv(hoozit, gizmo), true);
 
     Hoozit.prototype.foo = true; // not a function just in case we skip them
 
@@ -1180,10 +1180,10 @@ test("Prototypal inheritance", function() {
     // gizmo instanceof Gizmo; // true
     // gizmo instanceof Hoozit; // false
     // They are not equivalent
-    equals(QUnit.equiv(hoozit, gizmo), false);
+    equal(QUnit.equiv(hoozit, gizmo), false);
 
     // Make sure this is still true !important
-    equals(QUnit.equiv(function () {}, function () {}), false);
+    equal(QUnit.equiv(function () {}, function () {}), false);
 });
 
 
@@ -1198,12 +1198,12 @@ test("Instances", function() {
     var b1 = new B();
     var b2 = new B();
 
-    equals(QUnit.equiv(a1, a2), true, "Same property, same constructor");
+    equal(QUnit.equiv(a1, a2), true, "Same property, same constructor");
 
     // b1.fn and b2.fn are functions but they are different references
     // But we decided to skip function for instances.
-    equals(QUnit.equiv(b1, b2), true, "Same property, same constructor");
-    equals(QUnit.equiv(a1, b1), false, "Same properties but different constructor"); // failed
+    equal(QUnit.equiv(b1, b2), true, "Same property, same constructor");
+    equal(QUnit.equiv(a1, b1), false, "Same properties but different constructor"); // failed
 
     function Car(year) {
         var privateVar = 0;
@@ -1235,10 +1235,10 @@ test("Instances", function() {
         isOld: function () {}
     };
 
-    equals(QUnit.equiv(car, car), true);
-    equals(QUnit.equiv(car, carDiff), false);
-    equals(QUnit.equiv(car, carSame), true);
-    equals(QUnit.equiv(car, human), false);
+    equal(QUnit.equiv(car, car), true);
+    equal(QUnit.equiv(car, carDiff), false);
+    equal(QUnit.equiv(car, carSame), true);
+    equal(QUnit.equiv(car, human), false);
 });
 
 
@@ -1340,25 +1340,25 @@ test("Complex Instances Nesting (with function value in literals and/or in neste
 
     var a1 = new A(function () {});
     var a2 = new A(function () {});
-    equals(QUnit.equiv(a1, a2), true);
+    equal(QUnit.equiv(a1, a2), true);
 
-    equals(QUnit.equiv(a1, a2), true); // different instances
+    equal(QUnit.equiv(a1, a2), true); // different instances
 
     var b1 = new B(function () {});
     var b2 = new B(function () {});
-    equals(QUnit.equiv(b1, b2), true);
+    equal(QUnit.equiv(b1, b2), true);
 
     var c1 = new C(function () {});
     var c2 = new C(function () {});
-    equals(QUnit.equiv(c1, c2), true);
+    equal(QUnit.equiv(c1, c2), true);
 
     var d1 = new D(function () {});
     var d2 = new D(function () {});
-    equals(QUnit.equiv(d1, d2), false);
+    equal(QUnit.equiv(d1, d2), false);
 
     var e1 = new E(function () {});
     var e2 = new E(function () {});
-    equals(QUnit.equiv(e1, e2), false);
+    equal(QUnit.equiv(e1, e2), false);
 
 });
 
@@ -1371,15 +1371,15 @@ test('object with references to self wont loop', function(){
     };
     circularA.abc = circularA;
     circularB.abc = circularB;
-    equals(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object (ambigous test)");
+    equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object (ambigous test)");
 
     circularA.def = 1;
     circularB.def = 1;
-    equals(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object (ambigous test)");
+    equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object (ambigous test)");
 
     circularA.def = 1;
     circularB.def = 0;
-    equals(QUnit.equiv(circularA, circularB), false, "Should not repeat test on object (unambigous test)");
+    equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on object (unambigous test)");
 });
 
 test('array with references to self wont loop', function(){
@@ -1387,15 +1387,15 @@ test('array with references to self wont loop', function(){
         circularB = [];
     circularA.push(circularA);
     circularB.push(circularB);
-    equals(QUnit.equiv(circularA, circularB), true, "Should not repeat test on array (ambigous test)");
+    equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on array (ambigous test)");
 
     circularA.push( 'abc' );
     circularB.push( 'abc' );
-    equals(QUnit.equiv(circularA, circularB), true, "Should not repeat test on array (ambigous test)");
+    equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on array (ambigous test)");
 
     circularA.push( 'hello' );
     circularB.push( 'goodbye' );
-    equals(QUnit.equiv(circularA, circularB), false, "Should not repeat test on array (unambigous test)");
+    equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on array (unambigous test)");
 });
 
 test('mixed object/array with references to self wont loop', function(){
@@ -1406,15 +1406,15 @@ test('mixed object/array with references to self wont loop', function(){
 
     circularA.push(circularA);
     circularB.push(circularB);
-    equals(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object/array (ambigous test)");
+    equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object/array (ambigous test)");
 
     circularA[0].def = 1;
     circularB[0].def = 1;
-    equals(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object/array (ambigous test)");
+    equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object/array (ambigous test)");
 
     circularA[0].def = 1;
     circularB[0].def = 0;
-    equals(QUnit.equiv(circularA, circularB), false, "Should not repeat test on object/array (unambigous test)");
+    equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on object/array (unambigous test)");
 });
 
 test("Test that must be done at the end because they extend some primitive's prototype", function() {
@@ -1425,8 +1425,8 @@ test("Test that must be done at the end because they extend some primitive's pro
     Function.prototype.ignoreCase = false;
     Function.prototype.source = "my regex";
     var re = /my regex/gm;
-    equals(QUnit.equiv(re, function () {}), false, "A function that looks that a regex isn't a regex");
+    equal(QUnit.equiv(re, function () {}), false, "A function that looks that a regex isn't a regex");
     // This test will ensures it works in both ways, and ALSO especially that we can make differences
     // between RegExp and Function constructor because typeof on a RegExpt instance is "function"
-    equals(QUnit.equiv(function () {}, re), false, "Same conversely, but ensures that function and regexp are distinct because their constructor are different");
+    equal(QUnit.equiv(function () {}, re), false, "Same conversely, but ensures that function and regexp are distinct because their constructor are different");
 });

--- a/test/test.js
+++ b/test/test.js
@@ -247,11 +247,11 @@ test("each test can extend the module testEnvironment", {
 
 module("jsDump");
 test("jsDump output", function() {
-	equals( QUnit.jsDump.parse([1, 2]), "[\n  1,\n  2\n]" );
-	equals( QUnit.jsDump.parse({top: 5, left: 0}), "{\n  \"top\": 5,\n  \"left\": 0\n}" );
+	equal( QUnit.jsDump.parse([1, 2]), "[\n  1,\n  2\n]" );
+	equal( QUnit.jsDump.parse({top: 5, left: 0}), "{\n  \"top\": 5,\n  \"left\": 0\n}" );
 	if (typeof document !== 'undefined' && document.getElementById("qunit-header")) {
-		equals( QUnit.jsDump.parse(document.getElementById("qunit-header")), "<h1 id=\"qunit-header\"></h1>" );
-		equals( QUnit.jsDump.parse(document.getElementsByTagName("h1")), "[\n  <h1 id=\"qunit-header\"></h1>\n]" );
+		equal( QUnit.jsDump.parse(document.getElementById("qunit-header")), "<h1 id=\"qunit-header\"></h1>" );
+		equal( QUnit.jsDump.parse(document.getElementsByTagName("h1")), "[\n  <h1 id=\"qunit-header\"></h1>\n]" );
 	}
 });
 


### PR DESCRIPTION
I figured Qunit shouldn't be using code it has deprecated to test itself, right?
