### PR TITLE
Fix errors on non-browser env that does not have Element#attachEvent

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -1502,7 +1502,7 @@ function addEvent( elem, type, fn ) {
 	if ( elem.addEventListener ) {
 		elem.addEventListener( type, fn, false );
 	// IE
-	} else {
+	} else if ( elem.attachEvent ) {
 		elem.attachEvent( "on" + type, fn );
 	}
 }


### PR DESCRIPTION
Fixes errors on non-browser environment that does not have Element#attachEvent.
Reverts some part of jquery/qunit@f249711
### Error on Node.js

```
/path/to/qunit.js:1506
        elem.attachEvent( "on" + type, fn );
             ^
TypeError: Object #<Object> has no method 'attachEvent'
```
### Error on Rhino

```
js: uncaught JavaScript runtime exception: TypeError: Cannot find function attachEvent in object [object global].
```
