### PR TITLE
Include qunit.css in main directive

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "qunit",
   "version": "1.13.0pre",
-  "main": "qunit/qunit.js",
+  "main": ["qunit/qunit.js", "qunit/qunit.css"],
   "ignore": [
     "**/.*",
     "package.json",


### PR DESCRIPTION
Since qunit includes css as well as js, it should be listed as well in the main directive.

I had the previous qunit component mirror configured this way.

https://github.com/components/qunit/blob/master/bower.json#L4-L7
