### PR TITLE
improve result generated by jUnitReport addons to collect usable stats to show when running phantomjs

### DIFF
--- a/addons/junitlogger/junitlogger.js
+++ b/addons/junitlogger/junitlogger.js
@@ -22,7 +22,7 @@
 	});
 
 	QUnit.testStart(function(data) {
-        if(!start){ start = new Date(); }
+		if(!start){ start = new Date(); }
 
 		assertCount = 0;
 
@@ -152,7 +152,7 @@
         results.time = new Date() - start;
 
 		QUnit.jUnitReport({
-            results:results,
+			results:results,
 			xml: xmlWriter.getString()
 		});
 	});


### PR DESCRIPTION
Add stats results to data. QUnit.jUnitReport function take one argument
{
  xml:'<?xml ...',
  results:{failed:0, passed:0, total:0, time:0}
}
