### PR TITLE
Update pattern for QUnit assertion addons 

### DIFF
--- a/addons/canvas/README.md
+++ b/addons/canvas/README.md
@@ -1,13 +1,13 @@
 Canvas - A QUnit addon for testing Canvas rendering
 ================================
 
-This addon for QUnit adds a `QUnit.pixelEqual` method that allows you to assert
+This addon for QUnit adds a `pixelEqual` method that allows you to assert
 individual pixel values in a given canvas.
 
 ### Usage ###
 
 ```js
-QUnit.pixelEqual(canvas, x, y, r, g, b, a, message);
+assert.pixelEqual(canvas, x, y, r, g, b, a, message);
 ```
 
 Where:
@@ -15,3 +15,35 @@ Where:
  - `x`, `y`: Coordinates of the pixel to test
  - `r`, `g`, `b`, `a`: The color and opacity value of the pixel that you except
  - `message`: Optional message, same as for other assertions
+
+### Example ###
+
+```js
+module('Example module', {
+	setup: function() {
+		var canvas, context,
+			fixtureEl = document.getElementById('qunit-fixture');
+		fixtureEl.innerHTML = '<canvas width="5" height="5"></canvas>';
+
+		canvas = fixtureEl.firstChild;
+		try {
+			context = canvas.getContext('2d');
+		} catch(e) {
+			// probably no canvas support, just exit
+			return;
+		}
+
+		this.canvas = canvas;
+		this.context = context;
+	}
+});
+
+test('Example unit test', function(assert) {
+	this.context.fillStyle = 'rgba(0, 0, 0, 0)';
+	this.context.fillRect(0, 0, 5, 5);
+
+	assert.pixelEqual(this.canvas, 0, 0, 0, 0, 0, 0);
+});
+```
+
+For more examples, refer to the unit tests.

--- a/addons/canvas/canvas-test.js
+++ b/addons/canvas/canvas-test.js
@@ -1,76 +1,80 @@
-test("Canvas pixels", function () {
-	var canvas = document.getElementById('qunit-canvas'), context;
+module("Canvas Addon");
+
+test("Canvas pixels", function (assert) {
+	var context,
+		canvas = document.getElementById('qunit-canvas');
 	try {
 		context = canvas.getContext('2d');
 	} catch(e) {
-		// propably no canvas support, just exit
+		// probably no canvas support, just exit
 		return;
 	}
+
 	context.fillStyle = 'rgba(0, 0, 0, 0)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 0, 0, 0, 0, 0, 0);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 0, 0, 0, 0, 0, 0);
+	context.clearRect(0, 0, 5, 5);
 	context.fillStyle = 'rgba(255, 0, 0, 0)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 0, 0, 0, 0, 0, 0);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 0, 0, 0, 0, 0, 0);
+	context.clearRect(0, 0, 5, 5);
 	context.fillStyle = 'rgba(0, 255, 0, 0)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 0, 0, 0, 0, 0, 0);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 0, 0, 0, 0, 0, 0);
+	context.clearRect(0, 0, 5, 5);
 	context.fillStyle = 'rgba(0, 0, 255, 0)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 0, 0, 0, 0, 0, 0);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 0, 0, 0, 0, 0, 0);
+	context.clearRect(0, 0, 5, 5);
 
 	context.fillStyle = 'rgba(0, 0, 0, 0.6)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 0, 0, 0, 0, 0, 153);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 0, 0, 0, 0, 0, 153);
+	context.clearRect(0, 0, 5, 5);
 	context.fillStyle = 'rgba(255, 0, 0, 0.6)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 0, 0, 255, 0, 0, 153);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 0, 0, 255, 0, 0, 153);
+	context.clearRect(0, 0, 5, 5);
 	context.fillStyle = 'rgba(0, 255, 0, 0.6)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 0, 0, 0, 255, 0, 153);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 0, 0, 0, 255, 0, 153);
+	context.clearRect(0, 0, 5, 5);
 	context.fillStyle = 'rgba(0, 0, 255, 0.6)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 0, 0, 0, 0, 255, 153);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 0, 0, 0, 0, 255, 153);
+	context.clearRect(0, 0, 5, 5);
 
 	context.fillStyle = 'rgba(0, 0, 0, 0.6)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 2, 2, 0, 0, 0, 153);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 2, 2, 0, 0, 0, 153);
+	context.clearRect(0, 0, 5, 5);
 	context.fillStyle = 'rgba(255, 0, 0, 0.6)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 2, 2, 255, 0, 0, 153);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 2, 2, 255, 0, 0, 153);
+	context.clearRect(0, 0, 5, 5);
 	context.fillStyle = 'rgba(0, 255, 0, 0.6)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 2, 2, 0, 255, 0, 153);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 2, 2, 0, 255, 0, 153);
+	context.clearRect(0, 0, 5, 5);
 	context.fillStyle = 'rgba(0, 0, 255, 0.6)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 2, 2, 0, 0, 255, 153);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 2, 2, 0, 0, 255, 153);
+	context.clearRect(0, 0, 5, 5);
 
 	context.fillStyle = 'rgba(0, 0, 0, 1)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 4, 4, 0, 0, 0, 255);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 4, 4, 0, 0, 0, 255);
+	context.clearRect(0, 0, 5, 5);
 	context.fillStyle = 'rgba(255, 0, 0, 1)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 4, 4, 255, 0, 0, 255);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 4, 4, 255, 0, 0, 255);
+	context.clearRect(0, 0, 5, 5);
 	context.fillStyle = 'rgba(0, 255, 0, 1)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 4, 4, 0, 255, 0, 255);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 4, 4, 0, 255, 0, 255);
+	context.clearRect(0, 0, 5, 5);
 	context.fillStyle = 'rgba(0, 0, 255, 1)';
 	context.fillRect(0, 0, 5, 5);
-	QUnit.pixelEqual(canvas, 4, 4, 0, 0, 255, 255);
-	context.clearRect(0,0,5,5);
+	assert.pixelEqual(canvas, 4, 4, 0, 0, 255, 255);
+	context.clearRect(0, 0, 5, 5);
 });

--- a/addons/canvas/qunit-canvas.js
+++ b/addons/canvas/qunit-canvas.js
@@ -1,4 +1,4 @@
-QUnit.extend( QUnit, {
+QUnit.extend( QUnit.assert, {
 	pixelEqual: function(canvas, x, y, r, g, b, a, message) {
 		var actual = Array.prototype.slice.apply(canvas.getContext('2d').getImageData(x, y, 1, 1).data), expected = [r, g, b, a];
 		QUnit.push(QUnit.equiv(actual, expected), actual, expected, message);

--- a/addons/close-enough/README.md
+++ b/addons/close-enough/README.md
@@ -1,18 +1,27 @@
 Close-Enough - A QUnit addon for testing number approximations
 ================================
 
-This addon for QUnit adds `QUnit.close` and `QUnit.notClose` assertion methods to test that
+This addon for QUnit adds `close` and `notClose` assertion methods to test that
 numbers are close enough (or different enough) from an expected number, with
 a specified accuracy.
 
 ### Usage ###
 
 ```js
-QUnit.close(actual, expected, maxDifference, message);
-QUnit.notClose(actual, expected, minDifference, message);
+assert.close(actual, expected, maxDifference, message);
+assert.notClose(actual, expected, minDifference, message);
 ```
 
 Where:
  - `maxDifference`: the maximum inclusive difference allowed between the `actual` and `expected` numbers
  - `minDifference`: the minimum exclusive difference allowed between the `actual` and `expected` numbers
  - `actual`, `expected`, `message`: The usual
+
+### Example ###
+```js
+test('Example unit test', function(assert) {
+	assert.close(3.141, Math.PI, 0.001);
+	assert.notClose(3.1, Math.PI, 0.001);
+```
+
+For more examples, refer to the unit tests.

--- a/addons/close-enough/close-enough-test.js
+++ b/addons/close-enough/close-enough-test.js
@@ -1,35 +1,37 @@
-test("Close Numbers", function () {
+module("CloseEnough Addon");
+
+test("Close Numbers", function (assert) {
 	var halfPi = Math.PI / 2,
 		sqrt2 = Math.sqrt(2);
 
-	QUnit.close(7, 7, 0);
-	QUnit.close(7, 7.1, 0.1);
-	QUnit.close(7, 7.1, 0.2);
+	assert.close(7, 7, 0);
+	assert.close(7, 7.1, 0.1);
+	assert.close(7, 7.1, 0.2);
 
-	QUnit.close(3.141, Math.PI, 0.001);
-	QUnit.close(3.1, Math.PI, 0.1);
+	assert.close(3.141, Math.PI, 0.001);
+	assert.close(3.1, Math.PI, 0.1);
 
-	QUnit.close(halfPi, 1.57, 0.001);
+	assert.close(halfPi, 1.57, 0.001);
 
-	QUnit.close(sqrt2, 1.4142, 0.0001);
+	assert.close(sqrt2, 1.4142, 0.0001);
 
-	QUnit.close(Infinity, Infinity, 1);
+	assert.close(Infinity, Infinity, 1);
 });
 
-test("Distant Numbers", function () {
+test("Distant Numbers", function (assert) {
 	var halfPi = Math.PI / 2,
 		sqrt2 = Math.sqrt(2);
 
-	QUnit.notClose(6, 7, 0);
-	QUnit.notClose(7, 7.2, 0.1);
-	QUnit.notClose(7, 7.2, 0.19999999999);
+	assert.notClose(6, 7, 0);
+	assert.notClose(7, 7.2, 0.1);
+	assert.notClose(7, 7.2, 0.19999999999);
 
-	QUnit.notClose(3.141, Math.PI, 0.0001);
-	QUnit.notClose(3.1, Math.PI, 0.001);
+	assert.notClose(3.141, Math.PI, 0.0001);
+	assert.notClose(3.1, Math.PI, 0.001);
 
-	QUnit.notClose(halfPi, 1.57, 0.0001);
+	assert.notClose(halfPi, 1.57, 0.0001);
 
-	QUnit.notClose(sqrt2, 1.4142, 0.00001);
+	assert.notClose(sqrt2, 1.4142, 0.00001);
 
-	QUnit.notClose(Infinity, -Infinity, 5);
+	assert.notClose(Infinity, -Infinity, 5);
 });

--- a/addons/close-enough/qunit-close-enough.js
+++ b/addons/close-enough/qunit-close-enough.js
@@ -1,9 +1,9 @@
-QUnit.extend( QUnit, {
+QUnit.extend( QUnit.assert, {
 	/**
 	 * Checks that the first two arguments are equal, or are numbers close enough to be considered equal
 	 * based on a specified maximum allowable difference.
 	 *
-	 * @example close(3.141, Math.PI, 0.001);
+	 * @example assert.close(3.141, Math.PI, 0.001);
 	 *
 	 * @param Number actual
 	 * @param Number expected
@@ -19,7 +19,7 @@ QUnit.extend( QUnit, {
 	 * Checks that the first two arguments are numbers with differences greater than the specified
 	 * minimum difference.
 	 *
-	 * @example notClose(3.1, Math.PI, 0.001);
+	 * @example assert.notClose(3.1, Math.PI, 0.001);
 	 *
 	 * @param Number actual
 	 * @param Number expected

--- a/addons/step/README.md
+++ b/addons/step/README.md
@@ -1,20 +1,32 @@
 Step - A QUnit addon for testing execution order
 ================================
 
-This addon for QUnit adds a `QUnit.step` method that allows you to assert
+This addon for QUnit adds a `step` method that allows you to assert
 the proper sequence in which the code should execute.
+
+### Usage ###
+
+```js
+assert.step(expected, message);
+```
+
+Where:
+ - `expected`: The expected step number (assertion sequence index)
+ - `message`: Optional message, same as for other assertions
 
 ### Example ###
 
 ```js
-test("example test", function () {
+test("example test", function (assert) {
   function x() {
-    QUnit.step(2, "function y should be called first");
+    assert.step(2, "function y should be called first");
   }
   function y() {
-    QUnit.step(1);
+    assert.step(1);
   }
   y();
   x();
 });
 ```
+
+For more examples, refer to the unit tests.

--- a/addons/step/qunit-step.js
+++ b/addons/step/qunit-step.js
@@ -1,19 +1,19 @@
-QUnit.extend( QUnit, {
+QUnit.extend( QUnit.assert, {
 
 	/**
 	 * Check the sequence/order
 	 *
-	 * @example step(1); setTimeout(function () { step(3); }, 100); step(2);
+	 * @example test('Example unit test', function(assert) { assert.step(1); setTimeout(function () { assert.step(3); start(); }, 100); assert.step(2); stop(); });
 	 * @param Number expected The excepted step within the test()
 	 * @param String message (optional)
 	 */
 	step: function (expected, message) {
 		// increment internal step counter.
-		this.config.current.step++;
+		QUnit.config.current.step++;
 		if (typeof message === "undefined") {
 			message = "step " + expected;
 		}
-		var actual = this.config.current.step;
+		var actual = QUnit.config.current.step;
 		QUnit.push(QUnit.equiv(actual, expected), actual, expected, message);
 	}
 });
@@ -22,5 +22,5 @@ QUnit.extend( QUnit, {
  * Reset the step counter for every test()
  */
 QUnit.testStart(function () {
-	this.config.current.step = 0;
+	QUnit.config.current.step = 0;
 });

--- a/addons/step/step-test.js
+++ b/addons/step/step-test.js
@@ -1,15 +1,15 @@
-module('Step Addon');
+module("Step Addon");
 
-test("step", 3, function () {
-	QUnit.step(1, "step starts at 1");
+test("step", 3, function (assert) {
+	assert.step(1, "step starts at 1");
 	setTimeout(function () {
 		start();
-		QUnit.step(3);
+		assert.step(3);
 	}, 100);
-	QUnit.step(2, "before the setTimeout callback is run");
+	assert.step(2, "before the setTimeout callback is run");
 	stop();
 });
 
-test("step counter", 1, function () {
-	QUnit.step(1, "each test has its own step counter");
+test("step counter resets", 1, function (assert) {
+	assert.step(1, "each test has its own step counter");
 });


### PR DESCRIPTION
Changed all of the QUnit assertion addons to extend the `QUnit.assert` object instead of the core `QUnit` object itself. See @Krinkle's notes in JamesMGreene/qunit-assert-html#3 for more details.

Minor other tweaks mixed in... let me know if you want them removed.
