### PR TITLE
Change QUnit fixture reset behavior

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -564,15 +564,15 @@ extend(QUnit, {
 	/**
 	 * Resets the test setup. Useful for tests that modify the DOM.
 	 *
-	 * If jQuery is available, uses jQuery's html(), otherwise just innerHTML.
+	 * If jQuery is available, uses jQuery's replaceWith(), otherwise use replaceChild
 	 */
 	reset: function() {
 		if ( window.jQuery ) {
-			jQuery( "#qunit-fixture" ).html( config.fixture );
-		} else {
-			var main = id( 'qunit-fixture' );
+			jQuery( "#qunit-fixture" ).replaceWith( config.fixture.outerHTML );
+		} else {			
+			main = id( 'qunit-fixture' );
 			if ( main ) {
-				main.innerHTML = config.fixture;
+				main.parentNode.replaceChild(config.fixture.cloneNode(true), main);
 			}
 		}
 	},
@@ -779,7 +779,7 @@ QUnit.load = function() {
 
 	var main = id('qunit-fixture');
 	if ( main ) {
-		config.fixture = main.innerHTML;
+		config.fixture = main.cloneNode(true);
 	}
 
 	if (config.autostart) {

--- a/test/test.js
+++ b/test/test.js
@@ -313,9 +313,11 @@ if (typeof document !== "undefined") {
 module("fixture");
 test("setup", function() {
 	document.getElementById("qunit-fixture").innerHTML = "foobar";
+	document.getElementById("qunit-fixture").setAttribute('title','foobar');
 });
 test("basics", function() {
 	equal( document.getElementById("qunit-fixture").innerHTML, "test markup", "automatically reset" );
+	equal( document.getElementById("qunit-fixture").getAttribute('title'), null, "properties automatically reset" );
 });
 
 }


### PR DESCRIPTION
Change for issue #194

Essentially, cache a clean copy of
the fixture node on load and replace subsequent fixture nodes with that.

On load, clone qunit-fixture element and set config.fixture equal to
that. Change the reset function to replace the entire qunit-fixture
element with a deep copy of the clone. 

Added tests to check if properties on the fixture are cleared between
tests.
