### PR TITLE
Fix issue with Error.prototype.toString in IE 7

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -34,6 +34,34 @@ var QUnit,
 		}())
 	},
 	/**
+	 * Provides a normalized error string, correcting an issue
+	 * with IE 7 (and prior) where Error.prototype.toString is
+	 * not properly implemented
+	 *
+	 * Based on http://es5.github.com/#x15.11.4.4
+	 *
+	 * @param {String|Error} error
+	 * @return {String} error message
+	 */
+	errorString = function(error) {
+		var errorString = error.toString();
+		if (errorString.substring(0,7) === '[object') {
+			var name = error.name ? error.name.toString() : 'Error',
+				message = error.message ? error.message.toString() : '';
+			if (name && message) {
+				return name + ': ' + message;
+			} else if (name) {
+				return name;
+			} else if (message) {
+				return message;
+			} else {
+				return 'Error';
+			}
+		} else {
+			return errorString;
+		}
+	};
+	/**
 	 * Makes a clone of an object using only Array or Object as base,
 	 * and copies over the own enumerable properties.
 	 *
@@ -601,7 +629,7 @@ assert = {
 				expectedOutput = null;
 			// expected is a regexp
 			} else if ( QUnit.objectType( expected ) === "regexp" ) {
-				ok = expected.test( actual );
+				ok = expected.test( errorString( actual ) );
 			// expected is a constructor
 			} else if ( actual instanceof expected ) {
 				ok = true;

--- a/test/test.js
+++ b/test/test.js
@@ -469,7 +469,7 @@ test("propEqual", 5, function( assert ) {
 	);
 });
 
-test("raises", 8, function() {
+test("raises", 9, function() {
 	function CustomError( message ) {
 		this.message = message;
 	}
@@ -489,6 +489,16 @@ test("raises", 8, function() {
 			throw "my error";
 		},
 		"simple string throw, no 'expected' value given"
+	);
+
+	// This test is for IE 7 and prior which does not properly
+	// implement Error.prototype.toString
+	throws(
+		function() {
+			throw new Error("error message");
+		},
+		/error message/,
+		"use regexp against instance of Error"
 	);
 
 	throws(


### PR DESCRIPTION
IE 7 and prior don't properly implement Error.prototype.toString which makes
regexp checks via `throws` fail unexpectedly. This provides a method that
generates a standardized ES5 error message.
