### PR TITLE
Removed the polling mechanism in favor of PhantomJS 1.6+'s WebPage#onCallback

### DIFF
--- a/addons/phantomjs/README.md
+++ b/addons/phantomjs/README.md
@@ -1,14 +1,16 @@
-PhantomJS Runner
-================
+# PhantomJS Runner #
+A PhantomJS-powered headless test runner, providing basic console output for QUnit tests.  
 
-A runner for PhantomJS, providing console output for tests.
+### Usage ###
+```bash
+  phantomjs runner.js [url-of-your-qunit-testsuite]
+```
 
-Usage:
+### Example ###
+```bash
+  phantomjs runner.js http://localhost/qunit/test/index.html
+```
 
-	phantomjs runner.js url
-
-Example:
-
-	phantomjs runner.js http://localhost/qunit/test
-
-If you're using Grunt, you should take a look at its [qunit task](https://github.com/cowboy/grunt/blob/master/docs/task_qunit.md).
+### Notes ###
+ - Requires [PhantomJS](http://phantomjs.org/) 1.6+ (1.7+ recommended).
+ - If you're using Grunt, you should take a look at its [qunit task](https://github.com/gruntjs/grunt/blob/master/docs/task_qunit.md).

--- a/addons/phantomjs/runner.js
+++ b/addons/phantomjs/runner.js
@@ -1,98 +1,124 @@
 /*
- * Qt+WebKit powered headless test runner using Phantomjs
+ * QtWebKit-powered headless test runner using PhantomJS
  *
- * Phantomjs installation: http://code.google.com/p/phantomjs/wiki/BuildInstructions
+ * PhantomJS binaries: http://phantomjs.org/download.html
+ * Requires PhantomJS 1.6+ (1.7+ recommended)
  *
  * Run with:
- *  phantomjs runner.js [url-of-your-qunit-testsuite]
+ *   phantomjs runner.js [url-of-your-qunit-testsuite]
  *
- * E.g.
- *      phantomjs runner.js http://localhost/qunit/test
+ * e.g.
+ *   phantomjs runner.js http://localhost/qunit/test/index.html
  */
 
 /*jshint latedef:false */
-/*global phantom:true require:true console:true */
-var url = phantom.args[0],
-	page = require('webpage').create();
+/*global phantom:false, require:false, console:false, window:false, QUnit:false */
 
-// Route "console.log()" calls from within the Page context to the main Phantom context (i.e. current "this")
-page.onConsoleMessage = function(msg) {
-	console.log(msg);
-};
+(function() {
+	'use strict';
 
-page.onInitialized = function() {
-	page.evaluate(addLogging);
-};
-page.open(url, function(status){
-	if (status !== "success") {
-		console.log("Unable to access network: " + status);
+	var args = require('system').args;
+
+	// arg[0]: scriptName, args[1...]: arguments
+	if (args.length !== 2) {
+		console.error('Usage:\n  phantomjs runner.js [url-of-your-qunit-testsuite]');
 		phantom.exit(1);
-	} else {
-		// page.evaluate(addLogging);
-		var interval = setInterval(function() {
-			if (finished()) {
-				clearInterval(interval);
-				onfinishedTests();
-			}
-		}, 500);
 	}
-});
 
-function finished() {
-	return page.evaluate(function(){
-		return !!window.qunitDone;
+	var url = args[1],
+		page = require('webpage').create();
+
+	// Route `console.log()` calls from within the Page context to the main Phantom context (i.e. current `this`)
+	page.onConsoleMessage = function(msg) {
+		console.log(msg);
+	};
+
+	page.onInitialized = function() {
+		page.evaluate(addLogging);
+	};
+	
+	page.onCallback = function(message) {
+		var result,
+			failed;
+
+		if (message) {
+			if (message.name === 'QUnit.done') {
+				result = message.data;
+				failed = !result || result.failed;
+
+				phantom.exit(failed ? 1 : 0);
+			}
+		}
+	};
+
+	page.open(url, function(status) {
+		if (status !== 'success') {
+			console.error('Unable to access network: ' + status);
+			phantom.exit(1);
+		} else {
+			// Cannot do this verification with the 'DOMContentLoaded' handler because it
+			// will be too late to attach it if a page does not have any script tags.
+			var qunitMissing = page.evaluate(function() { return (typeof QUnit === 'undefined' || !QUnit); });
+			if (qunitMissing) {
+				console.error('The `QUnit` object is not present on this page.');
+				phantom.exit(1);
+			}
+
+			// Do nothing... the callback mechanism will handle everything!
+		}
 	});
-}
 
-function onfinishedTests() {
-	var output = page.evaluate(function() {
-			return JSON.stringify(window.qunitDone);
-	});
-	phantom.exit(JSON.parse(output).failed > 0 ? 1 : 0);
-}
+	function addLogging() {
+		window.document.addEventListener('DOMContentLoaded', function() {
+			var current_test_assertions = [];
 
-function addLogging() {
-	window.document.addEventListener( "DOMContentLoaded", function() {
-		var current_test_assertions = [];
+			QUnit.log(function(details) {
+				var response;
 
-		QUnit.testDone(function(result) {
-			var i,
-				name = result.module + ': ' + result.name;
-
-			if (result.failed) {
-				console.log('Assertion Failed: ' + name);
-
-				for (i = 0; i < current_test_assertions.length; i++) {
-					console.log('    ' + current_test_assertions[i]);
-				}
-			}
-
-			current_test_assertions = [];
-		});
-
-		QUnit.log(function(details) {
-			var response;
-
-			if (details.result) {
-				return;
-			}
-
-			response = details.message || '';
-
-			if (typeof details.expected !== 'undefined') {
-				if (response) {
-					response += ', ';
+				// Ignore passing assertions
+				if (details.result) {
+					return;
 				}
 
-				response += 'expected: ' + details.expected + ', but was: ' + details.actual;
-			}
+				response = details.message || '';
 
-			current_test_assertions.push('Failed assertion: ' + response);
-		});
+				if (typeof details.expected !== 'undefined') {
+					if (response) {
+						response += ', ';
+					}
 
-		QUnit.done(function(result){
-			console.log('Took ' + result.runtime +  'ms to run ' + result.total + ' tests. ' + result.passed + ' passed, ' + result.failed + ' failed.');
-			window.qunitDone = result;
-		});
-	}, false );
-}
+					response += 'expected: ' + details.expected + ', but was: ' + details.actual;
+				}
+
+				current_test_assertions.push('Failed assertion: ' + response);
+			});
+
+			QUnit.testDone(function(result) {
+				var i,
+					len,
+					name = result.module + ': ' + result.name;
+
+				if (result.failed) {
+					console.log('Test failed: ' + name);
+
+					for (i = 0, len = current_test_assertions.length; i < len; i++) {
+						console.log('    ' + current_test_assertions[i]);
+					}
+				}
+
+				current_test_assertions.length = 0;
+			});
+
+			QUnit.done(function(result) {
+				console.log('Took ' + result.runtime +  'ms to run ' + result.total + ' tests. ' + result.passed + ' passed, ' + result.failed + ' failed.');
+
+				if (typeof window.callPhantom === 'function') {
+					window.callPhantom({
+						'name': 'QUnit.done',
+						'data': result
+					});
+				}
+			});
+		}, false);
+	}
+})();


### PR DESCRIPTION
- Removed the polling mechanism in favor of the PhantomJS 1.6+ callback mechanism ([`WebPage#onCallback`](https://github.com/ariya/phantomjs/wiki/API-Reference#wiki-webpage-onCallback)).
- Added argument length checking.
- Added QUnit object detection to avoid an infinite wait if accidentally pointed at a page without QUnit.
- Standardized the coding style.
- Added/updated comments and README.
- Made some minor performance tweaks.
