### PR TITLE
Callback changes

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -787,6 +787,8 @@ extend( QUnit, {
 
 		var output, source,
 			details = {
+                module: config.current.module,
+                name: config.current.testName,
 				result: result,
 				message: message,
 				actual: actual,

--- a/test/logs.js
+++ b/test/logs.js
@@ -69,7 +69,9 @@ test("test1", 13, function() {
 		result: true,
 		message: "msg",
 		actual: "foo",
-		expected: "foo"
+		expected: "foo",
+        name: "test1",
+        module: "logs1"
 	});
 	strictEqual(testDoneContext, undefined);
 	deepEqual(testContext, {


### PR DESCRIPTION
This adds the name of the module and the test, to the information returned to the callback to `QUnit.log(Function)`. This is pretty useful when used with PhantomJS because you can get the test name and module information from just one call, instead of having to use `QUnit.moduleStart(Function)` and `QUnit.testStart(Function)`
