### PR TITLE
Banner: Link should ignore "testNumber" and "module". Fixes #270

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -885,7 +885,7 @@ QUnit.load = function() {
 	// `banner` initialized at top of scope
 	banner = id( "qunit-header" );
 	if ( banner ) {
-		banner.innerHTML = "<a href='" + QUnit.url({ filter: undefined }) + "'>" + banner.innerHTML + "</a> " + urlConfigHtml;
+		banner.innerHTML = "<a href='" + QUnit.url({ filter: undefined, module: undefined, testNumber: undefined }) + "'>" + banner.innerHTML + "</a> " + urlConfigHtml;
 		addEvent( banner, "change", function( event ) {
 			var params = {};
 			params[ event.target.name ] = event.target.checked ? true : undefined;


### PR DESCRIPTION
- Follows-up:
  - 14f3acb: Implement 'module' url parameter
  - f08dc89: Create rerun links based on ... number
