### PR TITLE
Keep a local reference to Date.

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -17,6 +17,8 @@ var QUnit,
 	fileName = (sourceFromStacktrace( 0 ) || "" ).replace(/(:\d+)+\)?/, "").replace(/.+\//, ""),
 	toString = Object.prototype.toString,
 	hasOwn = Object.prototype.hasOwnProperty,
+	// Keep a local reference to Date (GH-283)
+	Date = window.Date,
 	defined = {
 	setTimeout: typeof window.setTimeout !== "undefined",
 	sessionStorage: (function() {

--- a/test/test.js
+++ b/test/test.js
@@ -71,6 +71,28 @@ test("module without setup/teardown", function() {
 	ok(true);
 });
 
+
+
+var orgDate;
+
+module("Date test", {
+	setup: function() {
+		orgDate = Date;
+		Date = function () {
+			ok( false, 'QUnit should internally be independant from Date-related manipulation and testing' );
+			return new orgDate();
+		};
+	},
+	teardown: function() {
+		Date = orgDate;
+	}
+});
+
+test("sample test for Date test", function () {
+	expect(1);
+	ok(true);
+});
+
 if (typeof setTimeout !== 'undefined') {
 state = 'fail';
 


### PR DESCRIPTION
Fixes #283.

```
>> 293 assertions passed (2382ms)
Done, without errors.
```

Though performance is not the motivation behind this fix, it appears to slightly improve performance as well, by having it in the local scope instead of going through the scope chain. 
