### PR TITLE
Lint tests

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,7 @@
+{
+	"predef": [
+		"QUnit"
+	],
+	"browser": true,
+	"smarttabs": true
+}

--- a/test/deepEqual.js
+++ b/test/deepEqual.js
@@ -70,38 +70,38 @@ test("Primitive types and constants", function () {
 	equal(QUnit.equiv('', null), false, "string");
 	equal(QUnit.equiv('', undefined), false, "string");
 
-	// Short annotation VS new annotation
-	equal(QUnit.equiv(0, new Number()), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(new Number(), 0), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(1, new Number(1)), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(new Number(1), 1), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(new Number(0), 1), false, "short annotation VS new annotation");
-	equal(QUnit.equiv(0, new Number(1)), false, "short annotation VS new annotation");
+	// primitives vs. objects
+	equal(QUnit.equiv(0, new Number()), true, "primitives vs. objects");
+	equal(QUnit.equiv(new Number(), 0), true, "primitives vs. objects");
+	equal(QUnit.equiv(1, new Number(1)), true, "primitives vs. objects");
+	equal(QUnit.equiv(new Number(1), 1), true, "primitives vs. objects");
+	equal(QUnit.equiv(new Number(0), 1), false, "primitives vs. objects");
+	equal(QUnit.equiv(0, new Number(1)), false, "primitives vs. objects");
 
-	equal(QUnit.equiv(new String(), ""), true, "short annotation VS new annotation");
-	equal(QUnit.equiv("", new String()), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(new String("My String"), "My String"), true, "short annotation VS new annotation");
-	equal(QUnit.equiv("My String", new String("My String")), true, "short annotation VS new annotation");
-	equal(QUnit.equiv("Bad String", new String("My String")), false, "short annotation VS new annotation");
-	equal(QUnit.equiv(new String("Bad String"), "My String"), false, "short annotation VS new annotation");
+	equal(QUnit.equiv(new String(), ""), true, "primitives vs. objects");
+	equal(QUnit.equiv("", new String()), true, "primitives vs. objects");
+	equal(QUnit.equiv(new String("My String"), "My String"), true, "primitives vs. objects");
+	equal(QUnit.equiv("My String", new String("My String")), true, "primitives vs. objects");
+	equal(QUnit.equiv("Bad String", new String("My String")), false, "primitives vs. objects");
+	equal(QUnit.equiv(new String("Bad String"), "My String"), false, "primitives vs. objects");
 
-	equal(QUnit.equiv(false, new Boolean()), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(new Boolean(), false), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(true, new Boolean(true)), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(new Boolean(true), true), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(true, new Boolean(1)), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(false, new Boolean(false)), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(new Boolean(false), false), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(false, new Boolean(0)), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(true, new Boolean(false)), false, "short annotation VS new annotation");
-	equal(QUnit.equiv(new Boolean(false), true), false, "short annotation VS new annotation");
+	equal(QUnit.equiv(false, new Boolean()), true, "primitives vs. objects");
+	equal(QUnit.equiv(new Boolean(), false), true, "primitives vs. objects");
+	equal(QUnit.equiv(true, new Boolean(true)), true, "primitives vs. objects");
+	equal(QUnit.equiv(new Boolean(true), true), true, "primitives vs. objects");
+	equal(QUnit.equiv(true, new Boolean(1)), true, "primitives vs. objects");
+	equal(QUnit.equiv(false, new Boolean(false)), true, "primitives vs. objects");
+	equal(QUnit.equiv(new Boolean(false), false), true, "primitives vs. objects");
+	equal(QUnit.equiv(false, new Boolean(0)), true, "primitives vs. objects");
+	equal(QUnit.equiv(true, new Boolean(false)), false, "primitives vs. objects");
+	equal(QUnit.equiv(new Boolean(false), true), false, "primitives vs. objects");
 
-	equal(QUnit.equiv(new Object(), {}), true, "short annotation VS new annotation");
-	equal(QUnit.equiv({}, new Object()), true, "short annotation VS new annotation");
-	equal(QUnit.equiv(new Object(), {a:1}), false, "short annotation VS new annotation");
-	equal(QUnit.equiv({a:1}, new Object()), false, "short annotation VS new annotation");
-	equal(QUnit.equiv({a:undefined}, new Object()), false, "short annotation VS new annotation");
-	equal(QUnit.equiv(new Object(), {a:undefined}), false, "short annotation VS new annotation");
+	equal(QUnit.equiv(new Object(), {}), true, "object literal vs. instantiation");
+	equal(QUnit.equiv({}, new Object()), true, "object literal vs. instantiation");
+	equal(QUnit.equiv(new Object(), {a:1}), false, "object literal vs. instantiation");
+	equal(QUnit.equiv({a:1}, new Object()), false, "object literal vs. instantiation");
+	equal(QUnit.equiv({a:undefined}, new Object()), false, "object literal vs. instantiation");
+	equal(QUnit.equiv(new Object(), {a:undefined}), false, "object literal vs. instantiation");
 });
 
 test("Objects Basics.", function() {
@@ -334,6 +334,7 @@ test("Functions.", function() {
 	// f2 and f3 have the same code, formatted differently
 	var f2 = function () {var i = 0;};
 	var f3 = function () {
+		/*jshint asi:true */
 		var i = 0 // this comment and no semicoma as difference
 	};
 
@@ -851,9 +852,9 @@ test("Complex Objects.", function() {
 				prop: null,
 				foo: [1,2,null,{}, [], [1,2,3]],
 				bar: undefined
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
 		],
-		unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
 		b: "b",
 		c: fn1
 	};
@@ -864,9 +865,9 @@ test("Complex Objects.", function() {
 				prop: null,
 				foo: [1,2,null,{}, [], [1,2,3]],
 				bar: undefined
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
 		],
-		unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
 		b: "b",
 		c: fn1
 	};
@@ -877,9 +878,9 @@ test("Complex Objects.", function() {
 				prop: null,
 				foo: [1,2,null,{}, [], [1,2,3,4]], // different: 4 was add to the array
 				bar: undefined
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
 		],
-		unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
 		b: "b",
 		c: fn1
 	};
@@ -891,9 +892,9 @@ test("Complex Objects.", function() {
 				foo: [1,2,null,{}, [], [1,2,3]],
 				newprop: undefined, // different: newprop was added
 				bar: undefined
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
 		],
-		unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
 		b: "b",
 		c: fn1
 	};
@@ -904,9 +905,9 @@ test("Complex Objects.", function() {
 				prop: null,
 				foo: [1,2,null,{}, [], [1,2,3]],
 				bar: undefined
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±" // different: missing last char
+			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±" // different: missing last char
 		],
-		unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
 		b: "b",
 		c: fn1
 	};
@@ -917,9 +918,9 @@ test("Complex Objects.", function() {
 				prop: null,
 				foo: [1,2,undefined,{}, [], [1,2,3]], // different: undefined instead of null
 				bar: undefined
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
 		],
-		unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
 		b: "b",
 		c: fn1
 	};
@@ -930,9 +931,9 @@ test("Complex Objects.", function() {
 				prop: null,
 				foo: [1,2,null,{}, [], [1,2,3]],
 				bat: undefined // different: property name not "bar"
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰Ï�Î¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏ�Î¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿Ï�Î¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
 		],
-		unicode: "è€� æ±‰è¯­ä¸­å­˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„å�Žäººåœˆä¸­ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
 		b: "b",
 		c: fn1
 	};
@@ -1363,7 +1364,7 @@ test("Complex Instances Nesting (with function value in literals and/or in neste
 });
 
 
-test('object with references to self wont loop', function(){
+test('object with references to self wont loop', function() {
 	var circularA = {
 		abc:null
 	}, circularB = {
@@ -1382,7 +1383,7 @@ test('object with references to self wont loop', function(){
 	equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on object (unambigous test)");
 });
 
-test('array with references to self wont loop', function(){
+test('array with references to self wont loop', function() {
 	var circularA = [],
 		circularB = [];
 	circularA.push(circularA);
@@ -1398,7 +1399,7 @@ test('array with references to self wont loop', function(){
 	equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on array (unambigous test)");
 });
 
-test('mixed object/array with references to self wont loop', function(){
+test('mixed object/array with references to self wont loop', function() {
 	var circularA = [{abc:null}],
 		circularB = [{abc:null}];
 	circularA[0].abc = circularA;

--- a/test/headless.html
+++ b/test/headless.html
@@ -1,21 +1,25 @@
 <!DOCTYPE html>
 <html>
 <head>
+	<meta charset="UTF-8">
 	<title>QUnit Test Suite</title>
-	<link rel="stylesheet" href="../qunit/qunit.css" type="text/css" media="screen">
-	<script type="text/javascript" src="../qunit/qunit.js"></script>
-	<script type="text/javascript" src="test.js"></script>
-	<script type="text/javascript" src="deepEqual.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
+	<script src="test.js"></script>
+	<script src="deepEqual.js"></script>
 	<script>
-		var logs = ["begin", "testStart", "testDone", "log", "moduleStart", "moduleDone", "done"];
-		for (var i = 0; i < logs.length; i++) {
-			(function() {
-				var log = logs[i];
-				QUnit[log] = function() {
-					console.log(log, arguments);
-				};
-			})();
-		}
+		(function () {
+			function createCallback(logType) {
+				QUnit[logType](function () {
+					console.log(logType, arguments);
+				});
+			}
+
+			var logs = ["begin", "testStart", "testDone", "log", "moduleStart", "moduleDone", "done"];
+			for (var i = 0; i < logs.length; i++) {
+				createCallback(logs[i]);
+			}
+		}());
 	</script>
 </head>
 <body>

--- a/test/index.html
+++ b/test/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta charset="UTF-8" />
+	<meta charset="UTF-8">
 	<title>QUnit Test Suite</title>
 	<link rel="stylesheet" href="../qunit/qunit.css">
 	<script src="../qunit/qunit.js"></script>

--- a/test/logs.html
+++ b/test/logs.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html>
 <head>
+	<meta charset="UTF-8">
 	<title>QUnit Test Suite</title>
-	<link rel="stylesheet" href="../qunit/qunit.css" type="text/css" media="screen">
-	<script type="text/javascript" src="../qunit/qunit.js"></script>
-	<script type="text/javascript" src="logs.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
+	<script src="logs.js"></script>
 </head>
 <body>
 	<div id="qunit"></div>

--- a/test/logs.js
+++ b/test/logs.js
@@ -39,15 +39,18 @@ QUnit.log(function(context) {
 	logContext = context;
 });
 
-var logs = ["begin", "testStart", "testDone", "log", "moduleStart", "moduleDone", "done"];
-for (var i = 0; i < logs.length; i++) {
-	(function() {
-		var log = logs[i];
-		QUnit[log](function() {
-			console.log(log, arguments);
+(function () {
+	function createCallback(logType) {
+		QUnit[logType](function () {
+			console.log(logType, arguments);
 		});
-	})();
-}
+	}
+
+	var logs = ["begin", "testStart", "testDone", "log", "moduleStart", "moduleDone", "done"];
+	for (var i = 0; i < logs.length; i++) {
+		createCallback(logs[i]);
+	}
+}());
 
 module("logs1");
 
@@ -168,12 +171,12 @@ QUnit.done(function() {
 
 	moduleStart = moduleDone = 0;
 
-	test("first", function(){
+	test("first", function() {
 		equal(moduleStart, 1, "test started");
 		equal(moduleDone, 0, "test in progress");
 	});
 
-	test("second", function(){
+	test("second", function() {
 		equal(moduleStart, 2, "test started");
 		equal(moduleDone, 1, "test in progress");
 	});

--- a/test/narwhal-test.js
+++ b/test/narwhal-test.js
@@ -1,7 +1,8 @@
 // run with
 // node test/node-test.js
 var QUnit = require("../qunit/qunit");
-QUnit.log(function(details) {
+
+QUnit.log(function (details) {
 	if (!details.result) {
 		var output = "FAILED: " + (details.message ? details.message + ", " : "");
 		if (details.actual) {
@@ -15,8 +16,10 @@ QUnit.log(function(details) {
 		print("ok!");
 	}
 });
-QUnit.test("yo", function() {
-	QUnit.equal(true, false);
-	QUnit.equal(true, false, "gotta fail");
-	x.y.z;
+
+QUnit.test("fail twice with stacktrace", function (assert) {
+	/*jshint expr:true */
+	assert.equal(true, false);
+	assert.equal(true, false, "gotta fail");
+	x.y.z; // Throws ReferenceError
 });

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -1,7 +1,8 @@
 // run with
 // node test/node-test.js
 var QUnit = require("../qunit/qunit");
-QUnit.log(function(details) {
+
+QUnit.log(function (details) {
 	if (!details.result) {
 		var output = "FAILED: " + (details.message ? details.message + ", " : "");
 		if (details.actual) {
@@ -13,8 +14,10 @@ QUnit.log(function(details) {
 		console.log(output);
 	}
 });
-QUnit.test("yo", function() {
-	QUnit.equal(true, false);
-	QUnit.equal(true, false, "gotta fail");
-	x.y.z;
+
+QUnit.test("fail twice with stacktrace", function (assert) {
+	/*jshint expr:true */
+	assert.equal(true, false);
+	assert.equal(true, false, "gotta fail");
+	x.y.z; // Throws ReferenceError
 });

--- a/test/swarminject.js
+++ b/test/swarminject.js
@@ -5,5 +5,5 @@
 	if ( !url || url.indexOf("http") !== 0 ) {
 		return;
 	}
-    document.write("<scr" + "ipt src='http://swarm.jquery.org/js/inject.js?" + (new Date).getTime() + "'></scr" + "ipt>");
+    document.write("<scr" + "ipt src='http://swarm.jquery.org/js/inject.js?" + (new Date()).getTime() + "'></scr" + "ipt>");
 })();

--- a/test/test.js
+++ b/test/test.js
@@ -49,13 +49,13 @@ module("setup/teardown test", {
 	setup: function() {
 		state = true;
 		ok(true);
-		x = 1;
+		window.x = 1;
 	},
 	teardown: function() {
 		ok(true);
 		// can introduce and delete globals in setup/teardown
 		// without noglobals sounding the alarm
-		delete x;
+		delete window.x;
 	}
 });
 
@@ -114,7 +114,7 @@ test("parameter passed to start decrements semaphore n times", function() {
 module("async setup test", {
 	setup: function() {
 		stop();
-		setTimeout(function(){
+		setTimeout(function() {
 			ok(true);
 			start();
 		}, 500);
@@ -130,7 +130,7 @@ asyncTest("module with async setup", function() {
 module("async teardown test", {
 	teardown: function() {
 		stop();
-		setTimeout(function(){
+		setTimeout(function() {
 			ok(true);
 			start();
 		}, 500);
@@ -179,11 +179,11 @@ test("sync", 2, function() {
 
 test("test synchronous calls to stop", 2, function() {
 	stop();
-	setTimeout(function(){
+	setTimeout(function() {
 		ok(true, 'first');
 		start();
 		stop();
-		setTimeout(function(){
+		setTimeout(function() {
 			ok(true, 'second');
 			start();
 		}, 150);
@@ -206,7 +206,8 @@ test("scope check", function() {
 
 module("simple testEnvironment setup", {
 	foo: "bar",
-	bugid: "#5311" // example of meta-data
+	// example of meta-data
+	bugid: "#5311"
 });
 test("scope check", function() {
 	deepEqual(this.foo, "bar");
@@ -282,13 +283,13 @@ test("raises",function() {
 
 	throws(
 		function() {
-			throw "my error"
+			throw "my error";
 		}
 	);
 
 	throws(
 		function() {
-			throw "my error"
+			throw "my error";
 		},
 		"simple string throw, no 'expected' value given"
 	);
@@ -323,9 +324,10 @@ test("raises",function() {
 
 	throws(
 		function() {
+			/*jshint evil:true */
 			( window.execScript || function( data ) {
 				window["eval"].call( window, data );
-			})( "throw 'error'" );
+			})( "throw 'error';" );
 		},
 		'globally-executed errors caught'
 	);
@@ -342,7 +344,7 @@ test("raises",function() {
 
     raises(
         function() {
-            throw "error"
+            throw "error";
         },
         "simple throw, asserting with deprecated raises() function"
     );
@@ -388,7 +390,9 @@ module("recursions");
 
 function Wrap(x) {
 	this.wrap = x;
-	if (x == undefined)  this.first = true;
+	if (x === undefined) {
+		this.first = true;
+	}
 }
 
 function chainwrap(depth, first, prev) {
@@ -508,29 +512,27 @@ test('Circular reference - test reported by soniciq in #105', function() {
 	});
 })();
 
-if (typeof setTimeout !== 'undefined') {
-function testAfterDone(){
+function testAfterDone() {
 	var testName = "ensure has correct number of assertions";
 
-	function secondAfterDoneTest(){
+	function secondAfterDoneTest() {
 		QUnit.config.done = [];
-		//QUnit.done = function(){};
-		//because when this does happen, the assertion count parameter doesn't actually
-		//work we use this test to check the assertion count.
+		// Because when this does happen, the assertion count parameter doesn't actually
+		// work we use this test to check the assertion count.
 		module("check previous test's assertion counts");
-		test('count previous two test\'s assertions', function(){
-			var spans = document.getElementsByTagName('span'),
-			tests = [],
-			countNodes;
+		test('count previous two test\'s assertions', function () {
+			var i, countNodes,
+				spans = document.getElementsByTagName('span'),
+				tests = [];
 
-			//find these two tests
-			for (var i = 0; i < spans.length; i++) {
+			// Find these two tests
+			for (i = 0; i < spans.length; i++) {
 				if (spans[i].innerHTML.indexOf(testName) !== -1) {
 					tests.push(spans[i]);
 				}
 			}
 
-			//walk dom to counts
+			// Walk dom to counts.
 			countNodes = tests[0].nextSibling.nextSibling.getElementsByTagName('b');
 			equal(countNodes[1].innerHTML, "99");
 			countNodes = tests[1].nextSibling.nextSibling.getElementsByTagName('b');
@@ -542,22 +544,22 @@ function testAfterDone(){
 
 	module("Synchronous test after load of page");
 
-	asyncTest('Async test', function(){
+	asyncTest('Async test', function() {
 		start();
 		for (var i = 1; i < 100; i++) {
 			ok(i);
 		}
 	});
 
-	test(testName, 99, function(){
+	test(testName, 99, function() {
 		for (var i = 1; i < 100; i++) {
 			ok(i);
 		}
 	});
 
-	//we need two of these types of tests in order to ensure that assertions
-	//don't move between tests.
-	test(testName + ' 2', 99, function(){
+	// We need two of these types of tests in order to ensure that assertions
+	// don't move between tests.
+	test(testName + ' 2', 99, function() {
 		for (var i = 1; i < 100; i++) {
 			ok(i);
 		}
@@ -566,6 +568,6 @@ function testAfterDone(){
 
 }
 
-QUnit.done(testAfterDone);
-
+if (typeof setTimeout !== 'undefined') {
+	QUnit.done(testAfterDone);
 }


### PR DESCRIPTION
- Mostly semi-colons and adding inline /*jshint */ options for
  justified test exceptions for options: "ask", "expr" and "evil".
  
  The only thing left failing is new Number/Boolean/Object.
  See also
- Fixed other warnings such as deleting window properties instead
  of implied globals, functions in a loop, and function declarations
  inside an if statement (instead put it outside and only the
  invocation inside the if statement)
- Consistency in HTML template.
