### PR TITLE
code around ie issues for location

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -962,7 +962,8 @@ extend( QUnit, {
 			querystring += encodeURIComponent( key ) + "=" +
 				encodeURIComponent( params[ key ] ) + "&";
 		}
-		return window.location.pathname + querystring.slice( 0, -1 );
+		return window.location.protocol + "//" + window.location.host +
+			window.location.pathname + querystring.slice( 0, -1 );
 	},
 
 	extend: extend,


### PR DESCRIPTION
Assigning incomplete url won't work for local files in ie7 and ie8. Means controls won't work when test page is opened locally.
