### PR TITLE
Where we recieve no exception in raises() use a relevant message.

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -497,7 +497,7 @@ QUnit.assert = {
 
 			QUnit.push( ok, actual, null, message );
 		} else {
-			QUnit.pushFailure( message, null, 'No exception was raised.' );
+			QUnit.pushFailure( message, null, 'No exception was thrown.' );
 		}
 	}
 };


### PR DESCRIPTION
Currently in qunit if you write an assertion as follows:

raises(function() {
  ...
  // raises no exception
});

the message you receive in qunit says your return value does not match null. I stumbled on this while writing unit tests for some code where I work and it caused a short head scratching moment until I looked in the qunit code.

Please let me know if you'd prefer me to open an issue and debate a solution there - since this is my first attempt at a contribution to qunit I'm happy to refactor / rework the solution as necessary.
