### PR TITLE
jsHint: Conform to jQuery jsHint style guide

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,32 +1,22 @@
 {
+    "boss": true,
+    "curly": true,
+    "eqeqeq": true,
+    "eqnull": true,
+    "expr": true,
+    "immed": true,
+    "noarg": true,
+    "onevar": true,
+    "quotmark": "double",
+    "smarttabs": true,
+    "trailing": true,
+    "undef": true,
+    "unused": true,
+
+	"browser": true,
+	"es3": true,
+
 	"globals": {
 		"module": false
-	},
-
-	"boss": true,
-	"curly": true,
-	"eqeqeq": true,
-	"eqnull": true,
-	"expr": true,
-	"immed": true,
-	"noarg": true,
-	"onevar": true,
-	"quotmark": "double",
-	"smarttabs": true,
-	"trailing": true,
-	"undef": true,
-	"unused": true,
-
-	"bitwise": true,
-	"browser": true,
-	"camelcase": true,
-	"es3": true,
-	"forin": true,
-	"latedef": false,
-	"newcap": true,
-	"noempty": true,
-	"nonew": true,
-	"plusplus": false,
-	"proto": true,
-	"sub": true
+	}
 }

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -23,7 +23,7 @@ QUnit.equiv = (function() {
 		parentsB = [],
 
 		getProto = Object.getPrototypeOf || function ( obj ) {
-			/*jshint camelcase:false */
+			/* jshint camelcase: false, proto: true */
 			return obj.__proto__;
 		},
 		callbacks = (function () {

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,33 +1,27 @@
 {
-	"predef": [
-		"QUnit",
-		"module",
-		"test",
-		"asyncTest",
-		"expect",
-		"start",
-		"stop",
-		"raises"
-	],
-
-	"bitwise": true,
-	"camelcase": true,
-	"curly": true,
-	"eqeqeq": true,
-	"forin": true,
-	"immed": true,
-	"latedef": false,
-	"newcap": true,
-	"noarg": true,
-	"noempty": true,
-	"nonew": true,
-	"plusplus": false,
-	"quotmark": false,
-	"undef": true,
-	"unused": true,
-	"trailing": true,
+    "boss": true,
+    "curly": true,
+    "eqeqeq": true,
+    "eqnull": true,
+    "expr": true,
+    "immed": true,
+    "noarg": true,
+    "onevar": true,
+    "quotmark": "double",
+    "smarttabs": true,
+    "trailing": true,
+    "undef": true,
+    "unused": true,
 
 	"browser": true,
 
-	"onevar": false
+	"globals": {
+		"QUnit": false,
+		"module": false,
+		"test": false,
+		"asyncTest": false,
+		"expect": false,
+		"start": false,
+		"stop": false
+	}
 }

--- a/test/deepEqual.js
+++ b/test/deepEqual.js
@@ -7,7 +7,7 @@ test("Primitive types and constants", function ( assert ) {
 	assert.equal(QUnit.equiv(null, undefined), false, "null");
 	assert.equal(QUnit.equiv(null, 0), false, "null");
 	assert.equal(QUnit.equiv(null, false), false, "null");
-	assert.equal(QUnit.equiv(null, ''), false, "null");
+	assert.equal(QUnit.equiv(null, ""), false, "null");
 	assert.equal(QUnit.equiv(null, []), false, "null");
 
 	assert.equal(QUnit.equiv(undefined, undefined), true, "undefined");
@@ -45,9 +45,9 @@ test("Primitive types and constants", function ( assert ) {
 	assert.equal(QUnit.equiv(1, 1), true, "number");
 	assert.equal(QUnit.equiv(1.1, 1.1), true, "number");
 	assert.equal(QUnit.equiv(0.0000005, 0.0000005), true, "number");
-	assert.equal(QUnit.equiv(0, ''), false, "number");
-	assert.equal(QUnit.equiv(0, '0'), false, "number");
-	assert.equal(QUnit.equiv(1, '1'), false, "number");
+	assert.equal(QUnit.equiv(0, ""), false, "number");
+	assert.equal(QUnit.equiv(0, "0"), false, "number");
+	assert.equal(QUnit.equiv(1, "1"), false, "number");
 	assert.equal(QUnit.equiv(0, false), false, "number");
 	assert.equal(QUnit.equiv(1, true), false, "number");
 
@@ -61,14 +61,14 @@ test("Primitive types and constants", function ( assert ) {
 	assert.equal(QUnit.equiv(true, null), false, "boolean");
 	assert.equal(QUnit.equiv(true, undefined), false, "boolean");
 
-	assert.equal(QUnit.equiv('', ''), true, "string");
-	assert.equal(QUnit.equiv('a', 'a'), true, "string");
+	assert.equal(QUnit.equiv("", ""), true, "string");
+	assert.equal(QUnit.equiv("a", "a"), true, "string");
 	assert.equal(QUnit.equiv("foobar", "foobar"), true, "string");
 	assert.equal(QUnit.equiv("foobar", "foo"), false, "string");
-	assert.equal(QUnit.equiv('', 0), false, "string");
-	assert.equal(QUnit.equiv('', false), false, "string");
-	assert.equal(QUnit.equiv('', null), false, "string");
-	assert.equal(QUnit.equiv('', undefined), false, "string");
+	assert.equal(QUnit.equiv("", 0), false, "string");
+	assert.equal(QUnit.equiv("", false), false, "string");
+	assert.equal(QUnit.equiv("", null), false, "string");
+	assert.equal(QUnit.equiv("", undefined), false, "string");
 
 	// Rename for lint validation.
 	// We know this is bad, we are asserting whether we can coop with bad code like this.
@@ -144,7 +144,7 @@ test("Objects basics", function( assert ) {
 
 	// Objects with no prototype, created via Object.create(null), are used e.g. as dictionaries.
 	// Being able to test equivalence against object literals is quite useful.
-	if (typeof Object.create === 'function') {
+	if (typeof Object.create === "function") {
 		assert.equal(QUnit.equiv(Object.create(null), {}), true, "empty object without prototype VS empty object");
 
 		var nonEmptyWithNoProto = Object.create(null);
@@ -270,7 +270,7 @@ test("Arrays basics", function( assert ) {
 												1,2,3,4,[
 													2,3,4,[
 														1,2,[
-															'1',2,3,4,[                 // string instead of number
+															"1",2,3,4,[                 // string instead of number
 																1,2,3,4,5,6,7,8,9,[
 																	0
 																],1,2,3,4,5,6,7,8,9
@@ -333,15 +333,15 @@ test("Arrays basics", function( assert ) {
 });
 
 test("Functions", function( assert ) {
-	var f0 = function () {};
-	var f1 = function () {};
+	var f0 = function () {},
+		f1 = function () {},
 
 	// f2 and f3 have the same code, formatted differently
-	var f2 = function () {return 0;};
-	var f3 = function () {
-		/*jshint asi:true */
-		return 0 // this comment and no semicoma as difference
-	};
+		f2 = function () {return 0;},
+		f3 = function () {
+			/* jshint asi:true */
+			return 0 // this comment and no semicoma as difference
+		};
 
 	assert.equal(QUnit.equiv(function() {}, function() {}), false, "Anonymous functions"); // exact source code
 	assert.equal(QUnit.equiv(function() {}, function() {return true;}), false, "Anonymous functions");
@@ -361,14 +361,15 @@ test("Date instances", function( assert ) {
 	// Date, we don't need to test Date.parse() because it returns a number.
 	// Only test the Date instances by setting them a fix date.
 	// The date use is midnight January 1, 1970
+	var d1, d2, d3;
 
-	var d1 = new Date();
+	d1 = new Date();
 	d1.setTime(0); // fix the date
 
-	var d2 = new Date();
+	d2 = new Date();
 	d2.setTime(0); // fix the date
 
-	var d3 = new Date(); // The very now
+	d3 = new Date(); // The very now
 
 	// Anyway their types differs, just in case the code fails in the order in which it deals with date
 	assert.equal(QUnit.equiv(d1, 0), false); // d1.valueOf() returns 0, but d1 and 0 are different
@@ -387,31 +388,32 @@ test("RegExp", function( assert ) {
 	// typeof a === "function";    // Oops, false in IE and Opera, true in FF and Safari ("object")
 
 	// Tests same regex with same modifiers in different order
-	var r = /foo/;
-	var r5 = /foo/gim;
-	var r6 = /foo/gmi;
-	var r7 = /foo/igm;
-	var r8 = /foo/img;
-	var r9 = /foo/mig;
-	var r10 = /foo/mgi;
-	var ri1 = /foo/i;
-	var ri2 = /foo/i;
-	var rm1 = /foo/m;
-	var rm2 = /foo/m;
-	var rg1 = /foo/g;
-	var rg2 = /foo/g;
+	var regex1, regex2, regex3, r3a, r3b,
+		r1 = /foo/,
+		r2 = /foo/gim,
+		r3 = /foo/gmi,
+		r4 = /foo/igm,
+		r5 = /foo/img,
+		r6 = /foo/mig,
+		r7 = /foo/mgi,
+		ri1 = /foo/i,
+		ri2 = /foo/i,
+		rm1 = /foo/m,
+		rm2 = /foo/m,
+		rg1 = /foo/g,
+		rg2 = /foo/g;
 
-	assert.equal(QUnit.equiv(r5, r6), true, "Modifier order");
-	assert.equal(QUnit.equiv(r5, r7), true, "Modifier order");
-	assert.equal(QUnit.equiv(r5, r8), true, "Modifier order");
-	assert.equal(QUnit.equiv(r5, r9), true, "Modifier order");
-	assert.equal(QUnit.equiv(r5, r10), true, "Modifier order");
-	assert.equal(QUnit.equiv(r, r5), false, "Modifier");
+	assert.equal(QUnit.equiv(r2, r3), true, "Modifier order");
+	assert.equal(QUnit.equiv(r2, r4), true, "Modifier order");
+	assert.equal(QUnit.equiv(r2, r5), true, "Modifier order");
+	assert.equal(QUnit.equiv(r2, r6), true, "Modifier order");
+	assert.equal(QUnit.equiv(r2, r7), true, "Modifier order");
+	assert.equal(QUnit.equiv(r1, r2), false, "Modifier");
 
 	assert.equal(QUnit.equiv(ri1, ri2), true, "Modifier");
-	assert.equal(QUnit.equiv(r, ri1), false, "Modifier");
+	assert.equal(QUnit.equiv(r1, ri1), false, "Modifier");
 	assert.equal(QUnit.equiv(ri1, rm1), false, "Modifier");
-	assert.equal(QUnit.equiv(r, rm1), false, "Modifier");
+	assert.equal(QUnit.equiv(r1, rm1), false, "Modifier");
 	assert.equal(QUnit.equiv(rm1, ri1), false, "Modifier");
 	assert.equal(QUnit.equiv(rm1, rm2), true, "Modifier");
 	assert.equal(QUnit.equiv(rg1, rm1), false, "Modifier");
@@ -419,44 +421,44 @@ test("RegExp", function( assert ) {
 	assert.equal(QUnit.equiv(rg1, rg2), true, "Modifier");
 
 	// Different regex, same modifiers
-	var r11 = /[a-z]/gi;
-	var r13 = /[0-9]/gi; // oops! different
-	assert.equal(QUnit.equiv(r11, r13), false, "Regex pattern");
+	r1 = /[a-z]/gi;
+	r2 = /[0-9]/gi; // oops! different
+	assert.equal(QUnit.equiv(r1, r2), false, "Regex pattern");
 
-	var r14 = /0/ig;
-	var r15 = /"0"/ig; // oops! different
-	assert.equal(QUnit.equiv(r14, r15), false, "Regex pattern");
+	r1 = /0/ig;
+	r2 = /"0"/ig; // oops! different
+	assert.equal(QUnit.equiv(r1, r2), false, "Regex pattern");
 
-	var r1 = /[\n\r\u2028\u2029]/g;
-	var r2 = /[\n\r\u2028\u2029]/g;
-	var r3 = /[\n\r\u2028\u2028]/g; // differs from r1
-	var r4 = /[\n\r\u2028\u2029]/;  // differs from r1
+	r1 = /[\n\r\u2028\u2029]/g;
+	r2 = /[\n\r\u2028\u2029]/g;
+	r3 = /[\n\r\u2028\u2028]/g; // differs from r1
+	r4 = /[\n\r\u2028\u2029]/;  // differs from r1
 
 	assert.equal(QUnit.equiv(r1, r2), true, "Regex pattern");
 	assert.equal(QUnit.equiv(r1, r3), false, "Regex pattern");
 	assert.equal(QUnit.equiv(r1, r4), false, "Regex pattern");
 
 	// More complex regex
-	var regex1 = "^[-_.a-z0-9]+@([-_a-z0-9]+\\.)+([A-Za-z][A-Za-z]|[A-Za-z][A-Za-z][A-Za-z])|(([0-9][0-9]?|[0-1][0-9][0-9]|[2][0-4][0-9]|[2][5][0-5]))$";
-	var regex2 = "^[-_.a-z0-9]+@([-_a-z0-9]+\\.)+([A-Za-z][A-Za-z]|[A-Za-z][A-Za-z][A-Za-z])|(([0-9][0-9]?|[0-1][0-9][0-9]|[2][0-4][0-9]|[2][5][0-5]))$";
+	regex1 = "^[-_.a-z0-9]+@([-_a-z0-9]+\\.)+([A-Za-z][A-Za-z]|[A-Za-z][A-Za-z][A-Za-z])|(([0-9][0-9]?|[0-1][0-9][0-9]|[2][0-4][0-9]|[2][5][0-5]))$";
+	regex2 = "^[-_.a-z0-9]+@([-_a-z0-9]+\\.)+([A-Za-z][A-Za-z]|[A-Za-z][A-Za-z][A-Za-z])|(([0-9][0-9]?|[0-1][0-9][0-9]|[2][0-4][0-9]|[2][5][0-5]))$";
 	// regex 3 is different: '.' not escaped
-	var regex3 = "^[-_.a-z0-9]+@([-_a-z0-9]+.)+([A-Za-z][A-Za-z]|[A-Za-z][A-Za-z][A-Za-z])|(([0-9][0-9]?|[0-1][0-9][0-9]|[2][0-4][0-9]|[2][5][0-5]))$";
+	regex3 = "^[-_.a-z0-9]+@([-_a-z0-9]+.)+([A-Za-z][A-Za-z]|[A-Za-z][A-Za-z][A-Za-z])|(([0-9][0-9]?|[0-1][0-9][0-9]|[2][0-4][0-9]|[2][5][0-5]))$";
 
-	var r21 = new RegExp(regex1);
-	var r22 = new RegExp(regex2);
-	var r23 = new RegExp(regex3); // diff from r21, not same pattern
-	var r23a = new RegExp(regex3, "gi"); // diff from r23, not same modifier
-	var r24a = new RegExp(regex3, "ig"); // same as r23a
+	r1 = new RegExp(regex1);
+	r2 = new RegExp(regex2);
+	r3 = new RegExp(regex3); // diff from r21, not same pattern
+	r3a = new RegExp(regex3, "gi"); // diff from r23, not same modifier
+	r3b = new RegExp(regex3, "ig"); // same as r23a
 
-	assert.equal(QUnit.equiv(r21, r22), true, "Complex Regex");
-	assert.equal(QUnit.equiv(r21, r23), false, "Complex Regex");
-	assert.equal(QUnit.equiv(r23, r23a), false, "Complex Regex");
-	assert.equal(QUnit.equiv(r23a, r24a), true, "Complex Regex");
+	assert.equal(QUnit.equiv(r1, r2), true, "Complex Regex");
+	assert.equal(QUnit.equiv(r1, r3), false, "Complex Regex");
+	assert.equal(QUnit.equiv(r3, r3a), false, "Complex Regex");
+	assert.equal(QUnit.equiv(r3a, r3b), true, "Complex Regex");
 
 	// typeof r1 is "function" in some browsers and "object" in others so we must cover this test
-	var re = / /;
-	assert.equal(QUnit.equiv(re, function () {}), false, "Regex internal");
-	assert.equal(QUnit.equiv(re, {}), false, "Regex internal");
+	r1 = / /;
+	assert.equal(QUnit.equiv(r1, function () {}), false, "Regex internal");
+	assert.equal(QUnit.equiv(r1, {}), false, "Regex internal");
 });
 
 
@@ -852,109 +854,109 @@ test("Complex objects", function( assert ) {
 	), false);
 
 	var same1 = {
-		a: [
-			"string", null, 0, "1", 1, {
-				prop: null,
-				foo: [1,2,null,{}, [], [1,2,3]],
-				bar: undefined
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
-		],
-		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
-		b: "b",
-		c: fn1
-	};
+			a: [
+				"string", null, 0, "1", 1, {
+					prop: null,
+					foo: [1,2,null,{}, [], [1,2,3]],
+					bar: undefined
+				}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+			],
+			unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+			b: "b",
+			c: fn1
+		},
 
-	var same2 = {
-		a: [
-			"string", null, 0, "1", 1, {
-				prop: null,
-				foo: [1,2,null,{}, [], [1,2,3]],
-				bar: undefined
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
-		],
-		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
-		b: "b",
-		c: fn1
-	};
+		same2 = {
+			a: [
+				"string", null, 0, "1", 1, {
+					prop: null,
+					foo: [1,2,null,{}, [], [1,2,3]],
+					bar: undefined
+				}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+			],
+			unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+			b: "b",
+			c: fn1
+		},
 
-	var diff1 = {
-		a: [
-			"string", null, 0, "1", 1, {
-				prop: null,
-				foo: [1,2,null,{}, [], [1,2,3,4]], // different: 4 was add to the array
-				bar: undefined
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
-		],
-		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
-		b: "b",
-		c: fn1
-	};
+		diff1 = {
+			a: [
+				"string", null, 0, "1", 1, {
+					prop: null,
+					foo: [1,2,null,{}, [], [1,2,3,4]], // different: 4 was add to the array
+					bar: undefined
+				}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+			],
+			unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+			b: "b",
+			c: fn1
+		},
 
-	var diff2 = {
-		a: [
-			"string", null, 0, "1", 1, {
-				prop: null,
-				foo: [1,2,null,{}, [], [1,2,3]],
-				newprop: undefined, // different: newprop was added
-				bar: undefined
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
-		],
-		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
-		b: "b",
-		c: fn1
-	};
+		diff2 = {
+			a: [
+				"string", null, 0, "1", 1, {
+					prop: null,
+					foo: [1,2,null,{}, [], [1,2,3]],
+					newprop: undefined, // different: newprop was added
+					bar: undefined
+				}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+			],
+			unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+			b: "b",
+			c: fn1
+		},
 
-	var diff3 = {
-		a: [
-			"string", null, 0, "1", 1, {
-				prop: null,
-				foo: [1,2,null,{}, [], [1,2,3]],
-				bar: undefined
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±" // different: missing last char
-		],
-		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
-		b: "b",
-		c: fn1
-	};
+		diff3 = {
+			a: [
+				"string", null, 0, "1", 1, {
+					prop: null,
+					foo: [1,2,null,{}, [], [1,2,3]],
+					bar: undefined
+				}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±" // different: missing last char
+			],
+			unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+			b: "b",
+			c: fn1
+		},
 
-	var diff4 = {
-		a: [
-			"string", null, 0, "1", 1, {
-				prop: null,
-				foo: [1,2,undefined,{}, [], [1,2,3]], // different: undefined instead of null
-				bar: undefined
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
-		],
-		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
-		b: "b",
-		c: fn1
-	};
+		diff4 = {
+			a: [
+				"string", null, 0, "1", 1, {
+					prop: null,
+					foo: [1,2,undefined,{}, [], [1,2,3]], // different: undefined instead of null
+					bar: undefined
+				}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+			],
+			unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+			b: "b",
+			c: fn1
+		},
 
-	var diff5 = {
-		a: [
-			"string", null, 0, "1", 1, {
-				prop: null,
-				foo: [1,2,null,{}, [], [1,2,3]],
-				bat: undefined // different: property name not "bar"
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
-		],
-		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
-		b: "b",
-		c: fn1
-	};
+		diff5 = {
+			a: [
+				"string", null, 0, "1", 1, {
+					prop: null,
+					foo: [1,2,null,{}, [], [1,2,3]],
+					bat: undefined // different: property name not "bar"
+				}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+			],
+			unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+			b: "b",
+			c: fn1
+		},
 
-	var diff6 = {
-		a: [
-			"string", null, 0, "1", 1, {
-				prop: null,
-				foo: [1,2,null,{}, [], [1,2,3]],
-				bar: undefined
-			}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
-		],
-		unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
-		b: "b",
-		c: fn2 // different: fn2 instead of fn1
-	};
+		diff6 = {
+			a: [
+				"string", null, 0, "1", 1, {
+					prop: null,
+					foo: [1,2,null,{}, [], [1,2,3]],
+					bar: undefined
+				}, 3, "Hey!", "ÎšÎ¬Î½Îµ Ï€Î¬Î½Ï„Î± Î³Î½Ï‰ÏÎ¯Î¶Î¿Ï…Î¼Îµ Î±Ï‚ Ï„Ï‰Î½, Î¼Î·Ï‡Î±Î½Î®Ï‚ ÎµÏ€Î¹Î´Î¹ÏŒÏÎ¸Ï‰ÏƒÎ·Ï‚ ÎµÏ€Î¹Î´Î¹Î¿ÏÎ¸ÏŽÏƒÎµÎ¹Ï‚ ÏŽÏ‚ Î¼Î¹Î±. ÎšÎ»Ï€ Î±Ï‚"
+			],
+			unicode: "è€ æ±‰è¯ä¸å˜åœ¨ æ¸¯æ¾³å’Œæµ·å¤–çš„åŽäººåœˆä¸ è´µå·ž æˆ‘åŽ»äº†ä¹¦åº— çŽ°åœ¨å°šæœ‰äº‰",
+			b: "b",
+			c: fn2 // different: fn2 instead of fn1
+		};
 
 	assert.equal(QUnit.equiv(same1, same2), true);
 	assert.equal(QUnit.equiv(same2, same1), true);
@@ -980,13 +982,13 @@ test("Complex Arrays", function( assert ) {
 	assert.equal(QUnit.equiv(
 				[1, 2, 3, true, {}, null, [
 					{
-						a: ["", '1', 0]
+						a: ["", "1", 0]
 					},
 					5, 6, 7
 				], "foo"],
 				[1, 2, 3, true, {}, null, [
 					{
-						a: ["", '1', 0]
+						a: ["", "1", 0]
 					},
 					5, 6, 7
 				], "foo"]),
@@ -995,13 +997,13 @@ test("Complex Arrays", function( assert ) {
 	assert.equal(QUnit.equiv(
 				[1, 2, 3, true, {}, null, [
 					{
-						a: ["", '1', 0]
+						a: ["", "1", 0]
 					},
 					5, 6, 7
 				], "foo"],
 				[1, 2, 3, true, {}, null, [
 					{
-						b: ["", '1', 0]         // not same property name
+						b: ["", "1", 0]         // not same property name
 					},
 					5, 6, 7
 				], "foo"]),
@@ -1168,8 +1170,8 @@ test("Prototypal inheritance", function( assert ) {
 	}
 	Hoozit.prototype = new Gizmo();
 
-	var gizmo = new Gizmo("ok");
-	var hoozit = new Hoozit("ok");
+	var gizmo = new Gizmo("ok"),
+		hoozit = new Hoozit("ok");
 
 	// Try this test many times after test on instances that hold function
 	// to make sure that our code does not mess with last object constructor memoization.
@@ -1208,15 +1210,17 @@ test("Prototypal inheritance", function( assert ) {
 
 
 test("Instances", function( assert ) {
+	var a1, a2, b1, b2, car, carSame, carDiff, human;
+
 	function A() {}
-	var a1 = new A();
-	var a2 = new A();
+	a1 = new A();
+	a2 = new A();
 
 	function B() {
 		this.fn = function () {};
 	}
-	var b1 = new B();
-	var b2 = new B();
+	b1 = new B();
+	b2 = new B();
 
 	assert.equal(QUnit.equiv(a1, a2), true, "Same property, same constructor");
 
@@ -1241,10 +1245,10 @@ test("Instances", function( assert ) {
 		};
 	}
 
-	var car = new Car(30);
-	var carSame = new Car(30);
-	var carDiff = new Car(10);
-	var human = new Human(30);
+	car = new Car(30);
+	carSame = new Car(30);
+	carDiff = new Car(10);
+	human = new Human(30);
 
 	/**
 	 * difference:
@@ -1262,6 +1266,8 @@ test("Instances", function( assert ) {
 
 
 test("Complex instance nesting (with function values in literals and/or in nested instances)", function( assert ) {
+	var a1, a2, b1, b2, c1, c2, d1, d2, e1, e2;
+
 	function A(fn) {
 		this.a = {};
 		this.fn = fn;
@@ -1357,26 +1363,26 @@ test("Complex instance nesting (with function values in literals and/or in neste
 	}
 
 
-	var a1 = new A(function () {});
-	var a2 = new A(function () {});
+	a1 = new A(function () {});
+	a2 = new A(function () {});
 	assert.equal(QUnit.equiv(a1, a2), true);
 
 	assert.equal(QUnit.equiv(a1, a2), true); // different instances
 
-	var b1 = new B(function () {});
-	var b2 = new B(function () {});
+	b1 = new B(function () {});
+	b2 = new B(function () {});
 	assert.equal(QUnit.equiv(b1, b2), true);
 
-	var c1 = new C(function () {});
-	var c2 = new C(function () {});
+	c1 = new C(function () {});
+	c2 = new C(function () {});
 	assert.equal(QUnit.equiv(c1, c2), true);
 
-	var d1 = new D(function () {});
-	var d2 = new D(function () {});
+	d1 = new D(function () {});
+	d2 = new D(function () {});
 	assert.equal(QUnit.equiv(d1, d2), false);
 
-	var e1 = new E(function () {});
-	var e2 = new E(function () {});
+	e1 = new E(function () {});
+	e2 = new E(function () {});
 	assert.equal(QUnit.equiv(e1, e2), false);
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,7 @@
 (function( window ) {
 
+var OrgDate, state;
+
 function getPreviousTests( rTestName, rModuleName ) {
 	var testSpan, moduleSpan,
 		matches = [],
@@ -135,8 +137,6 @@ if ( typeof document !== "undefined" ) {
 
 }
 
-var state;
-
 QUnit.module( "setup/teardown test", {
 	setup: function( assert ) {
 		state = true;
@@ -183,13 +183,11 @@ test("module without setup/teardown", function( assert ) {
 	assert.ok(true);
 });
 
-var OrgDate;
-
 QUnit.module( "Date test", {
 	setup: function( assert ) {
 		OrgDate = Date;
 		window.Date = function () {
-			assert.ok( false, 'QUnit should internally be independent from Date-related manipulation and testing' );
+			assert.ok( false, "QUnit should internally be independent from Date-related manipulation and testing" );
 			return new OrgDate();
 		};
 	},
@@ -203,8 +201,8 @@ test("sample test for Date test", function ( assert ) {
 	assert.ok(true);
 });
 
-if (typeof setTimeout !== 'undefined') {
-state = 'fail';
+if (typeof setTimeout !== "undefined") {
+state = "fail";
 
 QUnit.module( "teardown and stop", {
 	teardown: function( assert ) {
@@ -318,11 +316,11 @@ test("test synchronous calls to stop", function( assert ) {
 	expect( 2 );
 	stop();
 	setTimeout(function() {
-		assert.ok(true, 'first');
+		assert.ok(true, "first");
 		start();
 		stop();
 		setTimeout(function() {
-			assert.ok(true, 'second');
+			assert.ok(true, "second");
 			start();
 		}, 150);
 	}, 150);
@@ -387,31 +385,31 @@ test("testEnvironment reset for next test",function( assert ) {
 QUnit.module( "testEnvironment tests" );
 
 function makeurl() {
-	var testEnv = QUnit.config.current.testEnvironment;
-	var url = testEnv.url || 'http://example.com/search';
-	var q   = testEnv.q   || 'a search test';
-	return url + '?q='+encodeURIComponent(q);
+	var testEnv = QUnit.config.current.testEnvironment,
+		url = testEnv.url || "http://example.com/search",
+		q   = testEnv.q   || "a search test";
+	return url + "?q=" + encodeURIComponent(q);
 }
 
 test("makeurl working", function( assert ) {
 	expect( 2 );
-	assert.equal( QUnit.config.current.testEnvironment, this, 'The current testEnvironment QUnit.config');
-	assert.equal( makeurl(), 'http://example.com/search?q=a%20search%20test', 'makeurl returns a default url if nothing specified in the testEnvironment');
+	assert.equal( QUnit.config.current.testEnvironment, this, "The current testEnvironment QUnit.config");
+	assert.equal( makeurl(), "http://example.com/search?q=a%20search%20test", "makeurl returns a default url if nothing specified in the testEnvironment");
 });
 
 QUnit.module( "testEnvironment with makeurl settings", {
-	url: 'http://google.com/',
-	q: 'another_search_test'
+	url: "http://google.com/",
+	q: "another_search_test"
 });
 test("makeurl working with settings from testEnvironment", function( assert ) {
-	assert.equal( makeurl(), 'http://google.com/?q=another_search_test', 'rather than passing arguments, we use test metadata to from the url');
+	assert.equal( makeurl(), "http://google.com/?q=another_search_test", "rather than passing arguments, we use test metadata to from the url");
 });
 
 QUnit.module( "jsDump" );
 test("jsDump output", function( assert ) {
 	assert.equal( QUnit.jsDump.parse([1, 2]), "[\n  1,\n  2\n]" );
 	assert.equal( QUnit.jsDump.parse({top: 5, left: 0}), "{\n  \"left\": 0,\n  \"top\": 5\n}" );
-	if (typeof document !== 'undefined' && document.getElementById("qunit-header")) {
+	if (typeof document !== "undefined" && document.getElementById("qunit-header")) {
 		assert.equal( QUnit.jsDump.parse(document.getElementById("qunit-header")), "<h1 id=\"qunit-header\"></h1>" );
 		assert.equal( QUnit.jsDump.parse(document.getElementsByTagName("h1")), "[\n  <h1 id=\"qunit-header\"></h1>\n]" );
 	}
@@ -435,7 +433,7 @@ test("propEqual", function( assert ) {
 	}
 	Foo.prototype.doA = function () {};
 	Foo.prototype.doB = function () {};
-	Foo.prototype.bar = 'prototype';
+	Foo.prototype.bar = "prototype";
 
 	function Bar() {
 	}
@@ -443,56 +441,56 @@ test("propEqual", function( assert ) {
 	Bar.prototype.constructor = Bar;
 
 	assert.propEqual(
-		new Foo( 1, '2', [] ),
+		new Foo( 1, "2", [] ),
 		{
 			x: 1,
-			y: '2',
+			y: "2",
 			z: []
 		}
 	);
 
 	assert.notPropEqual(
-		new Foo( '1', 2, 3 ),
+		new Foo( "1", 2, 3 ),
 		{
 			x: 1,
-			y: '2',
+			y: "2",
 			z: 3
 		},
-		'Primitive values are strictly compared'
+		"Primitive values are strictly compared"
 	);
 
 	assert.notPropEqual(
-		new Foo( 1, '2', [] ),
+		new Foo( 1, "2", [] ),
 		{
 			x: 1,
-			y: '2',
+			y: "2",
 			z: {}
 		},
-		'Array type is preserved'
+		"Array type is preserved"
 	);
 
 	assert.notPropEqual(
-		new Foo( 1, '2', {} ),
+		new Foo( 1, "2", {} ),
 		{
 			x: 1,
-			y: '2',
+			y: "2",
 			z: []
 		},
-		'Empty array is not the same as empty object'
+		"Empty array is not the same as empty object"
 	);
 
 	assert.propEqual(
-		new Foo( 1, '2', new Foo( [ 3 ], new Bar(), null ) ),
+		new Foo( 1, "2", new Foo( [ 3 ], new Bar(), null ) ),
 		{
 			x: 1,
-			y: '2',
+			y: "2",
 			z: {
 				x: [ 3 ],
 				y: {},
 				z: null
 			}
 		},
-		'Complex nesting of different types, inheritance and constructors'
+		"Complex nesting of different types, inheritance and constructors"
 	);
 });
 
@@ -534,7 +532,7 @@ test("throws", function( assert ) {
 			throw new CustomError();
 		},
 		CustomError,
-		'thrown error is an instance of CustomError'
+		"thrown error is an instance of CustomError"
 	);
 
 	assert.throws(
@@ -564,7 +562,7 @@ test("throws", function( assert ) {
 				window["eval"].call( window, data );
 			})( "throw 'error';" );
 		},
-		'globally-executed errors caught'
+		"globally-executed errors caught"
 	);
 
 	this.CustomError = CustomError;
@@ -696,69 +694,75 @@ function chainwrap(depth, first, prev) {
 test("Check jsDump recursion", function( assert ) {
 	expect(4);
 
-	var noref = chainwrap(0);
-	var nodump = QUnit.jsDump.parse(noref);
-	assert.equal(nodump, '{\n  "first": true,\n  "wrap": undefined\n}');
+	var noref, nodump, selfref, selfdump, parentref, parentdump, circref, circdump;
 
-	var selfref = chainwrap(1);
-	var selfdump = QUnit.jsDump.parse(selfref);
-	assert.equal(selfdump, '{\n  "first": true,\n  "wrap": recursion(-1)\n}');
+	noref = chainwrap(0);
+	nodump = QUnit.jsDump.parse(noref);
+	assert.equal(nodump, "{\n  \"first\": true,\n  \"wrap\": undefined\n}");
 
-	var parentref = chainwrap(2);
-	var parentdump = QUnit.jsDump.parse(parentref);
-	assert.equal(parentdump, '{\n  "wrap": {\n    "first": true,\n    "wrap": recursion(-2)\n  }\n}');
+	selfref = chainwrap(1);
+	selfdump = QUnit.jsDump.parse(selfref);
+	assert.equal(selfdump, "{\n  \"first\": true,\n  \"wrap\": recursion(-1)\n}");
 
-	var circref = chainwrap(10);
-	var circdump = QUnit.jsDump.parse(circref);
+	parentref = chainwrap(2);
+	parentdump = QUnit.jsDump.parse(parentref);
+	assert.equal(parentdump, "{\n  \"wrap\": {\n    \"first\": true,\n    \"wrap\": recursion(-2)\n  }\n}");
+
+	circref = chainwrap(10);
+	circdump = QUnit.jsDump.parse(circref);
 	assert.ok(new RegExp("recursion\\(-10\\)").test(circdump), "(" +circdump + ") should show -10 recursion level");
 });
 
 test("Check equal/deepEqual recursion", function( assert ) {
-	var noRecursion = chainwrap(0);
+	var noRecursion, selfref, circref;
+
+	noRecursion = chainwrap(0);
 	assert.equal(noRecursion, noRecursion, "I should be equal to me.");
 	assert.deepEqual(noRecursion, noRecursion, "... and so in depth.");
 
-	var selfref = chainwrap(1);
+	selfref = chainwrap(1);
 	assert.equal(selfref, selfref, "Even so if I nest myself.");
 	assert.deepEqual(selfref, selfref, "... into the depth.");
 
-	var circref = chainwrap(10);
+	circref = chainwrap(10);
 	assert.equal(circref, circref, "Or hide that through some levels of indirection.");
 	assert.deepEqual(circref, circref, "... and checked on all levels!");
 });
 
 
 test("Circular reference with arrays", function( assert ) {
+	var arr, arrdump, obj, childarr, objdump, childarrdump;
 
 	// pure array self-ref
-	var arr = [];
+	arr = [];
 	arr.push(arr);
 
-	var arrdump = QUnit.jsDump.parse(arr);
+	arrdump = QUnit.jsDump.parse(arr);
 
-	assert.equal(arrdump, '[\n  recursion(-1)\n]');
-	assert.equal(arr, arr[0], 'no endless stack when trying to dump arrays with circular ref');
+	assert.equal(arrdump, "[\n  recursion(-1)\n]");
+	assert.equal(arr, arr[0], "no endless stack when trying to dump arrays with circular ref");
 
 
 	// mix obj-arr circular ref
-	var obj = {};
-	var childarr = [obj];
+	obj = {};
+	childarr = [obj];
 	obj.childarr = childarr;
 
-	var objdump = QUnit.jsDump.parse(obj);
-	var childarrdump = QUnit.jsDump.parse(childarr);
+	objdump = QUnit.jsDump.parse(obj);
+	childarrdump = QUnit.jsDump.parse(childarr);
 
-	assert.equal(objdump, '{\n  "childarr": [\n    recursion(-2)\n  ]\n}');
-	assert.equal(childarrdump, '[\n  {\n    "childarr": recursion(-2)\n  }\n]');
+	assert.equal(objdump, "{\n  \"childarr\": [\n    recursion(-2)\n  ]\n}");
+	assert.equal(childarrdump, "[\n  {\n    \"childarr\": recursion(-2)\n  }\n]");
 
-	assert.equal(obj.childarr, childarr, 'no endless stack when trying to dump array/object mix with circular ref');
-	assert.equal(childarr[0], obj, 'no endless stack when trying to dump array/object mix with circular ref');
+	assert.equal(obj.childarr, childarr, "no endless stack when trying to dump array/object mix with circular ref");
+	assert.equal(childarr[0], obj, "no endless stack when trying to dump array/object mix with circular ref");
 
 });
 
 
 test("Circular reference - test reported by soniciq in #105", function( assert ) {
-	var MyObject = function() {};
+	var a, b, barr,
+		MyObject = function() {};
 	MyObject.prototype.parent = function(obj) {
 		if (obj === undefined) { return this._parent; }
 		this._parent = obj;
@@ -768,10 +772,10 @@ test("Circular reference - test reported by soniciq in #105", function( assert )
 		this._children = obj;
 	};
 
-	var a = new MyObject(),
-		b = new MyObject();
+	a = new MyObject();
+	b = new MyObject();
 
-	var barr = [b];
+	barr = [b];
 	a.children(barr);
 	b.parent(a);
 
@@ -803,7 +807,7 @@ function testAfterDone() {
 		// Because when this does happen, the assertion count parameter doesn't actually
 		// work we use this test to check the assertion count.
 		QUnit.module( "check previous test's assertion counts" );
-		test('count previous two test\'s assertions', function ( assert ) {
+		test("count previous two test's assertions", function ( assert ) {
 			var tests = getPreviousTests(/^ensure has correct number of assertions/, /^Synchronous test after load of page$/);
 
 			assert.equal(tests[0].firstChild.lastChild.getElementsByTagName("b")[1].innerHTML, "99");
@@ -815,7 +819,7 @@ function testAfterDone() {
 
 	QUnit.module( "Synchronous test after load of page" );
 
-	asyncTest('Async test', function( assert ) {
+	asyncTest("Async test", function( assert ) {
 		start();
 		for (var i = 1; i < 100; i++) {
 			assert.ok(i);
@@ -831,7 +835,7 @@ function testAfterDone() {
 
 	// We need two of these types of tests in order to ensure that assertions
 	// don't move between tests.
-	test(testName + ' 2', function( assert ) {
+	test(testName + " 2", function( assert ) {
 		expect( 99 );
 		for (var i = 1; i < 100; i++) {
 			assert.ok(i);
@@ -840,7 +844,7 @@ function testAfterDone() {
 
 }
 
-if (typeof setTimeout !== 'undefined') {
+if (typeof setTimeout !== "undefined") {
 	QUnit.done(testAfterDone);
 }
 


### PR DESCRIPTION
QUnit doesn't currently conform to our [jsHint-related style guide](http://contribute.jquery.org/style-guide/js/#linting). This PR fixes it.

BTW, I wanted to add the `es3` option in tests since we should check if we didn't break oldIE but I was blocked on this bug: https://github.com/jshint/jshint/issues/1508
