### PR TITLE
Fix errors on non-browser environments

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -21,6 +21,7 @@ var QUnit,
 	// Keep a local reference to Date (GH-283)
 	Date = window.Date,
 	defined = {
+		document: typeof window.document !== "undefined",
 		setTimeout: typeof window.setTimeout !== "undefined",
 		sessionStorage: (function() {
 			var x = "qunit-test-string";
@@ -1181,7 +1182,9 @@ QUnit.load = function() {
 	}
 };
 
-addEvent( window, "load", QUnit.load );
+if ( defined.document ) {
+	addEvent( window, "load", QUnit.load );
+}
 
 // `onErrorFnPrev` initialized at top of scope
 // Preserve other handlers


### PR DESCRIPTION
Fix errors on non-browser environments since that does not have addEventListener nor attachEvent.

Since QUnit 1.11.0, an error occurs when loading QUnit under non-browser environments. For example, on Node.js, `require('qunitjs')` raises an error.
### Stacktrace on Node.js

```
/Users/takuto/work/git-sandbox/github/qunit-tap/test/compatibility/1.11.0/qunit.js:1506
        elem.attachEvent( "on" + type, fn );
             ^
TypeError: Object #<Object> has no method 'attachEvent'
    at addEvent (/Users/takuto/work/git-sandbox/github/qunit-tap/test/compatibility/1.11.0/qunit.js:1506:8)
    at /Users/takuto/work/git-sandbox/github/qunit-tap/test/compatibility/1.11.0/qunit.js:1184:1
    at Object.<anonymous> (/Users/takuto/work/git-sandbox/github/qunit-tap/test/compatibility/1.11.0/qunit.js:2152:2)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:362:17)
    at require (module.js:378:17)
    at Object.<anonymous> (/Users/takuto/work/git-sandbox/github/qunit-tap/test/node/test_helper.js:18:13)
```

This PR is a refinement of closed PR https://github.com/jquery/qunit/pull/399
