### PR TITLE
Keep label and checkbox on the same line

### DIFF
--- a/qunit/qunit.css
+++ b/qunit/qunit.css
@@ -54,6 +54,10 @@
 	color: #fff;
 }
 
+#qunit-header label {
+	display: inline-block;
+}
+
 #qunit-banner {
 	height: 5px;
 }


### PR DESCRIPTION
See http://i.imgur.com/5Wk3A.png

display-inline on the container (`<label>`) fixes this: http://i.imgur.com/9lccT.png
