### PR TITLE
Update qunit.css

### DIFF
--- a/src/qunit.css
+++ b/src/qunit.css
@@ -39,14 +39,8 @@
 	line-height: 1em;
 	font-weight: 400;
 
-	-webkit-border-radius: 5px 5px 0 0;
-	-moz-border-radius: 5px 5px 0 0;
 	border-radius: 5px 5px 0 0;
-	-webkit-border-top-right-radius: 5px;
-	-moz-border-radius-topright: 5px;
 	border-top-right-radius: 5px;
-	-webkit-border-top-left-radius: 5px;
-	-moz-border-radius-topleft: 5px;
 	border-top-left-radius: 5px;
 }
 
@@ -128,8 +122,6 @@
 
 	background-color: #FFF;
 
-	-webkit-border-radius: 5px;
-	-moz-border-radius: 5px;
 	border-radius: 5px;
 }
 
@@ -209,14 +201,8 @@
 }
 
 #qunit-tests > li:last-child {
-	-webkit-border-radius: 0 0 5px 5px;
-	-moz-border-radius: 0 0 5px 5px;
 	border-radius: 0 0 5px 5px;
-	-webkit-border-bottom-right-radius: 5px;
-	-moz-border-radius-bottomright: 5px;
 	border-bottom-right-radius: 5px;
-	-webkit-border-bottom-left-radius: 5px;
-	-moz-border-radius-bottomleft: 5px;
 	border-bottom-left-radius: 5px;
 }
 


### PR DESCRIPTION
From a quick look I had I couldn't find any coding style guide for the CSS but maybe I missed it.

I tried to be consistent with the current style, but if people prefer `normal` or color names let me know and I will rebase the PR.

For the vendor prefixed properties we could add https://github.com/nDmitry/grunt-autoprefixer.

BTW, how about generating the minified versions for the files too in dist?
