### PR TITLE
Fixes #491: use previous module name for moduleDone callback when tests are complete

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -747,9 +747,9 @@ function done() {
 	config.autorun = true;
 
 	// Log the last module results
-	if ( config.currentModule ) {
+	if ( config.previousModule ) {
 		runLoggingCallbacks( "moduleDone", QUnit, {
-			name: config.currentModule,
+			name: config.previousModule,
 			failed: config.moduleStats.bad,
 			passed: config.moduleStats.all - config.moduleStats.bad,
 			total: config.moduleStats.all


### PR DESCRIPTION
When running tests in a single module, the moduleDone callback would not have the correct name if it was not the last module, since config.currentModule contains the name of the next module. If config.previousModule is passed instead, it works correctly when running all tests in all modules, or running tests in a single module.
