### PR TITLE
added optional timeout to phantomjs runner

### DIFF
--- a/addons/phantomjs/README.md
+++ b/addons/phantomjs/README.md
@@ -3,7 +3,7 @@ A PhantomJS-powered headless test runner, providing basic console output for QUn
 
 ### Usage ###
 ```bash
-  phantomjs runner.js [url-of-your-qunit-testsuite]
+  phantomjs runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds]
 ```
 
 ### Example ###

--- a/addons/phantomjs/runner.js
+++ b/addons/phantomjs/runner.js
@@ -20,13 +20,14 @@
 	var args = require('system').args;
 
 	// arg[0]: scriptName, args[1...]: arguments
-	if (args.length !== 2) {
-		console.error('Usage:\n  phantomjs runner.js [url-of-your-qunit-testsuite]');
+	if (args.length < 2) {
+		console.error('Usage:\n  phantomjs runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds]');
 		phantom.exit(1);
 	}
 
 	var url = args[1],
-		page = require('webpage').create();
+		page = require('webpage').create(),
+		timeout = args[2];
 
 	// Route `console.log()` calls from within the Page context to the main Phantom context (i.e. current `this`)
 	page.onConsoleMessage = function(msg) {
@@ -62,6 +63,13 @@
 			if (qunitMissing) {
 				console.error('The `QUnit` object is not present on this page.');
 				phantom.exit(1);
+			}
+
+			// Set a timeout on the test running, otherwise tests with async problems will hang forever
+			if (timeout) {
+				setTimeout(function(){
+					phantom.exit(1);
+				}, timeout*1000);
 			}
 
 			// Do nothing... the callback mechanism will handle everything!


### PR DESCRIPTION
If an async test has a problem and hangs, the phantomjs qunit runner would hang as well.  I added an optional timeout as the third parameter and updated the usage text in the readme.  I've tested the change with both working and broken async tests.
