### PR TITLE
Tests: cache window.clearTimeout so that it’s not mocked

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -9,6 +9,7 @@ var QUnit,
 	// Keep a local reference to Date (GH-283)
 	Date = window.Date,
 	setTimeout = window.setTimeout,
+	clearTimeout = window.clearTimeout,
 	defined = {
 		document: typeof window.document !== "undefined",
 		setTimeout: typeof window.setTimeout !== "undefined",


### PR DESCRIPTION
window.setTimeout is already cached; doing the same for clearTimeout
may reduce race conditions causing TestSwarm to sometimes stop executing
tests in the middle.
