### PR TITLE
Keep calling QUnit.start until config.semaphore is 0

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -211,7 +211,9 @@ Test.prototype = {
 
 			// Restart the tests if they're blocking
 			if ( config.blocking ) {
-				QUnit.start();
+				while ( config.semaphore !== 0 ) {
+					QUnit.start();
+				}
 			}
 		}
 	},


### PR DESCRIPTION
I am using an iframe to load my page and my testcases run on the top frame. I do QUnit.stop() twice( as suggested here http://naheece.wordpress.com/2012/12/15/qunit-acceptance-test-framework-with-iframe-require-js-and-jquery-simulate/) in the beginning of the page load and when the page loads successfully (i.e. in onload event handler) I do QUnit.start().
Now, if say onload event doesn't trigger or say it doesn't even get attached(due to some Javascript error) then the QUnit.config.semaphore value is 2 and thus the test cases stuck in running state. Now, the config.blocking check just do QUnit.start once and thus final value of config.semaphore for my case still equals to 1.
