### PR TITLE
setup() methods are called prematurely when tests are loaded asynchronously

### DIFF
--- a/test/async.html
+++ b/test/async.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8" />
+	<title>QUnit Test Suite</title>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+</head>
+<body>
+	<div id="qunit"></div>
+	<div id="qunit-fixture">test markup</div>
+	<script type="text/javascript" src="../qunit/qunit.js"></script>
+	<script type="text/javascript">
+		// Simulate a delay in retrieving the tests, as when they are loaded
+		// asynchronously using steal, etc.
+		// This results in the document loading before any tests are loaded,
+		// which means config.autorun is true and config.blocking is false.
+		var head= document.getElementsByTagName('head')[0];
+		var script= document.createElement('script');
+		script.type= 'text/javascript';
+		script.src= 'async_setup.js';
+		setTimeout(function() {
+			head.appendChild(script);
+		}, 1000);
+	</script>
+</body>
+</html>

--- a/test/async_setup.js
+++ b/test/async_setup.js
@@ -1,0 +1,27 @@
+var empty_me = ['start'];
+
+module("multiple async tests with setup", {
+	setup: function() {
+		empty_me = [];
+	}
+});
+
+asyncTest("async A", function() {
+	equal(empty_me.length, 0, "setup should have emptied the array.");
+	empty_me.push('A');
+	start();
+});
+
+asyncTest("async B", function() {
+	equal(empty_me.length, 0, "setup should have emptied the array.");
+	empty_me.push('B');
+	start();
+});
+
+asyncTest("async C", function() {
+	equal(empty_me.length, 0, "setup should have emptied the array.");
+	empty_me.push('C');
+	start();
+});
+
+


### PR DESCRIPTION
I believe [this](http://stackoverflow.com/questions/11036514/qunit-async-tests-with-setup-and-teardown) might be an example of this problem in the wild.

If tests are loaded asynchronously, the document is loaded before they are read, which changes the values of `config.autorun` and `config.blocking` and eventually causes the callbacks queued in Test.queue() to be run out-of-sequence.

This pull request contains a separate test HTML file with accompanying JS tests that exemplify the problem.

The exact sequence of problematic events goes like this:
1. DOM loads
2. `QUnit.load()` completes, and calls `QUnit.start()`
3. `QUnit.start()` sets `config.blocking` to `false`, then calls `process()`
4. There's nothing in the queue, so `process()` calls `done()`
5. `done()` sets `config.autorun` to `true`
6. Test A queues `init()`, which is autorun by `synchronize()`
7. Test A queues the inner `run()`, which is autorun
8. Test A queues `setup()`, which is autorun
9. Test A queues `run()`, which is autorun; now we're blocking.
10. Test A queues `teardown()` and `finish()`. queue is now [A.teardown, A.finish]
11. Test B queues `init()` and inner `run()`. queue is now [A.teardown, A.finish, B.init, B.run]
12. Test C queues `init()` and inner `run()`. queue is now [A.teardown, A.finish, B.init, B.run, C.init, C.run]
13. Test A's `teardown()` and `finish()` are run; no more blocking. queue is now [B.init, B.run, C.init, C.run]
14. Test B's `init()` and inner `run()` are run. queue is now [C.init, C.run]
15. Test B queues `setup()`. queue is now [C.init, C.run, B.setup]
16. **`synchronize()` queues Test B's `setup()` and kicks off `process()`**
17. **`process()` runs the next functions in the queue, which are Test C's `init()` and `run()`.**
18. Test C queues `setup()`. queue is now [B.setup, C.setup]

And now you're thinking with portals.
