### PR TITLE
Chrome's "source" (stack trace) is one line out...

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -885,12 +885,17 @@ function sourceFromStacktrace() {
 	try {
 		throw new Error();
 	} catch ( e ) {
+		var stack;
 		if (e.stacktrace) {
 			// Opera
 			return e.stacktrace.split("\n")[6];
 		} else if (e.stack) {
+			stack = e.stack.split("\n");
+                	if (/^error$/i.test(stack[0])) {
+                		stack.shift(); 
+                	}
 			// Firefox, Chrome
-			return e.stack.split("\n")[4];
+			return stack[4];
 		} else if (e.sourceURL) {
 			// Safari, PhantomJS
 			// TODO sourceURL points at the 'throw new Error' line above, useless


### PR DESCRIPTION
...because stack traces start with "Error\n".

This adds an if to check the first line of the stack trace, and if it matches /^error$/i then it shifts the array, putting it at the right line.
