### PR TITLE
Assertion information to callback

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -164,9 +164,9 @@ Test.prototype = {
 		if ( config.requireExpects && this.expected == null ) {
 			QUnit.pushFailure( "Expected number of assertions to be defined, but expect() was not called.", this.stack );
 		} else if ( this.expected != null && this.expected != this.assertions.length ) {
-			QUnit.pushFailure( "Expected " + this.expected + " assertions, but " + this.assertions.length + " were run", this.stack );
+			QUnit.pushFailure( "Expected " + this.expected + " assertions, but " + this.assertions.length + " were run", this.stack, null, QUnit.AssertionType.EXPECT );
 		} else if ( this.expected == null && !this.assertions.length ) {
-			QUnit.pushFailure( "Expected at least one assertion, but none were run - call expect(0) to accept zero assertions.", this.stack );
+			QUnit.pushFailure( "Expected at least one assertion, but none were run - call expect(0) to accept zero assertions.", this.stack, null, QUnit.AssertionType.EXPECT );
 		}
 
 		var assertion, a, b, i, li, ol,
@@ -399,6 +399,24 @@ QUnit = {
 	}
 };
 
+// Assertion types
+// A type of "enum" so that we don't have to use raw strings
+// We can expose this to the outside world so that we can check for specific assertion types when looking at the results
+// of QUnit.log(...). Especially useful when automating tests with PhantomJS
+QUnit.AssertionType = {
+    OK: "ok",
+    EQUAL: "equal",
+    NOT_EQUAL: "notEqual",
+    DEEP_EQUAL: "deepEqual",
+    NOT_DEEP_EQUAL: "notDeepEqual",
+    STRICT_EQUAL: "strictEqual",
+    NOT_STRICT_EQUAL: "notStrictEqual",
+    THROWS: "throws",
+    EXPECT: "expect"
+};
+
+extend( QUnit, QUnit.AssertionType );
+
 // Asssert helpers
 // All of these must call either QUnit.push() or manually do:
 // - runLoggingCallbacks( "log", .. );
@@ -418,6 +436,7 @@ QUnit.assert = {
 
 		var source,
 			details = {
+                assertionType: QUnit.AssertionType.OK,
                 module: config.current.module,
                 name: config.current.testName,
 				result: result,
@@ -449,7 +468,7 @@ QUnit.assert = {
 	 * @example equal( format( "Received {0} bytes.", 2), "Received 2 bytes.", "format() replaces {0} with next argument" );
 	 */
 	equal: function( actual, expected, message ) {
-		QUnit.push( expected == actual, actual, expected, message );
+		QUnit.push( expected == actual, actual, expected, message, QUnit.AssertionType.EQUAL );
 	},
 
 	/**
@@ -457,7 +476,7 @@ QUnit.assert = {
 	 * @function
 	 */
 	notEqual: function( actual, expected, message ) {
-		QUnit.push( expected != actual, actual, expected, message );
+		QUnit.push( expected != actual, actual, expected, message, QUnit.AssertionType.NOT_EQUAL );
 	},
 
 	/**
@@ -465,7 +484,7 @@ QUnit.assert = {
 	 * @function
 	 */
 	deepEqual: function( actual, expected, message ) {
-		QUnit.push( QUnit.equiv(actual, expected), actual, expected, message );
+		QUnit.push( QUnit.equiv(actual, expected), actual, expected, message, QUnit.AssertionType.DEEP_EQUAL );
 	},
 
 	/**
@@ -473,7 +492,7 @@ QUnit.assert = {
 	 * @function
 	 */
 	notDeepEqual: function( actual, expected, message ) {
-		QUnit.push( !QUnit.equiv(actual, expected), actual, expected, message );
+		QUnit.push( !QUnit.equiv(actual, expected), actual, expected, message, QUnit.AssertionType.NOT_DEEP_EQUAL );
 	},
 
 	/**
@@ -481,7 +500,7 @@ QUnit.assert = {
 	 * @function
 	 */
 	strictEqual: function( actual, expected, message ) {
-		QUnit.push( expected === actual, actual, expected, message );
+		QUnit.push( expected === actual, actual, expected, message, QUnit.AssertionType.STRICT_EQUAL );
 	},
 
 	/**
@@ -489,7 +508,7 @@ QUnit.assert = {
 	 * @function
 	 */
 	notStrictEqual: function( actual, expected, message ) {
-		QUnit.push( expected !== actual, actual, expected, message );
+		QUnit.push( expected !== actual, actual, expected, message, QUnit.AssertionType.NOT_STRICT_EQUAL );
 	},
 
 	throws: function( block, expected, message ) {
@@ -525,9 +544,9 @@ QUnit.assert = {
 				ok = true;
 			}
 
-			QUnit.push( ok, actual, null, message );
+			QUnit.push( ok, actual, null, message, QUnit.AssertionType.THROWS );
 		} else {
-			QUnit.pushFailure( message, null, 'No exception was thrown.' );
+			QUnit.pushFailure( message, null, 'No exception was thrown.', QUnit.AssertionType.THROWS );
 		}
 	}
 };
@@ -782,13 +801,14 @@ extend( QUnit, {
 		return undefined;
 	},
 
-	push: function( result, actual, expected, message ) {
+	push: function( result, actual, expected, message, assertionType ) {
 		if ( !config.current ) {
 			throw new Error( "assertion outside test context, was " + sourceFromStacktrace() );
 		}
 
 		var output, source,
 			details = {
+                assertionType: assertionType,
                 module: config.current.module,
                 name: config.current.testName,
 				result: result,
@@ -829,13 +849,14 @@ extend( QUnit, {
 		});
 	},
 
-	pushFailure: function( message, source, actual ) {
+	pushFailure: function( message, source, actual, assertionType ) {
 		if ( !config.current ) {
 			throw new Error( "pushFailure() assertion outside test context, was " + sourceFromStacktrace(2) );
 		}
 
 		var output,
 			details = {
+                assertionType: assertionType,
                 module: config.current.module,
                 name: config.current.testName,
 				result: false,

--- a/test/logs.js
+++ b/test/logs.js
@@ -64,7 +64,8 @@ test("test1", 13, function() {
 		actual: 0,
 		expected: 0,
         name: "test1",
-        module: "logs1"
+        module: "logs1",
+        assertionType: QUnit.AssertionType.EQUAL
 	});
 	equal("foo", "foo", "msg");
 	deepEqual(logContext, {
@@ -73,21 +74,24 @@ test("test1", 13, function() {
 		actual: "foo",
 		expected: "foo",
         name: "test1",
-        module: "logs1"
+        module: "logs1",
+        assertionType: QUnit.AssertionType.EQUAL
 	});
     ok(false, "msg");
     deepEqual(logContext, {
         result: false,
         message: "msg",
         name: "test1",
-        module: "logs1"
+        module: "logs1",
+        assertionType: QUnit.AssertionType.OK
     });
     ok(true, "msg");
     deepEqual(logContext, {
         result: true,
         message: "msg",
         name: "test1",
-        module: "logs1"
+        module: "logs1",
+        assertionType: QUnit.AssertionType.OK
     });
 	strictEqual(testDoneContext, undefined);
 	deepEqual(testContext, {


### PR DESCRIPTION
This includes the previous callback changes along with the addition of assertion information to the information returned by `log`.

The rationale for adding assertion information is as follows:
- The assertion-type provides information about the type of assertion that was violated. This is pretty useful when doing automated tests with PhantomJS and QUnit.
- Currently the `throws` assertion has an expected value of `null`. This is because the expected value can be a regular expression. When reporting the results of tests, we can tell whether the test failed or not by examining the `result` property from `log`. However, the decision to show `expected` and `actual` values (which don't apply in the case of `throws` when using a regular expression) cannot be safely made by simply examining the `expected` value and checking if it is null. There can be cases where `null` is an actual expected-value. Instead, it would be safer and more obvious to look at the `assertionType` property and decide whether to show the `expected` and `actual` values. This problem also exists in the current QUnit report. When a `throws` assertion that expects an exception fails (and it uses a regular expression), the expected value is shown as `null`, which is not correct. In this case, we could simply examine the `assertionType` property and decide to not show the expected and actual values if the assertion was a `throws` assertion.
