### PR TITLE
Not using Object.keys() when reporting error

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -1715,13 +1715,9 @@ QUnit.jsDump = (function() {
 				object: function( map, stack ) {
 					var ret = [ ], keys, key, val, i;
 					QUnit.jsDump.up();
-					if ( Object.keys ) {
-						keys = Object.keys( map );
-					} else {
-						keys = [];
-						for ( key in map ) {
-							keys.push( key );
-						}
+					keys = [];
+					for ( key in map ) {
+						keys.push( key );
 					}
 					keys.sort();
 					for ( i = 0; i < keys.length; i++ ) {


### PR DESCRIPTION
So we can have a better error message for tests like:

```
test( 'test', function() {
  deepEqual( Object.create({ a: 1, b:2 }), { a: 1 } )
})
```
