### PR TITLE
Assert.throws: handle string typed thrown errors

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -142,6 +142,12 @@ assert = QUnit.assert = {
 				ok = true;
 				expectedOutput = null;
 
+			// expected is an Error object
+			} else if ( expected instanceof Error ) {
+				ok = actual instanceof Error &&
+					 actual.name === expected.name &&
+					 actual.message === expected.message;
+
 			// expected is a regexp
 			} else if ( QUnit.objectType( expected ) === "regexp" ) {
 				ok = expected.test( errorString( actual ) );

--- a/test/test.js
+++ b/test/test.js
@@ -497,7 +497,7 @@ test("propEqual", function( assert ) {
 });
 
 test("throws", function( assert ) {
-	expect(9);
+	expect(10);
 	function CustomError( message ) {
 		this.message = message;
 	}
@@ -583,6 +583,14 @@ test("throws", function( assert ) {
 		},
 		"some error description",
 		"handle string typed thrown errors"
+	);
+
+	assert.throws(
+		function() {
+			throw new Error( "foo" );
+		},
+		new Error( "foo" ),
+		"assert when a function throws an 'Error' object"
 	);
 });
 


### PR DESCRIPTION
Before this patch, assert.throws accepted only a regexp to check for string typed thrown errors, otherwise it would replace the expected to null and consider its value as the assertion message.
