### PR TITLE
Build: switch from the "popular" browser set to "popular-qunit"

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,7 +112,7 @@ grunt.registerTask( "testswarm", function( commit, configFile ) {
 			name: "Commit <a href='https://github.com/jquery/qunit/commit/" + commit + "'>" +
 				commit.substr( 0, 10 ) + "</a>",
 			runs: runs,
-			browserSets: [ "popular", "ios" ]
+			browserSets: [ "popular-qunit", "ios" ]
 		}, function( err, passed ) {
 			if ( err ) {
 				grunt.log.error( err );


### PR DESCRIPTION
jQuery is moving toward future removal of support for IE6/7, Opera 12.1x
and Safari 5.1 whereas QUnit continues to support them. This commit switches
the used browser set to one containing all those browsers.

cc @jzaefferer

The definition of the browserSet is here: https://github.com/jquery/infrastructure/blob/1b4fe5b200467b268e4f7f3acc7d644cf7c3a577/modules/jquery/files/swarm/localSettings.json#L323-340
