### PR TITLE
Gruntfile: Add QUnit.step test suite to qunit:addons config

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -11,7 +11,8 @@ grunt.initConfig({
 		addons: [
 			'addons/canvas/canvas.html',
 			'addons/close-enough/close-enough.html',
-			'addons/composite/composite-demo-test.html'
+			'addons/composite/composite-demo-test.html',
+			'addons/step/step.html'
 		],
 		async: 'test/async.html'
 	},


### PR DESCRIPTION
Added the `QUnit.step` test suite to the list of suites in the `qunit:addons` config in the Gruntfile. They were not being run with the grunt build before this.
