### PR TITLE
Refactor assertion helpers into QUnit.assert (backwards compatible)

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,21 @@ test("expect in test", 1, function() {
 	ok(true);
 });
 
+QUnit.module("assertion helpers");
+
+QUnit.test( "QUnit.assert compatibility", function( assert ) {
+	QUnit.expect(4);
+
+	assert.ok( true, "Calling method on `assert` argument to test() callback" );
+
+	// Should also work, although not documented
+	QUnit.assert.ok( true, "Calling method on QUnit.assert object" );
+
+	// Test compatibility aliases
+	QUnit.ok( true, "Calling aliased method in QUnit root object" );
+	ok( true, "Calling aliased function in global namespace" );
+});
+
 module("setup test", {
 	setup: function() {
 		ok(true);


### PR DESCRIPTION
- QUnit.assert
  - Now contains all assertion helpers
    (kept equals and same out of it, those are only in QUnit itself)
  - Had to move QUnit.test / QUnit.stop up in the code so that they're
    not inside QUnit.assert. The actual test/stop functions have not
    been altered.
  - Per #228 discussion, new standard format created by this:

``` javascript
// Test runner
QUnit.assert.cowType = function ( cow, expected, message ) {
    QUnit.push( .. , expected, message );
};

// Test suite
QUnit.test( "FooCow and BarCow defaults", function ( assert ) {
    var bar, foo;
    expect( 1 );

    bar = new BarCow();
    foo = new FooCow();

    assert.strictEqual( foo.name, "", "A FooCow has no name" );
    assert.cowType( foo, "awesome", "A FooCow must be awesome" );
});
```
- ..
  - Added unit tests for new QUnit.assert and test() "assert"
    argument. Also added unit tests for the old methods (global
    and via QUnit).
  - Kept rest of the test suite in tact to proof backwards
    compatibility.
- Issues:
  - fixes #228
- Misc:
  - Added few random bits of documentation.
    Turned some block comments into /\* .. */
