### PR TITLE
JUnitLogger: Add a `name` property to the test run

### DIFF
--- a/addons/junitlogger/junitlogger.js
+++ b/addons/junitlogger/junitlogger.js
@@ -10,6 +10,7 @@
 
 	QUnit.begin(function() {
 		currentRun = {
+			name: (window && window.location && window.location.href) || (run.modules.length === 1 && run.modules[0].name) || null,
 			modules: [],
 			total: 0,
 			passed: 0,
@@ -227,6 +228,7 @@
 			});
 
 		xmlWriter.start('testsuites', {
+			name: run.name,
 			hostname: 'localhost',
 			tests: run.total,
 			failures: run.failed,


### PR DESCRIPTION
Added a `name` property to the test run.

Its assigned value will be, in priority order:
1. `window.location.href` (i.e. in the standard browser-based use case, or with jsdom)
2. The name of the [first] test module if there was only 1 test module (i.e. in [node-qunit](https://github.com/kof/node-qunit))
3. `null` (i.e. WAT?)

This PR usurps #389.
