### PR TITLE
following issue #180, escape test names and show stack trace when failed

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -274,7 +274,7 @@ var QUnit = {
 	},
 
 	test: function(testName, expected, callback, async) {
-		var name = '<span class="test-name">' + testName + '</span>', testEnvironmentArg;
+		var name = '<span class="test-name">' + escapeInnerText(testName) + '</span>', testEnvironmentArg;
 
 		if ( arguments.length === 2 ) {
 			callback = expected;


### PR DESCRIPTION
- html escaping test names
- show stack trace when test failed

two changes are applied to simonz:development branch
