### PR TITLE
Remove conditional codepath based on jQuery presence from reset().

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -712,17 +712,10 @@ extend( QUnit, {
 	},
 
 	// Resets the test setup. Useful for tests that modify the DOM.
-	// If jQuery is available, uses jQuery's html(), otherwise just innerHTML.
 	reset: function() {
-		var fixture;
-
-		if ( window.jQuery ) {
-			jQuery( "#qunit-fixture" ).html( config.fixture );
-		} else {
-			fixture = id( "qunit-fixture" );
-			if ( fixture ) {
-				fixture.innerHTML = config.fixture;
-			}
+		var fixture = id( "qunit-fixture" );
+		if ( fixture ) {
+			fixture.innerHTML = config.fixture;
 		}
 	},
 


### PR DESCRIPTION
Though qunit should no longer depend on jQuery I found one codepath in the library thats still conditionally checks for the existence of jQuery and uses the html() utility method if available. Otherwise it falls back to assigning to innerHTML.

I propose removing this conditional codepath which creates two different codepaths dependent on the availability of an separate library. I actually hit this because I mocked a jQuery object and suddenly hit an internal exception.

Using innerHTML directly should be safe and all qunit tests continue to pass with this change.
