### PR TITLE
"rerun" is visible on passing tests now

### DIFF
--- a/qunit/qunit.css
+++ b/qunit/qunit.css
@@ -103,7 +103,7 @@
 
 #qunit-tests li a {
 	padding: 0.5em;
-	color: #c2ccd1;
+	color: #2B81AF;
 	text-decoration: none;
 }
 #qunit-tests li a:hover,


### PR DESCRIPTION
Currently, and I don't know if this is intentional, "Rerun" is very light gray and almost invisible on passing tests (which..they are passing but still, sometimes should be reran) and now the non-hover is blue like the title bg color and easily visible. 
