### PR TITLE
Phantomjs: include the stack trace for all failed tests

### DIFF
--- a/addons/phantomjs/runner.js
+++ b/addons/phantomjs/runner.js
@@ -88,9 +88,10 @@
 					}
 
 					response += 'expected: ' + details.expected + ', but was: ' + details.actual;
-					if (details.source) {
-						response += "\n" + details.source;
-					}
+				}
+
+				if (details.source) {
+					response += "\n" + details.source;
 				}
 
 				current_test_assertions.push('Failed assertion: ' + response);


### PR DESCRIPTION
I noticed while trying the phantomjs runner that some of my tests were failing without printing a stack trace to the terminal. 
This change includes the stack trace for failed tests that have it available instead of being dependant on the 'expected' parameter.
