### PR TITLE
Improved sessionStorage check

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -10,15 +10,28 @@
 
 (function(window) {
 
+var cachedStorage;
+
 var defined = {
 	setTimeout: typeof window.setTimeout !== "undefined",
 	sessionStorage: (function() {
-		try {
-			return !!sessionStorage.getItem;
-		} catch(e) {
-			return false;
-		}
-	})()
+	var key = '__sessionstorage__';
+	var value = key;
+
+	if (cachedStorage !== undefined) {
+		return cachedStorage;
+	}
+
+	try {
+		sessionStorage.setItem(key, value);
+		sessionStorage.removeItem(key);
+		cachedStorage = true;
+	} catch (exc) {
+		cachedStorage = false;
+	}
+
+	return cachedStorage;
+  })()
 };
 
 var	testId = 0,


### PR DESCRIPTION
I was using QUnit to test whether my localStorage library worked with local storage disabled (in Chrome preferences), and found that the sessionStorage check in QUnit doesn't work in that case- it gives the QUOTA_EXCEEDED_ERR. I replaced it with the check that I use for localStorage, which is based off Modernizr's and caches the result.
