### PR TITLE
Second version of fix for "cumulative expect" issue #226

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -352,7 +352,11 @@ QUnit = {
 
 	// Specify the number of expected assertions to gurantee that failed test (no assertions are run at all) don't slip through.
 	expect: function( asserts ) {
-		config.current.expected = asserts;
+		if (arguments.length === 1) {
+			config.current.expected = asserts;
+		} else {
+			return config.current.expected;
+		}
 	},
 
 	start: function( count ) {

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,15 @@ test("expect in test", 1, function() {
 	ok(true);
 });
 
+test("expect query and multiple issue", function() {
+  expect(2);
+  ok(true);
+  var expected = expect();
+  equal(expected, 2);
+  expect(expected + 1);
+  ok(true);
+});
+
 QUnit.module("assertion helpers");
 
 QUnit.test( "QUnit.assert compatibility", function( assert ) {


### PR DESCRIPTION
Strategy adjusted following feedback in issue #226 comments to use "query and reissue" rather than natural cumulative semantic for expect()
