### PR TITLE
Use classes to collapse assertion groups. Fixes #269

### DIFF
--- a/qunit/qunit.css
+++ b/qunit/qunit.css
@@ -20,7 +20,7 @@
 
 /** Resets */
 
-#qunit-tests, #qunit-tests ol, #qunit-header, #qunit-banner, #qunit-userAgent, #qunit-testresult {
+#qunit-tests, #qunit-header, #qunit-banner, #qunit-userAgent, #qunit-testresult {
 	margin: 0;
 	padding: 0;
 }
@@ -107,7 +107,7 @@
 	color: #000;
 }
 
-#qunit-tests ol {
+.qunit-assert-list {
 	margin-top: 0.5em;
 	padding: 0.5em;
 
@@ -120,6 +120,10 @@
 	box-shadow: inset 0px 2px 13px #999;
 	-moz-box-shadow: inset 0px 2px 13px #999;
 	-webkit-box-shadow: inset 0px 2px 13px #999;
+}
+
+.qunit-assert-list.qunit-collapsed {
+	display: none;
 }
 
 #qunit-tests table {

--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -178,6 +178,7 @@ Test.prototype = {
 
 		if ( tests ) {
 			ol = document.createElement( "ol" );
+			ol.className = "qunit-assert-list";
 
 			for ( i = 0; i < this.assertions.length; i++ ) {
 				assertion = this.assertions[i];
@@ -206,7 +207,7 @@ Test.prototype = {
 			}
 
 			if ( bad === 0 ) {
-				ol.style.display = "none";
+				addClass( ol, "qunit-collapsed" );
 			}
 
 			// `b` initialized at top of scope
@@ -215,8 +216,8 @@ Test.prototype = {
 
 			addEvent(b, "click", function() {
 				var next = b.nextSibling.nextSibling,
-					display = next.style.display;
-				next.style.display = display === "none" ? "block" : "none";
+					collapsed = hasClass( next, "qunit-collapsed" );
+				(collapsed ? removeClass : addClass)( next, "qunit-collapsed" );
 			});
 
 			addEvent(b, "dblclick", function( e ) {
@@ -1244,6 +1245,26 @@ function addEvent( elem, type, fn ) {
 	} else {
 		fn();
 	}
+}
+
+function hasClass( elem, name ) {
+	return (" " + elem.className + " ").indexOf(" " + name + " ") > -1;
+}
+
+function addClass( elem, name ) {
+	if ( !hasClass( elem, name ) ) {
+		elem.className += (elem.className ? " " : "") + name;
+	}
+}
+
+function removeClass( elem, name ) {
+	var set = " " + elem.className + " ";
+	// Class name may appear multiple times
+	while ( set.indexOf(" " + name + " ") > -1 ) {
+		set = set.replace(" " + name + " " , " ");
+	}
+	// If possible, trim it for prettiness, but not neccecarily
+	elem.className = window.jQuery ? jQuery.trim( set ) : ( set.trim ? set.trim() : set );
 }
 
 function id( name ) {


### PR DESCRIPTION
- Issues:
  - Fixes #269
- Also:
  - Added needed {has, add, remove}Class implementations.
    Should be solid, improvements welcome.
  - Removed '#qunit-tests ol' selector which was interfering with the
    lower-score selector '.qunit-assert-list'. This selector is
    redundant since it is always being overridden by '#qunit-tests ol'
    which sets margin and padding. Reset is redundant.
