### PR TITLE
AsyncTest timer addon

### DIFF
--- a/addons/asyncTest timer/qunit-testtimer-js.html
+++ b/addons/asyncTest timer/qunit-testtimer-js.html
@@ -1,0 +1,212 @@
+<!doctype html> 
+ 
+<!-- paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/ -->
+<!--[if lt IE 7 ]> <html lang="en" class="ie6"> <![endif]-->
+<!--[if IE 7 ]>    <html lang="en" class="ie7"> <![endif]-->
+<!--[if IE 8 ]>    <html lang="en" class="ie8"> <![endif]-->
+<!--[if IE 9 ]>    <html lang="en" class="ie9"> <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--> <html lang="en" ><!--<![endif]-->
+<head>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>QUnit test timer addon tests</title>
+
+<link rel="stylesheet" href="../../qunit/qunit.css" type="text/css" media="screen">
+	<script type="text/javascript" src="../../qunit/qunit.js"></script>
+	
+<script type="text/javascript" src="qunit.testtimer.js"></script>
+</head>
+<body>
+<h1 id="qunit-header">asyncTest timeout plugin tests</h1>
+	<h2 id="qunit-banner"></h2>
+	<div id="qunit-testrunner-toolbar"></div>
+	<h2 id="qunit-userAgent"></h2>
+	<ol id="qunit-tests"></ol>
+        <div id="qunit-fixture">test markup</div>
+        <div id="cssTests"></div>
+</body>
+
+<script type="text/javascript">
+	asyncTest.defaultTimeout=2000;
+
+	asyncTest("simple timed test", function(){
+		
+		var test = asyncTest.start();
+		setTimeout(function(){
+			if(test.done) return;
+			
+			ok(true, "didn't time out before callback");
+			test.continue();
+			ok(true, "callback continues to run after continue");
+		}, 1000);
+		
+		setTimeout(function(){
+			if(test.done) return;
+			
+			ok(false, "test runner should restart before second callback");
+			start();
+		}, 1020);
+	
+	});
+
+	asyncTest("test timing out, expect 'test timed out' failure", 2, function(){
+		var test = asyncTest.start();
+		
+		ok(true, "next assert should be failure, expect to see 'test timed out'");
+		setTimeout(function(){
+			if(test.done) return;
+			
+			ok(false, "FAILURE!! test should have timed out instead of hitting this assert");
+			test.continue();
+		
+		}, 3000);
+	});
+	
+	asyncTest("test two callbacks", 2, function(){
+		var test = asyncTest.start(2000,2);
+		
+		setTimeout(function(){
+			if(test.done) return;
+		
+			ok(true, "first callback happens before done");
+			test.continue();
+		}, 1000);
+		
+		setTimeout(function(){
+			if(test.done) return;
+			
+			ok(true, "second callback happens before done");
+			test.continue();
+		}, 1100);
+		
+		setTimeout(function(){
+			if(test.done) return;
+			test.continue();
+			ok(false, "should not happen before done");
+		}, 1500);
+	});
+	
+	asyncTest("test two callbacks with timeout, expect 'test timed out' failure", 2, function(){
+		var test = asyncTest.start(2000, 2);
+		
+		setTimeout(function(){
+			if(test.done) return;
+		
+			ok(true, "first callback happens, next assert should fail with 'test timed out'");
+			test.continue();
+		}, 500);
+		
+		setTimeout(function(){
+			if(test.done) return;
+			
+			ok(false, "FAILURE!!! expect 'test timed out' instead of this assert");
+			test.continue();
+		}, 2500);
+		
+	});
+	
+	asyncTest("test set timeout value, expect 'test timed out' failure", 2, function(){
+		var test = asyncTest.start(1000);
+		
+		ok(true, "next assert should be a failure, expect 'test timed out'");
+		setTimeout(function(){
+			if(test.done) return;
+			
+			ok(false, "FAILURE!!!! should have timed out instead of hitting this assert");
+		}, 1200);
+	});
+	
+	asyncTest("test abort, expect 'test aborted' failure", 2, function(){
+		var test = asyncTest.start();
+		
+		setTimeout(function(){
+			if(test.done) return;
+			
+			ok(true, "callback happens before done, expect next assert to fail with 'test aborted'");
+			test.abort();
+		}, 1000);
+	
+		setTimeout(function(){
+			if(test.done) return;
+			
+			ok(false, "FAILURE!!!! should have aborted instead of hitting this assert");
+		}, 1200);
+	});
+	
+	asyncTest("test abort, expect 'custom test abort message' failure", 2, function(){
+		var test = asyncTest.start();
+		
+		setTimeout(function(){
+			if(test.done) return;
+			
+			ok(true, "callback happens before done, expect next assert to fail with 'custom test abort message'");
+			test.abort("custom test abort message");
+		}, 1000);
+	
+		setTimeout(function(){
+			if(test.done) return;
+			
+			ok(false, "FAILURE!!!! should have aborted instead of hitting this assert");
+		}, 1200);
+	});
+	
+	
+	asyncTest("test abort after timeout, expect 'test timed out' failure and abort does nothing", 2, function(){
+		var test = asyncTest.start();
+		
+		ok(true, "the next assert should be a 'test timed out' failure");
+		
+		setTimeout(function(){
+			test.abort();
+		}, 2500);
+	});
+	
+	asyncTest("test finish, before timeout, immediately finishes", 1, function(){
+		var test = asyncTest.start();
+		
+		setTimeout(function(){
+			if(test.done) return;
+			
+			ok(true, "callback was hit");
+			test.finish();
+		}, 1000);
+		
+		setTimeout(function(){
+			if(test.done) return;
+		
+			ok(false, "should have finished before hitting this callback");
+		}, 1100);
+	});
+	
+	asyncTest("new test started before old test finished", 2, function(){
+		var test = asyncTest.start();
+		
+		setTimeout(function(){
+			if(test.done) return;
+			
+			ok(false, "first test should have been killed by new test");
+			test.finish();
+		}, 1200);
+		
+		setTimeout(function(){
+			ok(true, "Expect to kill old test quietly");
+			var test2 = asyncTest.start();
+			
+			setTimeout(function(){
+				if(test2.done) return;
+				
+				ok(true, "New test should run just fine");
+				test2.finish();
+			});
+		}, 1000);
+	});
+	
+	asyncTest("test catch all", 1, function(){
+		setTimeout(function(){
+			ok(true, "catch all finished");
+			start();
+		}, 10000);
+	});
+	
+</script>
+</html>
+

--- a/addons/asyncTest timer/qunit.testtimer.js
+++ b/addons/asyncTest timer/qunit.testtimer.js
@@ -1,0 +1,99 @@
+/*
+	A simple async test timer for QUnit.
+	
+	Calling 'asyncTest.start()' starts a timeout and returns a test object. This test object has a couple important methods, the first of which is 'continue'. 'continue()' is used anytime you are doing asserts in a callback. Once you've called 'continue' the number of times specified as a start parameter (default 1), Testtimer will automatically cancel the timeout and restart the QUnit test runner.
+
+The test object also has a 'done' boolean property. This property should be checked before performing asserts in callbacks to make sure your asserts dont end up in a separate test. See examples in test file.
+
+The test object has one other method, 'abort()'. This method immediately aborts the currently running asyncTest and begins the next one. The timeout will be cleared and 'ok(false, "async test aborted")' will be called, and the 'done' property would be set. Any async callbacks in the test should make sure to check the 'done' object as I have already described to make sure they arent processing after an abort.
+*/
+(function(w){
+	var topId = 1;
+	var current;
+	
+	function _continue(){
+		//ignore continues in the wrong context
+		if(this.done)
+			return;
+			
+		this.remaining--;
+		if (this.remaining <= 0 && this.timer != null){
+			console.log(this.id + " continues complete");
+			this.finish();
+		}
+	}
+	
+	function timedOut(){
+		if(this.done)
+			return;
+		
+		console.log(this.id + " timed out");
+		if(this.remaining >= 0){
+			ok(false, "test timed out");
+			this.finish();
+		}
+	}
+	
+	function _abort(message){
+		//ignore aborts in the wrong context
+		if(this.done)
+			return;
+	
+		if(!message) message = "async test aborted";
+		console.log(this.id + " aborting, msg: " + message);
+		if(this.remaining >= 0){
+			ok(false, message);
+			this.finish();
+		}
+	}
+	
+	function _finish(){
+		if(this.done)
+			return;
+				
+		console.log(this.id + " finished, killing");
+		this.kill();
+		current = null;
+		//restart test runner since we're done
+		console.log(this.id + " restarting test runner");
+		start();
+	}
+	
+	function _kill(){
+		if(this.done)
+			return;
+		
+		if(this.timer != null) 
+			clearTimeout(this.timer);
+		this.timer = null;
+		this.done = true;
+		console.log(this.id + " killed");
+		//do not restart test runner
+	}
+	
+	asyncTest.defaultTimeout = 2000;
+		
+	asyncTest.start = function(timeout, expect){
+		
+		if(current != null)
+			current.kill();
+			
+		//create the response object
+		temp = {
+			wait: timeout ? timeout : asyncTest.defaultTimeout,
+			remaining: expect ? expect : 1,
+			continue: _continue,
+			abort: _abort,
+			finish: _finish,
+			kill: _kill,
+			done: false
+		};
+		topId++;
+		current = temp;
+		console.log(temp.id + " starting");
+		temp.timer = setTimeout(timedOut.bind(temp), temp.wait);
+		
+		return current;
+	}
+
+})(window);


### PR DESCRIPTION
Hi,

I was working with a library that required a significant amount of asynchronous tests, and was having a few problems.  One was the test runner was not restarting when I had multiple callbacks in one test.  Another was I had trouble figuring out QUnit's default test timeout functionality.  A third was I had some assertion bleedover if a test timed out and another test was running, then the previous test's callback performed an assert.

I wrote this addon to solve my problems, and it does quite well.  Please forgive me if my problems are already solved by the QUnit library and I'm simply not configuring it correctly.  I thought I would contribute it for people working on complex asynchronous tests.

I did make an attempt to rewrite this to override QUnit's test start and assertion methods to accomplish the same thing, but my problem was I needed to override the Test object's run function and Test is not exposed.  

The idea was that my test object would extend the testEnvironment object, and the 'remaining' property would be set by the 'expected' parameter of QUnit.test.  The testEnvironment would also have a backreference to the test.  Then I would also override the assertions and add the overrides to the testEnvironment object so they operate in that context.  The overridden assertions would check if the testEnvironment was finished, and if not they would set the 'QUnit.config.current' to the backreferenced Test (which they would get from 'this.test'), so that the assert messages would not bleed over into another test.  They would also call '_continue' with 'this' as the context, decrementing the 'remaining' parameter and calling 'start()' once 'remaining <= 0'.  This, along with the timeout (which would be set at 'Test.prototype.run'), would execute the async tests as quickly as possible.

If you guys think this is a good idea I can continue to pursue it, and see if I can't make it work.

Signed-off-by: gburgett gordon.burgett@gmail.com
