### PR TITLE
Rename assert.raises to assert.throws. Fixes #267 

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -463,10 +463,11 @@ QUnit.assert = {
 		QUnit.push( expected !== actual, actual, expected, message );
 	},
 
-	raises: function( block, expected, message ) {
+	throws: function( block, expected, message ) {
 		var actual,
 			ok = false;
 
+		// 'expected' is optional
 		if ( typeof expected === "string" ) {
 			message = expected;
 			expected = null;
@@ -500,12 +501,21 @@ QUnit.assert = {
 	}
 };
 
-// @deprecated: Kept assertion helpers in root for backwards compatibility
+/**
+ * @deprecate since 1.8.0
+ * Kept assertion helpers in root for backwards compatibility
+ */
 extend( QUnit, QUnit.assert );
 
 /**
- * @deprecated: Kept for backwards compatibility
- * next step: remove entirely
+ * @deprecated since 1.9.0
+ * Kept global "raises()" for backwards compatibility
+ */
+QUnit.raises = QUnit.assert.throws;
+
+/**
+ * @deprecated since 1.0.0, replaced with error pushes since 1.3.0
+ * Kept to avoid TypeErrors for undefined methods.
  */
 QUnit.equals = function() {
 	QUnit.push( false, false, false, "QUnit.equals has been deprecated since 2009 (e88049a0), use QUnit.equal instead" );

--- a/test/test.js
+++ b/test/test.js
@@ -280,36 +280,36 @@ test("raises",function() {
 		return this.message;
 	};
 
-	raises(
+	throws(
 		function() {
-			throw "error"
+			throw "my error"
 		}
 	);
 
-	raises(
+	throws(
 		function() {
-			throw "error"
+			throw "my error"
 		},
-		'raises with just a message, no expected'
+		"simple string throw, no 'expected' value given"
 	);
 
-	raises(
+	throws(
 		function() {
 			throw new CustomError();
 		},
 		CustomError,
-		'raised error is an instance of CustomError'
+		'thrown error is an instance of CustomError'
 	);
 
-	raises(
+	throws(
 		function() {
 			throw new CustomError("some error description");
 		},
 		/description/,
-		"raised error message contains 'description'"
+		"use a regex to match against the stringified error"
 	);
 
-	raises(
+	throws(
 		function() {
 			throw new CustomError("some error description");
 		},
@@ -321,7 +321,7 @@ test("raises",function() {
 		"custom validation function"
 	);
 
-	raises(
+	throws(
 		function() {
 			( window.execScript || function( data ) {
 				window["eval"].call( window, data );
@@ -332,12 +332,19 @@ test("raises",function() {
 
     this.CustomError = CustomError;
 
-    raises(
+    throws(
         function() {
             throw new this.CustomError("some error description");
         },
         /description/,
-        "raised error with 'this' context"
+        "throw error from property of 'this' context"
+    );
+
+    raises(
+        function() {
+            throw "error"
+        },
+        "simple throw, asserting with deprecated raises() function"
     );
 
 });


### PR DESCRIPTION
- Issues:
  - Fixes #267
- Also:
  - Update unit test, and kept one to assert raises()
  - Improved doc-comments for the other deprecated
    methods.
