### PR TITLE
support windows8 metro app unit test

### DIFF
--- a/addons/composite/qunit-composite.js
+++ b/addons/composite/qunit-composite.js
@@ -83,11 +83,11 @@ QUnit.testDone(function() {
 		src = this.iframe.src;
 
 	// undo the auto-expansion of failed tests
-	for ( i = 0; i < children.length; i++ ) {
-		if ( children[i].nodeName === "OL" ) {
-			children[i].style.display = "none";
-		}
-	}
+	//for ( i = 0; i < children.length; i++ ) {
+	//	if ( children[i].nodeName === "OL" ) {
+	//		children[i].style.display = "none";
+	//	}
+	//}
 
 	QUnit.addEvent(current, "dblclick", function( e ) {
 		var target = e && e.target ? e.target : window.event.srcElement;

--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -1022,7 +1022,7 @@ QUnit.load = function() {
 		toolbar.appendChild( label );
 
 		urlConfigCheckboxes = document.createElement( 'span' );
-		urlConfigCheckboxes.innerHTML = urlConfigHtml;
+		urlConfigCheckboxes.innerHTML = (function (html) { return toStaticHTML ? toStaticHTML(html) : html; })(urlConfigHtml);
 		addEvent( urlConfigCheckboxes, "change", function( event ) {
 			var params = {};
 			params[ event.target.name ] = event.target.checked ? true : undefined;


### PR DESCRIPTION
add function toStaticHtml to handle metro app error, and remove qunit-composite "undo the auto-expansion of failed tests"  block.
