### PR TITLE
Standardized the READMEs for the QUnit bundled addons

### DIFF
--- a/addons/canvas/README.md
+++ b/addons/canvas/README.md
@@ -1,16 +1,17 @@
-Canvas - A QUnit Addon For Testing Canvas Rendering
+Canvas - A QUnit addon for testing Canvas rendering
 ================================
 
-This addon for QUnit adds a pixelEqual method that allows you to assert
+This addon for QUnit adds a `QUnit.pixelEqual` method that allows you to assert
 individual pixel values in a given canvas.
 
-Usage:
+### Usage ###
 
-    pixelEqual(canvas, x, y, r, g, b, a, message)
+```js
+QUnit.pixelEqual(canvas, x, y, r, g, b, a, message);
+```
 
 Where:
-
-  * canvas: Reference to a canvas element
-  * x, y: Coordinates of the pixel to test
-  * r, g, b, a: The color and opacity value of the pixel that you except
-  * message: Optional message, same as for other assertions
+ - `canvas`: Reference to a canvas element
+ - `x`, `y`: Coordinates of the pixel to test
+ - `r`, `g`, `b`, `a`: The color and opacity value of the pixel that you except
+ - `message`: Optional message, same as for other assertions

--- a/addons/close-enough/README.md
+++ b/addons/close-enough/README.md
@@ -1,17 +1,18 @@
-Close-Enough - A QUnit Addon For Number Approximations
+Close-Enough - A QUnit addon for testing number approximations
 ================================
 
-This addon for QUnit adds close and notClose assertion methods, to test that
+This addon for QUnit adds `QUnit.close` and `QUnit.notClose` assertion methods to test that
 numbers are close enough (or different enough) from an expected number, with
 a specified accuracy.
 
-Usage:
+### Usage ###
 
-    close(actual, expected, maxDifference, message)
-    notClose(actual, expected, minDifference, message)
+```js
+QUnit.close(actual, expected, maxDifference, message);
+QUnit.notClose(actual, expected, minDifference, message);
+```
 
 Where:
-
-  * maxDifference: the maximum inclusive difference allowed between the actual and expected numbers
-  * minDifference: the minimum exclusive difference allowed between the actual and expected numbers
-  * actual, expected, message: The usual
+ - `maxDifference`: the maximum inclusive difference allowed between the `actual` and `expected` numbers
+ - `minDifference`: the minimum exclusive difference allowed between the `actual` and `expected` numbers
+ - `actual`, `expected`, `message`: The usual

--- a/addons/composite/README.md
+++ b/addons/composite/README.md
@@ -1,20 +1,20 @@
-Composite - A QUnit Addon For Running Multiple Test Files
+Composite - A QUnit addon for running multiple test files
 ================================
 
 Composite is a QUnit addon that, when handed an array of files, will
-open each of those files inside of an iframe, run the tests and
+open each of those files inside of an iframe, run the tests, and
 display the results as a single suite of QUnit tests.
 
-The Rerun link next to each suite allows you to quickly rerun that suite,
+The "Rerun" link next to each suite allows you to quickly rerun that suite,
 outside the composite runner.
 
 If you want to see what assertion failed in a long list of assertions,
 just use the regular "Hide passed tests" checkbox.
 
-## Usage
+### Usage ###
 
-Load QUnit itself along with `qunit-composite.css` and `qunit-composite.js`,
-then specify the testsuites to load using `QUnit.testSuites`:
+Load QUnit itself as usual _plus_ `qunit-composite.css` and `qunit-composite.js`,
+then specify the test suites to load using `QUnit.testSuites`:
 
 ```js
 QUnit.testSuites([

--- a/addons/junitlogger/README.md
+++ b/addons/junitlogger/README.md
@@ -1,20 +1,18 @@
-JUnit Logger
+JUnit Logger - A QUnit addon for producing JUnit-style XML test reports
 ============
 
-A QUnit extension that produces JUnit-style XML output for test results, for integration into tools like Jenkins.
+A QUnit addon that produces JUnit-style XML test reports for integration into build tools like Jenkins.
 
-## Usage
+### Usage ###
 
-Include the addon script after QUnit itself, and implement the hook to do something with the XML string, for example uploading it to a server somewhere:
+Include the addon script after QUnit itself, then implement the `jUnitReport` hook to do something with the XML string (e.g. upload it to a server):
 
 ```js
-QUnit.jUnitReport = function(data) {
-	console.log(data.xml);
+QUnit.jUnitReport = function(report) {
+	console.log(report.xml);
 };
 ```
 
-As you might guess, this isn't a full-blown solution, yet.
-
-## Alternatives
+### Notes ###
 
 If you're using Grunt, you should take a look at its [qunit task](https://github.com/cowboy/grunt/blob/master/docs/task_qunit.md). Or use [John Bender's grunt-junit plugin](https://github.com/johnbender/grunt-junit) to have the `qunit` task output JUnit-style XML, as this reporter does.

--- a/addons/step/README.md
+++ b/addons/step/README.md
@@ -1,18 +1,20 @@
-QUnit.step() - A QUnit Addon For Testing execution in order
-============================================================
+Step - A QUnit addon for testing execution order
+================================
 
-This addon for QUnit adds a step method that allows you to assert
+This addon for QUnit adds a `QUnit.step` method that allows you to assert
 the proper sequence in which the code should execute.
 
-Example:
+### Example ###
 
-    test("example test", function () {
-      function x() {
-        QUnit.step(2, "function y should be called first");
-      }
-      function y() {
-        QUnit.step(1);
-      }
-      y();
-      x();
-    });
+```js
+test("example test", function () {
+  function x() {
+    QUnit.step(2, "function y should be called first");
+  }
+  function y() {
+    QUnit.step(1);
+  }
+  y();
+  x();
+});
+```

--- a/addons/themes/README.md
+++ b/addons/themes/README.md
@@ -2,5 +2,5 @@ Themes
 ======
 
 These custom themes fully replace the default qunit.css file and should work
-with the default markup. To see them in action, open the html file for each.
-They'll run the QUnit testsuite itself.
+with the default markup. To see them in action, open the HTML file for each.
+They'll run the QUnit test suite itself.


### PR DESCRIPTION
- Standardized the READMEs for the QUnit bundled addons. Nothing fancy, just gave them all equivalent markdown.
- Clarified that all of the new assertions must be used as `QUnit.{assertionType}` rather than just `{assertionType}` (e.g. `QUnit.close` instead of `close`).
