### PR TITLE
(issue #260) config.current should be reset at the right time.

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -255,6 +255,8 @@ Test.prototype = {
 			total: this.assertions.length
 		});
 
+		config.current = undefined;
+
 		QUnit.reset();
 	},
 
@@ -768,6 +770,10 @@ extend( QUnit, {
 	},
 
 	pushFailure: function( message, source ) {
+		if ( !config.current ) {
+			throw new Error( "pushFailure() assertion outside test context, was " + sourceFromStacktrace(2) );
+		}
+
 		var output,
 			details = {
 				result: false,


### PR DESCRIPTION
- Issues:
  - fixes #260
- Misc:
  - Added throw to pushFailure, like the other functions that
    add to config.current.assertions[] already do (ok(), push(), ..).
