### PR TITLE
addon: qunit-composite - Allow naming of test suites... 

### DIFF
--- a/addons/composite/README.md
+++ b/addons/composite/README.md
@@ -20,6 +20,6 @@ then specify the test suites to load using `QUnit.testSuites`:
 QUnit.testSuites([
     "test-file-1.html",
     "test-file-2.html",
-    "test-file-3.html"
+    { name: "Test File 3", path: "test-file-3.html" } // optionally provide a name and path
 ]);
 ```

--- a/addons/composite/composite-demo-test.html
+++ b/addons/composite/composite-demo-test.html
@@ -12,7 +12,7 @@
 			"../../test/index.html",
 			"../canvas/canvas.html",
 			"../close-enough/close-enough.html",
-			"../step/step.html"
+			{ name: "step tests", path: "../step/step.html" }
 		]);
 	</script>
 </head>

--- a/addons/composite/index.html
+++ b/addons/composite/index.html
@@ -22,7 +22,7 @@
 QUnit.testSuites([
 "test-file-1.html",
 "test-file-2.html",
-"test-file-3.html"
+{ name: "Test File 3", path: "test-file-3.html" } // optionally provide a name and path
 ]);
 	</pre>
 	<h4>Tests</h4>

--- a/addons/composite/qunit-composite.js
+++ b/addons/composite/qunit-composite.js
@@ -16,8 +16,15 @@ QUnit.extend( QUnit, {
 	},
 
 	runSuite: function( suite ) {
+		var path = suite;
+
+		if ( QUnit.is( 'object', suite ) ) {
+			path = suite.path;
+			suite = suite.name;
+		}
+
 		asyncTest( suite, function() {
-			QUnit.iframe.setAttribute( "src", suite );
+			QUnit.iframe.setAttribute( "src", path );
 		});
 	},
 


### PR DESCRIPTION
Hey there -

First, thanks for qunit-composite - great li'l helper! We made a small tweak to allow for naming of test suites - it's really just to make the GUI a bit more friendly when your test paths are kind of crazy (which ours are). 

in short, you can do:

```
QUnit.testSuites([
    "test-file-1.html",
    "test-file-2.html",
   { name: "Test File 3", path: "test-file-3.html" } // optionally provide a name and path
]);
```

Anyway, hope it helps!
-matt
