### PR TITLE
Fix typos

### DIFF
--- a/History.md
+++ b/History.md
@@ -52,11 +52,11 @@
   * added jsdoc for QUnit.assert functions
   * Styling: radius to 5px and small pass/error border, remove inner shadow
   * Move checkboxes into toolbar and give them labels and descriptions (as tooltip). Fixes #274 - Improve urlFilter API and UI
-  * Where we recieve no exception in throws() use a relevant message.
+  * Where we receive no exception in throws() use a relevant message.
   * Also make module filter case-insensitive. Follow-up to #252
   * Banner: Link should ignore "testNumber" and "module". Fixes #270
   * Rename assert.raises to assert.throws. Fixes #267
-  * Change package.json name property to 'qunitjs' to avoid conflicht with node-qunit; will publish next release to npm
+  * Change package.json name property to 'qunitjs' to avoid conflict with node-qunit; will publish next release to npm
 
 1.8.0 / 2012-06-14
 ==================
@@ -87,7 +87,7 @@
 
   * Save stack for each test, use that for failed expect() results, points at the line where test() was called. Fixes #209
   * Prefix test-output id and ignore that in noglobals check. Fixes #212
-  * Only check for an exports object to detect a CommonJS enviroment. Fixes #237 - Incompatibility with require.js
+  * Only check for an exports object to detect a CommonJS environment. Fixes #237 - Incompatibility with require.js
   * Add testswarm integration as grunt task
   * Added padding on URL config checkboxes.
   * Cleanup composite addon: Use callback registration instead of overwriting them. Set the correct src on rerun link (and dblclick). Remove the composite test itself, as that was a crazy hack not worth maintaining
@@ -108,7 +108,7 @@
 ==================
 
   * Prefix test-related session-storage items to make removal more specific. Fixes #213 - Keep hide-passed state when clearing session storage
-  * Update grunt.js with seperate configs for qunit.js and grunt.js, also add tests but disable for now, not passing yet. Add grunt to devDependencies
+  * Update grunt.js with separate configs for qunit.js and grunt.js, also add tests but disable for now, not passing yet. Add grunt to devDependencies
   * typo
   * Cleanup grunt.js, no need for the banner
   * Fix lint errors and some formatting issues. Use QUnit.pushFailure for noglobals and global error handler.
@@ -139,11 +139,11 @@
   * Set fixed dimensions for #qunit-fixture. Fixes #114
   * Extend nodejs test runner to check for stacktrace output, twice
   * Extend nodejs test runner to check for stacktrace output
-  * Generate more base markup, but allow the user to exclude that completelty or choose their own. Fixes #127
+  * Generate more base markup, but allow the user to exclude that completely or choose their own. Fixes #127
   * Add a simple test file to check basic nodejs integration works
   * Check for global object to find setTimeout in node
   * Fix CommonJS export by assigning QUnit to module.exports.
-  * Remove the testEnviromentArg to test(). Most obscure, never used anywhere. test() is still heavily overloaded with argument shifting, this makes it a little more sane. Fixes #172
+  * Remove the testEnvironmentArg to test(). Most obscure, never used anywhere. test() is still heavily overloaded with argument shifting, this makes it a little more sane. Fixes #172
   * Serialize expected and actual values only when test fails. Speeds up output of valid tests, especially for lots of large objects. Fixes #183
   * Fix sourceFromsTacktrace to get the right line in Firefox. Shift the 'error' line away in Chrome to get a match.
   * Fix references to test/deepEqual.js
@@ -155,7 +155,7 @@
   * Some cleanup in theme addons
   * Update headers
   * Update nv.html, add gabe theme based on https://github.com/jquery/qunit/pull/188
-  * Experiemental custom theme based on https://github.com/jquery/qunit/pull/62 by NV
+  * Experimental custom theme based on https://github.com/jquery/qunit/pull/62 by NV
   * Replace deprecated same and equals aliases with placeholders that just throw errors, providing a hint at what to use instead. Rename test file to match that.
   * Can't rely on outerHTML for Firefox < 11. Use cloneNode instead.
   * Merge remote branch 'conzett/master'
@@ -212,9 +212,9 @@
   * Add-on: New assertion-type: step()
   * added parameter to start and stop allowing a user to increment/decrement the semaphore more than once per call
   * Update readmes with .md extension for GitHub to render them as markdown
-  * Update close-enough addon to include readme and match (new) naming convetions
+  * Update close-enough addon to include readme and match (new) naming conventions
   * Merge remote branch 'righi/close-enough-addon'
-  * Canvas addon: Update file referneces
+  * Canvas addon: Update file references
   * Update canvas addon: Rename files and add README
   * Merge remote branch 'wwalser/composite'
   * Fix #142 - Backslash characters in messages should not be escaped
@@ -266,8 +266,8 @@
   * Prepend module name to sessionStorage keys to avoid conflicts
   * Store filter-tests only when checked
   * Write to sessionStorage only bad tests
-  * Moved QUnit.url() defintion after QUnit properties are merged into the global scope. Fixes #93 - QUnit url/extend function breaking urls in jQuery ajax test component
-  * Add a "Rerun" link to each test to replce the dblclick (still supported, for now).
+  * Moved QUnit.url() definition after QUnit properties are merged into the global scope. Fixes #93 - QUnit url/extend function breaking urls in jQuery ajax test component
+  * Add a "Rerun" link to each test to replace the dblclick (still supported, for now).
   * Fixed the regex for parsing the name of a test when double clicking to filter.
   * Merge remote branch 'scottgonzalez/url'
   * Added checkboxes to show which flags are currently on and allow toggling them.
@@ -280,9 +280,9 @@
   * Position test results above test list, making it visible without ever having to scroll. Create a placeholder to avoid pushing down results later.
   * Don't check for existing qunit-testresult element, it gets killed on init anyway.
   * Added URL flag ?notrycatch (ala ?noglobals) for debugging exceptions. Won't try/catch test code, giving better debugging changes on the original exceptions. Fixes #72
-  * Always show quni-toolbar (if at all specified), persist checkbox via sessionStorage. Fixes #47
+  * Always show qunit-toolbar (if at all specified), persist checkbox via sessionStorage. Fixes #47
   * Use non-html testname for calls to fail(). Fixes #77
-  * Overhaul of QUnit.callbacks. Consistent single argument with related properties, with additonal runtime property for QUnit.done
+  * Overhaul of QUnit.callbacks. Consistent single argument with related properties, with additional runtime property for QUnit.done
   * Extended test/logs.html to capture more of the callbacks.
   * Fixed moduleStart/Done callbacks. Added test/logs.html to test these callbacks. To be extended.
   * Update copyright and license header. Fixes #61
@@ -292,11 +292,11 @@
   * Added two tests for previous QUnit.raises behaviour. For #69
   * add optional 2. arg to QUnit.raises #69.
   * fix references inside Complex Instances Nesting to what was originally intended.
-  * Qualify calls to ok() in raises() for compability with CLI enviroments.
+  * Qualify calls to ok() in raises() for compatibility with CLI environments.
   * Fix done() handling, check for blocking, not block property
   * Fix moduleStart/Done and done callbacks.
   * Replacing sessionStorage test with the one from Modernizr/master (instead of current release). Here's hoping it'll work for some time.
-  * Updated test for availibility of sessionStorage, based on test from Modernizr. Fixes #64
+  * Updated test for availability of sessionStorage, based on test from Modernizr. Fixes #64
   * Defer test execution when previous run passed, persisted via sessionStorage. Fixes #49
   * Refactored module handling and queuing to enable selective defer of test runs.
   * Move assertions property from config to Test
@@ -343,7 +343,7 @@
   * Ammending previous commit: Remove jQuery-core specific resets (will be replaced within jQuery testsuite). Fixes issue #19 - QUnit.reset() removes global jQuery ajax event handlers
   * Remove jQuery-core specific resets (will be replaced within jQuery testsuite). Fixes issue #19 - QUnit.reset() removes global jQuery ajax event handlers
   * Cleaning up rubble from the previous commit.
-  * Added raises assertion, reusing some of kennsnyder's code.
+  * Added raises assertion, reusing some of kensnyder's code.
   * Merged kensnyder's object detection code. Original message: Streamlined object detection and exposed QUnit.objectType as a function.
   * Fixed some bad formatting.
   * Move various QUnit properties below the globals-export to avoid init becoming a global method. Fixes issue #11 - Remove 'init' function from a global namespace
@@ -453,7 +453,7 @@
   * Reverted the noglobals changed from QUnit - causing chaos in the jQuery test suite.
   * qunit: removed noglobals flag, instead always check for globals after teardown; if a test has to introduce a global "myVar", use delete window.myVar in teardown or at the end of a test
   * qunit: don't child selectors when IE should behave nicely, too
-  * qunit: improvment for the test-scope: create a new object and call setup, the test, and teardown in the scope of that object - allows you to provide test fixtures to each test without messing with global data; kudos to Martin Häcker for the contribution
+  * qunit: improvement for the test-scope: create a new object and call setup, the test, and teardown in the scope of that object - allows you to provide test fixtures to each test without messing with global data; kudos to Martin Häcker for the contribution
   * qunit: added missing semicolons
   * qunit: fixed a semicolon, that should have been a comma
   * QUnit: implemented error handling for Opera as proposed by #3628
@@ -477,9 +477,9 @@
   * QUnit: optional timeout argument for stop, while making tests undetermined, useful for debugging
   * QUnit: added toolbar with "hide passed tests" checkbox to help focus on failed tests
   * QUnit: minor output formatting
-  * QUnit: adding same-assertion for a recursive comparsion of primite values, arrays  and objects, thanks to Philippe Rathé for the contribution, including tests
-  * QUnit: adding same-assertion for a recursive comparsion of primite values, arrays  and objects, thanks to Philippe Rathé for the contribution, including tests
-  * QUnit: adding same-assertion for a recursive comparsion of primite values, arrays  and objects, thanks to Philippe Rathé for the contribution, including tests
+  * QUnit: adding same-assertion for a recursive comparison of primitive values, arrays  and objects, thanks to Philippe Rathé for the contribution, including tests
+  * QUnit: adding same-assertion for a recursive comparison of primitive values, arrays  and objects, thanks to Philippe Rathé for the contribution, including tests
+  * QUnit: adding same-assertion for a recursive comparison of primitive values, arrays  and objects, thanks to Philippe Rathé for the contribution, including tests
   * qunit: use window.load to initialize tests, allowing other code to run on document-ready before starting to run tests
   * qunit: allow either setup or teardown, instead of both or nothing
   * qunit: make everything private by default, expose only public API; removed old timeout-option (non-deterministic, disabled for a long time anyway); use local $ reference instead of global jQuery reference; minor code cleanup (var config instead of _config; queue.shift instead of slice)

--- a/addons/themes/gabe.css
+++ b/addons/themes/gabe.css
@@ -8,7 +8,7 @@
  * http://jquery.org/license
  */
 
-/** General Styles and Page Sturcture */
+/** General Styles and Page Structure */
 body {
 	font-family:Arial, 'sans serif';
     padding:20px 20px 0 20px;

--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -419,7 +419,7 @@ QUnit = {
 		test.queue();
 	},
 
-	// Specify the number of expected assertions to gurantee that failed test (no assertions are run at all) don't slip through.
+	// Specify the number of expected assertions to guarantee that failed test (no assertions are run at all) don't slip through.
 	expect: function( asserts ) {
 		if (arguments.length === 1) {
 			config.current.expected = asserts;
@@ -487,7 +487,7 @@ QUnit = {
 };
 
 // `assert` initialized at top of scope
-// Asssert helpers
+// Assert helpers
 // All of these must either call QUnit.push() or manually do:
 // - runLoggingCallbacks( "log", .. );
 // - config.current.assertions.push({ .. });
@@ -1144,7 +1144,7 @@ QUnit.load = function() {
 		// `label` initialized at top of scope
 		label = document.createElement( "label" );
 		label.setAttribute( "for", "qunit-filter-pass" );
-		label.setAttribute( "title", "Only show tests and assertons that fail. Stored in sessionStorage." );
+		label.setAttribute( "title", "Only show tests and assertions that fail. Stored in sessionStorage." );
 		label.innerHTML = "Hide passed tests";
 		toolbar.appendChild( label );
 
@@ -1195,7 +1195,7 @@ addEvent( window, "load", QUnit.load );
 onErrorFnPrev = window.onerror;
 
 // Cover uncaught exceptions
-// Returning true will surpress the default browser handler,
+// Returning true will suppress the default browser handler,
 // returning false will let it run.
 window.onerror = function ( error, filePath, linerNr ) {
 	var ret = false;
@@ -1204,7 +1204,7 @@ window.onerror = function ( error, filePath, linerNr ) {
 	}
 
 	// Treat return value as window.onerror itself does,
-	// Only do our handling if not surpressed.
+	// Only do our handling if not suppressed.
 	if ( ret !== true ) {
 		if ( QUnit.config.current ) {
 			if ( QUnit.config.current.ignoreGlobalErrors ) {
@@ -1542,7 +1542,7 @@ function removeClass( elem, name ) {
 	while ( set.indexOf(" " + name + " ") > -1 ) {
 		set = set.replace(" " + name + " " , " ");
 	}
-	// If possible, trim it for prettiness, but not neccecarily
+	// If possible, trim it for prettiness, but not necessarily
 	elem.className = window.jQuery ? jQuery.trim( set ) : ( set.trim ? set.trim() : set );
 }
 
@@ -1603,7 +1603,7 @@ QUnit.equiv = (function() {
 			function useStrictEquality( b, a ) {
 				/*jshint eqeqeq:false */
 				if ( b instanceof a.constructor || a instanceof b.constructor ) {
-					// to catch short annotaion VS 'new' annotation of a
+					// to catch short annotation VS 'new' annotation of a
 					// declaration
 					// e.g. var i = 1;
 					// var j = new Number(1);
@@ -1632,7 +1632,7 @@ QUnit.equiv = (function() {
 					return QUnit.objectType( b ) === "regexp" &&
 						// the regex itself
 						a.source === b.source &&
-						// and its modifers
+						// and its modifiers
 						a.global === b.global &&
 						// (gmi) ...
 						a.ignoreCase === b.ignoreCase &&
@@ -2170,7 +2170,7 @@ QUnit.diff = (function() {
 	};
 }());
 
-// for CommonJS enviroments, export everything
+// for CommonJS environments, export everything
 if ( typeof exports !== "undefined" ) {
 	extend( exports, QUnit );
 }

--- a/test/deepEqual.js
+++ b/test/deepEqual.js
@@ -1301,7 +1301,7 @@ test("Complex Instances Nesting (with function value in literals and/or in neste
 			b: fnOutside, // ok make reference to a function in all instances scope
 
 			// This function won't be ingored.
-			// It isn't visible for all C insances
+			// It isn't visible for all C instances
 			// and it is not in a property of an instance. (in an Object instances e.g. the object literal)
 			c: fnInside
 		};
@@ -1377,15 +1377,15 @@ test('object with references to self wont loop', function() {
 	};
 	circularA.abc = circularA;
 	circularB.abc = circularB;
-	equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object (ambigous test)");
+	equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object (ambiguous test)");
 
 	circularA.def = 1;
 	circularB.def = 1;
-	equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object (ambigous test)");
+	equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object (ambiguous test)");
 
 	circularA.def = 1;
 	circularB.def = 0;
-	equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on object (unambigous test)");
+	equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on object (unambiguous test)");
 });
 
 test('array with references to self wont loop', function() {
@@ -1393,15 +1393,15 @@ test('array with references to self wont loop', function() {
 		circularB = [];
 	circularA.push(circularA);
 	circularB.push(circularB);
-	equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on array (ambigous test)");
+	equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on array (ambiguous test)");
 
 	circularA.push( 'abc' );
 	circularB.push( 'abc' );
-	equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on array (ambigous test)");
+	equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on array (ambiguous test)");
 
 	circularA.push( 'hello' );
 	circularB.push( 'goodbye' );
-	equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on array (unambigous test)");
+	equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on array (unambiguous test)");
 });
 
 test('mixed object/array with references to self wont loop', function() {
@@ -1412,15 +1412,15 @@ test('mixed object/array with references to self wont loop', function() {
 
 	circularA.push(circularA);
 	circularB.push(circularB);
-	equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object/array (ambigous test)");
+	equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object/array (ambiguous test)");
 
 	circularA[0].def = 1;
 	circularB[0].def = 1;
-	equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object/array (ambigous test)");
+	equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object/array (ambiguous test)");
 
 	circularA[0].def = 1;
 	circularB[0].def = 0;
-	equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on object/array (unambigous test)");
+	equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on object/array (unambiguous test)");
 });
 
 test('compare self-referent to tree', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -106,13 +106,13 @@ module("<script id='qunit-unescaped-module'>'module';</script>", {
 		// is created before any test is ran. So use ids instead.
 		if (document.getElementById('qunit-unescaped-module')) {
 			// This can either be from in #qunit-modulefilter or #qunit-testresult
-			ok(false, 'Unscaped module name');
+			ok(false, 'Unescaped module name');
 		}
 		if (document.getElementById('qunit-unescaped-test')) {
-			ok(false, 'Unscaped test name');
+			ok(false, 'Unescaped test name');
 		}
 		if (document.getElementById('qunit-unescaped-assertion')) {
-			ok(false, 'Unscaped test name');
+			ok(false, 'Unescaped test name');
 		}
 	}
 });
@@ -174,7 +174,7 @@ module("Date test", {
 	setup: function() {
 		orgDate = Date;
 		window.Date = function () {
-			ok( false, 'QUnit should internally be independant from Date-related manipulation and testing' );
+			ok( false, 'QUnit should internally be independent from Date-related manipulation and testing' );
 			return new orgDate();
 		};
 	},


### PR DESCRIPTION
Fixed some typos in comments and test strings.

There are two more possible misspellings in History.md (L346 and L347):

> Added raises assertion, reusing some of kennsnyder's code.
> Merged kensnyder's object detection code. Original message: Streamlined object detection and exposed QUnit.objectType as a function.

kennsnyder and kensnyder -- not sure whats the correct version, may be both of them :)
