### PR TITLE
Add bower.json. Fixes #461

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "qunit",
+  "version": "1.13.0pre",
+  "main": "qunit/qunit.js",
+  "ignore": [
+    "**/.*",
+    "package.json",
+    "bower.json",
+    "Gruntfile.js",
+    "node_modules",
+    "test"
+  ]
+}


### PR DESCRIPTION
I looked at Sizzle's bower.json for the ignores, but figured that including readmes etc. is actually useful. I often look at readme files in node_modules. "version" and "main" match the ones in package.json,

cc @timmywil
