### PR TITLE
Minor commit to fix a dead link

### DIFF
--- a/addons/phantomjs/README.md
+++ b/addons/phantomjs/README.md
@@ -13,4 +13,4 @@ A PhantomJS-powered headless test runner, providing basic console output for QUn
 
 ### Notes ###
  - Requires [PhantomJS](http://phantomjs.org/) 1.6+ (1.7+ recommended).
- - If you're using Grunt, you should take a look at its [qunit task](https://github.com/gruntjs/grunt/blob/master/docs/task_qunit.md).
+ - If you're using Grunt, you should take a look at its [qunit task](https://github.com/gruntjs/grunt-contrib-qunit).


### PR DESCRIPTION
Replaced the addon URL for qunit runner task to point to the updated contrib repo.
