### PR TITLE
delay start() until init() happened. Fixes #358

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -406,7 +406,7 @@ QUnit = {
 			QUnit.begin(function() {
 				// This is triggered at the top of QUnit.load, push start() to the event loop, to allow QUnit.load to finish first
 				setTimeout(function() {
-					start( count );
+					QUnit.start( count );
 				});
 			});
 			return;


### PR DESCRIPTION
Prevent start() from running before init() had a chance to setup the config. This happened regularly in our RequireJS setup.
