### PR TITLE
Make `throws` ES3 compatible

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -496,7 +496,7 @@ QUnit.assert = {
 		QUnit.push( expected !== actual, actual, expected, message );
 	},
 
-	throws: function( block, expected, message ) {
+	"throws": function( block, expected, message ) {
 		var actual,
 			ok = false;
 
@@ -546,7 +546,7 @@ extend( QUnit, QUnit.assert );
  * @deprecated since 1.9.0
  * Kept global "raises()" for backwards compatibility
  */
-QUnit.raises = QUnit.assert.throws;
+QUnit.raises = QUnit.assert[ "throws" ];
 
 /**
  * @deprecated since 1.0.0, replaced with error pushes since 1.3.0


### PR DESCRIPTION
`throws` is an ES3 reserved word. This line causes an error in some older engines, including NarwhalJS: https://github.com/jquery/qunit/blob/e34ffb61488459f6823ded82e19865ba4b46e2ed/qunit/qunit.js#L499

See http://mothereff.in/js-properties#throws; either rename `throws` into something else, or quote the property name. (Renaming is probably safest though.)

To fix this, this line will need to be changed as well: https://github.com/jquery/qunit/blob/e34ffb61488459f6823ded82e19865ba4b46e2ed/qunit/qunit.js#L549 Use `['throws']` instead of `throws` here, or just rename the property to something that has never been a reserved word.

Ref. #322.
