### PR TITLE
grunt.js: shorten hash in jobname for testswarm

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -84,7 +84,7 @@ grunt.registerTask( "testswarm", function( commit, configFile ) {
 	}, {
 		authUsername: "qunit",
 		authToken: config.qunit.authToken,
-		jobName: 'QUnit commit #<a href="https://github.com/jquery/qunit/commit/' + commit + '">' + commit + '</a>',
+		jobName: 'QUnit commit #<a href="https://github.com/jquery/qunit/commit/' + commit + '">' + commit.substr( 0, 10 ) + '</a>',
 		runMax: 3,
 		"runNames[]": "QUnit",
 		"runUrls[]": "http://swarm.jquery.org/git/qunit/" + commit + "/test/index.html",


### PR DESCRIPTION
The url still has the full hash, but the display title can do with a major trim. Makes the testswarm pages cleaner, leaving more room for the real data and decreasing the changes of an ugly table cell bump.
