### PR TITLE
Tweak addEvent so it silently ignores non-eventing contexts

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1039,9 +1039,7 @@ function addEvent( elem, type, fn ) {
 	} else if ( elem.attachEvent ) {
 		elem.attachEvent( "on" + type, fn );
 	// Something without events, like Rhino
-	} else {
-		// Do nothing
-	}
+	} // else  Do nothing
 }
 
 /**


### PR DESCRIPTION
I was trying to use a recent QUnit within Rhino (for https://github.com/finnjohnsen/jstest), but couldn't, since the simple context set up in Rhino does not have events, and a very simple 'root' context object.

This tiny change made 1.12.0 usable for my purpose, but it could be that I'm just doing it wrong.
