### PR TITLE
CSS: Updating qunit.css for consistency

### DIFF
--- a/src/qunit.css
+++ b/src/qunit.css
@@ -32,32 +32,31 @@
 #qunit-header {
 	padding: 0.5em 0 0.5em 1em;
 
-	color: #8699a4;
-	background-color: #0d3349;
+	color: #8699A4;
+	background-color: #0D3349;
 
 	font-size: 1.5em;
 	line-height: 1em;
-	font-weight: normal;
+	font-weight: 400;
 
 	border-radius: 5px 5px 0 0;
-	-moz-border-radius: 5px 5px 0 0;
-	-webkit-border-top-right-radius: 5px;
-	-webkit-border-top-left-radius: 5px;
+	border-top-right-radius: 5px;
+	border-top-left-radius: 5px;
 }
 
 #qunit-header a {
 	text-decoration: none;
-	color: #c2ccd1;
+	color: #C2CCD1;
 }
 
 #qunit-header a:hover,
 #qunit-header a:focus {
-	color: #fff;
+	color: #FFF;
 }
 
 #qunit-testrunner-toolbar label {
 	display: inline-block;
-	padding: 0 .5em 0 .1em;
+	padding: 0 0.5em 0 0.1em;
 }
 
 #qunit-banner {
@@ -67,14 +66,14 @@
 #qunit-testrunner-toolbar {
 	padding: 0.5em 0 0.5em 2em;
 	color: #5E740B;
-	background-color: #eee;
+	background-color: #EEE;
 	overflow: hidden;
 }
 
 #qunit-userAgent {
 	padding: 0.5em 0 0.5em 2.5em;
-	background-color: #2b81af;
-	color: #fff;
+	background-color: #2B81AF;
+	color: #FFF;
 	text-shadow: rgba(0, 0, 0, 0.5) 2px 2px 1px;
 }
 
@@ -90,7 +89,7 @@
 
 #qunit-tests li {
 	padding: 0.4em 0.5em 0.4em 2.5em;
-	border-bottom: 1px solid #fff;
+	border-bottom: 1px solid #FFF;
 	list-style-position: inside;
 }
 
@@ -104,7 +103,7 @@
 
 #qunit-tests li a {
 	padding: 0.5em;
-	color: #c2ccd1;
+	color: #C2CCD1;
 	text-decoration: none;
 }
 #qunit-tests li a:hover,
@@ -121,11 +120,9 @@
 	margin-top: 0.5em;
 	padding: 0.5em;
 
-	background-color: #fff;
+	background-color: #FFF;
 
 	border-radius: 5px;
-	-moz-border-radius: 5px;
-	-webkit-border-radius: 5px;
 }
 
 .qunit-collapsed {
@@ -134,13 +131,13 @@
 
 #qunit-tests table {
 	border-collapse: collapse;
-	margin-top: .2em;
+	margin-top: 0.2em;
 }
 
 #qunit-tests th {
 	text-align: right;
 	vertical-align: top;
-	padding: 0 .5em 0 0;
+	padding: 0 0.5em 0 0;
 }
 
 #qunit-tests td {
@@ -154,26 +151,26 @@
 }
 
 #qunit-tests del {
-	background-color: #e0f2be;
-	color: #374e0c;
+	background-color: #E0F2BE;
+	color: #374E0C;
 	text-decoration: none;
 }
 
 #qunit-tests ins {
-	background-color: #ffcaca;
+	background-color: #FFCACA;
 	color: #500;
 	text-decoration: none;
 }
 
 /*** Test Counts */
 
-#qunit-tests b.counts                       { color: black; }
+#qunit-tests b.counts                       { color: #000; }
 #qunit-tests b.passed                       { color: #5E740B; }
 #qunit-tests b.failed                       { color: #710909; }
 
 #qunit-tests li li {
 	padding: 5px;
-	background-color: #fff;
+	background-color: #FFF;
 	border-bottom: none;
 	list-style-position: inside;
 }
@@ -181,8 +178,8 @@
 /*** Passing Styles */
 
 #qunit-tests li li.pass {
-	color: #3c510c;
-	background-color: #fff;
+	color: #3C510C;
+	background-color: #FFF;
 	border-left: 10px solid #C6E746;
 }
 
@@ -190,7 +187,7 @@
 #qunit-tests .pass .test-name               { color: #366097; }
 
 #qunit-tests .pass .test-actual,
-#qunit-tests .pass .test-expected           { color: #999999; }
+#qunit-tests .pass .test-expected           { color: #999; }
 
 #qunit-banner.qunit-pass                    { background-color: #C6E746; }
 
@@ -198,24 +195,23 @@
 
 #qunit-tests li li.fail {
 	color: #710909;
-	background-color: #fff;
+	background-color: #FFF;
 	border-left: 10px solid #EE5757;
 	white-space: pre;
 }
 
 #qunit-tests > li:last-child {
 	border-radius: 0 0 5px 5px;
-	-moz-border-radius: 0 0 5px 5px;
-	-webkit-border-bottom-right-radius: 5px;
-	-webkit-border-bottom-left-radius: 5px;
+	border-bottom-right-radius: 5px;
+	border-bottom-left-radius: 5px;
 }
 
-#qunit-tests .fail                          { color: #000000; background-color: #EE5757; }
+#qunit-tests .fail                          { color: #000; background-color: #EE5757; }
 #qunit-tests .fail .test-name,
-#qunit-tests .fail .module-name             { color: #000000; }
+#qunit-tests .fail .module-name             { color: #000; }
 
 #qunit-tests .fail .test-actual             { color: #EE5757; }
-#qunit-tests .fail .test-expected           { color: green;   }
+#qunit-tests .fail .test-expected           { color: #008000; }
 
 #qunit-banner.qunit-fail                    { background-color: #EE5757; }
 
@@ -225,13 +221,13 @@
 #qunit-testresult {
 	padding: 0.5em 0.5em 0.5em 2.5em;
 
-	color: #2b81af;
+	color: #2B81AF;
 	background-color: #D2E0E6;
 
-	border-bottom: 1px solid white;
+	border-bottom: 1px solid #FFF;
 }
 #qunit-testresult .module-name {
-	font-weight: bold;
+	font-weight: 700;
 }
 
 /** Fixture */


### PR DESCRIPTION
Summary:
Use uppercase hex colors for consistency and 0 before point.
Use the short hex consistently.
Use the numbered font-weight properties.
Remove the vendor prefixed properties.

Closes: #508

@jzaefferer, I have just squashed @XhmikosR commits and set the minor changes to a summary inside the commit msg. No other changes were done here.
