### PR TITLE
Code Style: Fixing inconsistencies

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -12,7 +12,7 @@ assert = QUnit.assert = {
 	 */
 	ok: function( result, msg ) {
 		if ( !config.current ) {
-			throw new Error( "ok() assertion outside test context, was " + sourceFromStacktrace(2) );
+			throw new Error( "ok() assertion outside test context, was " + sourceFromStacktrace( 2 ) );
 		}
 		result = !!result;
 		msg = msg || ( result ? "okay" : "failed" );
@@ -69,9 +69,9 @@ assert = QUnit.assert = {
 	 * @function
 	 */
 	propEqual: function( actual, expected, message ) {
-		actual = objectValues(actual);
-		expected = objectValues(expected);
-		QUnit.push( QUnit.equiv(actual, expected), actual, expected, message );
+		actual = objectValues( actual );
+		expected = objectValues( expected );
+		QUnit.push( QUnit.equiv( actual, expected ), actual, expected, message );
 	},
 
 	/**
@@ -79,9 +79,9 @@ assert = QUnit.assert = {
 	 * @function
 	 */
 	notPropEqual: function( actual, expected, message ) {
-		actual = objectValues(actual);
-		expected = objectValues(expected);
-		QUnit.push( !QUnit.equiv(actual, expected), actual, expected, message );
+		actual = objectValues( actual );
+		expected = objectValues( expected );
+		QUnit.push( !QUnit.equiv( actual, expected ), actual, expected, message );
 	},
 
 	/**
@@ -89,7 +89,7 @@ assert = QUnit.assert = {
 	 * @function
 	 */
 	deepEqual: function( actual, expected, message ) {
-		QUnit.push( QUnit.equiv(actual, expected), actual, expected, message );
+		QUnit.push( QUnit.equiv( actual, expected ), actual, expected, message );
 	},
 
 	/**
@@ -97,7 +97,7 @@ assert = QUnit.assert = {
 	 * @function
 	 */
 	notDeepEqual: function( actual, expected, message ) {
-		QUnit.push( !QUnit.equiv(actual, expected), actual, expected, message );
+		QUnit.push( !QUnit.equiv( actual, expected ), actual, expected, message );
 	},
 
 	/**

--- a/src/core.js
+++ b/src/core.js
@@ -3,7 +3,7 @@ var QUnit,
 	config,
 	onErrorFnPrev,
 	testId = 0,
-	fileName = (sourceFromStacktrace( 0 ) || "" ).replace(/(:\d+)+\)?/, "").replace(/.+\//, ""),
+	fileName = ( sourceFromStacktrace( 0 ) || "" ).replace( /(:\d+)+\)?/, "" ).replace( /.+\//, "" ),
 	toString = Object.prototype.toString,
 	hasOwn = Object.prototype.hasOwnProperty,
 	// Keep a local reference to Date (GH-283)
@@ -22,7 +22,7 @@ var QUnit,
 				sessionStorage.setItem( x, x );
 				sessionStorage.removeItem( x );
 				return true;
-			} catch( e ) {
+			} catch ( e ) {
 				return false;
 			}
 		}())
@@ -70,8 +70,8 @@ var QUnit,
 			vals = QUnit.is( "array", obj ) ? [] : {};
 		for ( key in obj ) {
 			if ( hasOwn.call( obj, key ) ) {
-				val = obj[key];
-				vals[key] = val === Object(val) ? objectValues(val) : val;
+				val = obj[ key ];
+				vals[ key ] = val === Object( val ) ? objectValues( val ) : val;
 			}
 		}
 		return vals;
@@ -86,7 +86,7 @@ QUnit = {
 	module: function( name, testEnvironment ) {
 		config.currentModule = name;
 		config.currentModuleTestEnvironment = testEnvironment;
-		config.modules[name] = true;
+		config.modules[ name ] = true;
 	},
 
 	asyncTest: function( testName, expected, callback ) {
@@ -131,7 +131,7 @@ QUnit = {
 
 	// Specify the number of expected assertions to guarantee that failed test (no assertions are run at all) don't slip through.
 	expect: function( asserts ) {
-		if (arguments.length === 1) {
+		if ( arguments.length === 1 ) {
 			config.current.expected = asserts;
 		} else {
 			return config.current.expected;
@@ -159,7 +159,7 @@ QUnit = {
 		// ignore if start is called more often then stop
 		if ( config.semaphore < 0 ) {
 			config.semaphore = 0;
-			QUnit.pushFailure( "Called start() while already started (QUnit.config.semaphore was 0 already)", sourceFromStacktrace(2) );
+			QUnit.pushFailure( "Called start() while already started (QUnit.config.semaphore was 0 already)", sourceFromStacktrace( 2 ) );
 			return;
 		}
 		// A slight delay, to avoid any current callbacks
@@ -174,7 +174,7 @@ QUnit = {
 
 				config.blocking = false;
 				process( true );
-			}, 13);
+			}, 13 );
 		} else {
 			config.blocking = false;
 			process( true );
@@ -202,6 +202,7 @@ QUnit = {
 	function F() {}
 	F.prototype = QUnit;
 	QUnit = new F();
+
 	// Make F QUnit's constructor so that we can add to the prototype later
 	QUnit.constructor = F;
 }());
@@ -393,12 +394,12 @@ extend( QUnit, {
 			return "null";
 		}
 
-		var match = toString.call( obj ).match(/^\[object\s(.*)\]$/),
-			type = match && match[1] || "";
+		var match = toString.call( obj ).match( /^\[object\s(.*)\]$/ ),
+			type = match && match[ 1 ] || "";
 
 		switch ( type ) {
 			case "Number":
-				if ( isNaN(obj) ) {
+				if ( isNaN( obj ) ) {
 					return "nan";
 				}
 				return "number";
@@ -436,8 +437,8 @@ extend( QUnit, {
 		output = message;
 
 		if ( !result ) {
-			expected = escapeText( QUnit.jsDump.parse(expected) );
-			actual = escapeText( QUnit.jsDump.parse(actual) );
+			expected = escapeText( QUnit.jsDump.parse( expected ) );
+			actual = escapeText( QUnit.jsDump.parse( actual ) );
 			output += "<table><tr class='test-expected'><th>Expected: </th><td><pre>" + expected + "</pre></td></tr>";
 
 			if ( actual !== expected ) {
@@ -465,7 +466,7 @@ extend( QUnit, {
 
 	pushFailure: function( message, source, actual ) {
 		if ( !config.current ) {
-			throw new Error( "pushFailure() assertion outside test context, was " + sourceFromStacktrace(2) );
+			throw new Error( "pushFailure() assertion outside test context, was " + sourceFromStacktrace( 2 ) );
 		}
 
 		var output,
@@ -522,6 +523,7 @@ extend( QUnit, {
 	addClass: addClass,
 	hasClass: hasClass,
 	removeClass: removeClass
+
 	// load, equiv, jsDump, diff: Attached later
 });
 
@@ -576,14 +578,14 @@ QUnit.load = function() {
 		oldconfig = extend( {}, config );
 
 	QUnit.init();
-	extend(config, oldconfig);
+	extend( config, oldconfig );
 
 	config.blocking = false;
 
 	len = config.urlConfig.length;
 
 	for ( i = 0; i < len; i++ ) {
-		val = config.urlConfig[i];
+		val = config.urlConfig[ i ];
 		if ( typeof val === "string" ) {
 			val = {
 				id: val,
@@ -611,20 +613,20 @@ QUnit.load = function() {
 			selection = false;
 			if ( QUnit.is( "array", val.value ) ) {
 				for ( j = 0; j < val.value.length; j++ ) {
-					urlConfigHtml += "<option value='" + escapeText( val.value[j] ) + "'" +
-						( config[ val.id ] === val.value[j] ?
-							(selection = true) && " selected='selected'" :
+					urlConfigHtml += "<option value='" + escapeText( val.value[ j ] ) + "'" +
+						( config[ val.id ] === val.value[ j ] ?
+							( selection = true ) && " selected='selected'" :
 							"" ) +
-						">" + escapeText( val.value[j] ) + "</option>";
+						">" + escapeText( val.value[ j ] ) + "</option>";
 				}
 			} else {
 				for ( j in val.value ) {
 					if ( hasOwn.call( val.value, j ) ) {
 						urlConfigHtml += "<option value='" + escapeText( j ) + "'" +
 							( config[ val.id ] === j ?
-								(selection = true) && " selected='selected'" :
+								( selection = true ) && " selected='selected'" :
 								"" ) +
-							">" + escapeText( val.value[j] ) + "</option>";
+							">" + escapeText( val.value[ j ] ) + "</option>";
 					}
 				}
 			}
@@ -639,22 +641,21 @@ QUnit.load = function() {
 	}
 	for ( i in config.modules ) {
 		if ( config.modules.hasOwnProperty( i ) ) {
-			moduleNames.push(i);
+			moduleNames.push( i );
 		}
 	}
 	numModules = moduleNames.length;
-	moduleNames.sort( function( a, b ) {
+	moduleNames.sort(function( a, b ) {
 		return a.localeCompare( b );
 	});
 	moduleFilterHtml += "<label for='qunit-modulefilter'>Module: </label><select id='qunit-modulefilter' name='modulefilter'><option value='' " +
-		( config.module === undefined  ? "selected='selected'" : "" ) +
+		( config.module === undefined ? "selected='selected'" : "" ) +
 		">< All Modules ></option>";
 
-
-	for ( i = 0; i < numModules; i++) {
-			moduleFilterHtml += "<option value='" + escapeText( encodeURIComponent(moduleNames[i]) ) + "' " +
-				( config.module === moduleNames[i] ? "selected='selected'" : "" ) +
-				">" + escapeText(moduleNames[i]) + "</option>";
+	for ( i = 0; i < numModules; i++ ) {
+		moduleFilterHtml += "<option value='" + escapeText( encodeURIComponent( moduleNames[ i ] ) ) + "' " +
+			( config.module === moduleNames[ i ] ? "selected='selected'" : "" ) +
+			">" + escapeText( moduleNames[ i ] ) + "</option>";
 	}
 	moduleFilterHtml += "</select>";
 
@@ -667,12 +668,13 @@ QUnit.load = function() {
 	// `banner` initialized at top of scope
 	banner = id( "qunit-header" );
 	if ( banner ) {
-		banner.innerHTML = "<a href='" + QUnit.url({ filter: undefined, module: undefined, testNumber: undefined }) + "'>" + banner.innerHTML + "</a> ";
+		banner.innerHTML = "<a href='" + QUnit.url( { filter: undefined, module: undefined, testNumber: undefined } ) + "'>" + banner.innerHTML + "</a> ";
 	}
 
 	// `toolbar` initialized at top of scope
 	toolbar = id( "qunit-testrunner-toolbar" );
 	if ( toolbar ) {
+
 		// `filter` initialized at top of scope
 		filter = document.createElement( "input" );
 		filter.type = "checkbox";
@@ -689,7 +691,7 @@ QUnit.load = function() {
 				ol.className = tmp.replace( / hidepass /, " " );
 			}
 			if ( defined.sessionStorage ) {
-				if (filter.checked) {
+				if ( filter.checked ) {
 					sessionStorage.setItem( "qunit-filter-passed-tests", "true" );
 				} else {
 					sessionStorage.removeItem( "qunit-filter-passed-tests" );
@@ -699,6 +701,7 @@ QUnit.load = function() {
 
 		if ( config.hidepassed || defined.sessionStorage && sessionStorage.getItem( "qunit-filter-passed-tests" ) ) {
 			filter.checked = true;
+
 			// `ol` initialized at top of scope
 			ol = id( "qunit-tests" );
 			ol.className = ol.className + " hidepass";
@@ -712,13 +715,14 @@ QUnit.load = function() {
 		label.innerHTML = "Hide passed tests";
 		toolbar.appendChild( label );
 
-		urlConfigContainer = document.createElement("span");
+		urlConfigContainer = document.createElement( "span" );
 		urlConfigContainer.innerHTML = urlConfigHtml;
+
 		// For oldIE support:
 		// * Add handlers to the individual elements instead of the container
 		// * Use "click" instead of "change" for checkboxes
 		// * Fallback from event.target to event.srcElement
-		addEvents( urlConfigContainer.getElementsByTagName("input"), "click", function( event ) {
+		addEvents( urlConfigContainer.getElementsByTagName( "input" ), "click", function( event ) {
 			var params = {},
 				target = event.target || event.srcElement;
 			params[ target.name ] = target.checked ?
@@ -726,7 +730,7 @@ QUnit.load = function() {
 				undefined;
 			window.location = QUnit.url( params );
 		});
-		addEvents( urlConfigContainer.getElementsByTagName("select"), "change", function( event ) {
+		addEvents( urlConfigContainer.getElementsByTagName( "select" ), "change", function( event ) {
 			var params = {},
 				target = event.target || event.srcElement;
 			params[ target.name ] = target.options[ target.selectedIndex ].value || undefined;
@@ -734,13 +738,13 @@ QUnit.load = function() {
 		});
 		toolbar.appendChild( urlConfigContainer );
 
-		if (numModules > 1) {
+		if ( numModules > 1 ) {
 			moduleFilter = document.createElement( "span" );
 			moduleFilter.setAttribute( "id", "qunit-modulefilter-container" );
 			moduleFilter.innerHTML = moduleFilterHtml;
 			addEvent( moduleFilter.lastChild, "change", function() {
-				var selectBox = moduleFilter.getElementsByTagName("select")[0],
-					selectedModule = decodeURIComponent(selectBox.options[selectBox.selectedIndex].value);
+				var selectBox = moduleFilter.getElementsByTagName( "select" )[ 0 ],
+					selectedModule = decodeURIComponent( selectBox.options[ selectBox.selectedIndex ].value );
 
 				window.location = QUnit.url({
 					module: ( selectedModule === "" ) ? undefined : selectedModule,
@@ -749,7 +753,7 @@ QUnit.load = function() {
 					testNumber: undefined
 				});
 			});
-			toolbar.appendChild(moduleFilter);
+			toolbar.appendChild( moduleFilter );
 		}
 	}
 
@@ -775,7 +779,7 @@ onErrorFnPrev = window.onerror;
 // Cover uncaught exceptions
 // Returning true will suppress the default browser handler,
 // returning false will let it run.
-window.onerror = function ( error, filePath, linerNr ) {
+window.onerror = function( error, filePath, linerNr ) {
 	var ret = false;
 	if ( onErrorFnPrev ) {
 		ret = onErrorFnPrev( error, filePath, linerNr );
@@ -790,7 +794,7 @@ window.onerror = function ( error, filePath, linerNr ) {
 			}
 			QUnit.pushFailure( error, filePath + ":" + linerNr );
 		} else {
-			QUnit.test( "global failure", extend( function() {
+			QUnit.test( "global failure", extend(function() {
 				QUnit.pushFailure( error, filePath + ":" + linerNr );
 			}, { validTest: validTest } ) );
 		}
@@ -841,6 +845,7 @@ function done() {
 	}
 
 	if ( config.altertitle && defined.document && document.title ) {
+
 		// show ✖ for good, ✔ for bad suite result in title
 		// use escape sequences in case file gets loaded with non-utf-8-charset
 		document.title = [
@@ -851,6 +856,7 @@ function done() {
 
 	// clear own sessionStorage items if all tests passed
 	if ( config.reorder && defined.sessionStorage && config.stats.bad === 0 ) {
+
 		// `key` & `i` initialized at top of scope
 		for ( i = 0; i < sessionStorage.length; i++ ) {
 			key = sessionStorage.key( i++ );
@@ -862,7 +868,7 @@ function done() {
 
 	// scroll back to top to show results
 	if ( config.scrolltop && window.scrollTo ) {
-		window.scrollTo(0, 0);
+		window.scrollTo( 0, 0 );
 	}
 
 	runLoggingCallbacks( "done", QUnit, {
@@ -923,12 +929,14 @@ function extractStacktrace( e, offset ) {
 	var stack, include, i;
 
 	if ( e.stacktrace ) {
+
 		// Opera
 		return e.stacktrace.split( "\n" )[ offset + 3 ];
 	} else if ( e.stack ) {
+
 		// Firefox, Chrome
 		stack = e.stack.split( "\n" );
-		if (/^error$/i.test( stack[0] ) ) {
+		if ( /^error$/i.test( stack[ 0 ] ) ) {
 			stack.shift();
 		}
 		if ( fileName ) {
@@ -945,12 +953,14 @@ function extractStacktrace( e, offset ) {
 		}
 		return stack[ offset ];
 	} else if ( e.sourceURL ) {
+
 		// Safari, PhantomJS
 		// hopefully one day Safari provides actual stacktraces
 		// exclude useless self-reference for generated Error objects
 		if ( /qunit.js$/.test( e.sourceURL ) ) {
 			return;
 		}
+
 		// for actual exceptions, this is useful
 		return e.sourceURL + ":" + e.line;
 	}
@@ -971,9 +981,10 @@ function escapeText( s ) {
 		return "";
 	}
 	s = s + "";
+
 	// Both single quotes and double quotes (for attributes)
 	return s.replace( /['"<>&]/g, function( s ) {
-		switch( s ) {
+		switch ( s ) {
 			case "'":
 				return "&#039;";
 			case "\"":
@@ -1042,12 +1053,12 @@ function checkPollution() {
 
 	newGlobals = diff( config.pollution, old );
 	if ( newGlobals.length > 0 ) {
-		QUnit.pushFailure( "Introduced global variable(s): " + newGlobals.join(", ") );
+		QUnit.pushFailure( "Introduced global variable(s): " + newGlobals.join( ", " ) );
 	}
 
 	deletedGlobals = diff( old, config.pollution );
 	if ( deletedGlobals.length > 0 ) {
-		QUnit.pushFailure( "Deleted global variable(s): " + deletedGlobals.join(", ") );
+		QUnit.pushFailure( "Deleted global variable(s): " + deletedGlobals.join( ", " ) );
 	}
 }
 
@@ -1058,7 +1069,7 @@ function diff( a, b ) {
 
 	for ( i = 0; i < result.length; i++ ) {
 		for ( j = 0; j < b.length; j++ ) {
-			if ( result[i] === b[j] ) {
+			if ( result[ i ] === b[ j ] ) {
 				result.splice( i, 1 );
 				i--;
 				break;
@@ -1071,6 +1082,7 @@ function diff( a, b ) {
 function extend( a, b ) {
 	for ( var prop in b ) {
 		if ( hasOwn.call( b, prop ) ) {
+
 			// Avoid "Member not found" error in IE8 caused by messing with window.constructor
 			if ( !( prop === "constructor" && a === window ) ) {
 				if ( b[ prop ] === undefined ) {
@@ -1114,28 +1126,30 @@ function addEvent( elem, type, fn ) {
 function addEvents( elems, type, fn ) {
 	var i = elems.length;
 	while ( i-- ) {
-		addEvent( elems[i], type, fn );
+		addEvent( elems[ i ], type, fn );
 	}
 }
 
 function hasClass( elem, name ) {
-	return (" " + elem.className + " ").indexOf(" " + name + " ") > -1;
+	return ( " " + elem.className + " " ).indexOf( " " + name + " " ) > -1;
 }
 
 function addClass( elem, name ) {
 	if ( !hasClass( elem, name ) ) {
-		elem.className += (elem.className ? " " : "") + name;
+		elem.className += ( elem.className ? " " : "" ) + name;
 	}
 }
 
 function removeClass( elem, name ) {
 	var set = " " + elem.className + " ";
+
 	// Class name may appear multiple times
-	while ( set.indexOf(" " + name + " ") > -1 ) {
-		set = set.replace(" " + name + " " , " ");
+	while ( set.indexOf( " " + name + " " ) > -1 ) {
+		set = set.replace( " " + name + " ", " " );
 	}
+
 	// If possible, trim it for prettiness, but not necessarily
-	elem.className = typeof set.trim === "function" ? set.trim() : set.replace(/^\s+|\s+$/g, "");
+	elem.className = typeof set.trim === "function" ? set.trim() : set.replace( /^\s+|\s+$/g, "" );
 }
 
 function id( name ) {
@@ -1144,7 +1158,7 @@ function id( name ) {
 
 function registerLoggingCallback( key ) {
 	return function( callback ) {
-		config[key].push( callback );
+		config[ key ].push( callback );
 	};
 }
 
@@ -1152,7 +1166,7 @@ function registerLoggingCallback( key ) {
 function runLoggingCallbacks( key, scope, args ) {
 	var i, callbacks;
 	if ( QUnit.hasOwnProperty( key ) ) {
-		QUnit[ key ].call(scope, args );
+		QUnit[ key ].call( scope, args );
 	} else {
 		callbacks = config[ key ];
 		for ( i = 0; i < callbacks.length; i++ ) {

--- a/src/diff.js
+++ b/src/diff.js
@@ -20,65 +20,65 @@ QUnit.diff = (function() {
 			os = {};
 
 		for ( i = 0; i < n.length; i++ ) {
-			if ( !hasOwn.call( ns, n[i] ) ) {
-				ns[ n[i] ] = {
+			if ( !hasOwn.call( ns, n[ i ] ) ) {
+				ns[ n[ i ] ] = {
 					rows: [],
 					o: null
 				};
 			}
-			ns[ n[i] ].rows.push( i );
+			ns[ n[ i ] ].rows.push( i );
 		}
 
 		for ( i = 0; i < o.length; i++ ) {
-			if ( !hasOwn.call( os, o[i] ) ) {
-				os[ o[i] ] = {
+			if ( !hasOwn.call( os, o[ i ] ) ) {
+				os[ o[ i ] ] = {
 					rows: [],
 					n: null
 				};
 			}
-			os[ o[i] ].rows.push( i );
+			os[ o[ i ] ].rows.push( i );
 		}
 
 		for ( i in ns ) {
 			if ( hasOwn.call( ns, i ) ) {
-				if ( ns[i].rows.length === 1 && hasOwn.call( os, i ) && os[i].rows.length === 1 ) {
-					n[ ns[i].rows[0] ] = {
-						text: n[ ns[i].rows[0] ],
-						row: os[i].rows[0]
+				if ( ns[ i ].rows.length === 1 && hasOwn.call( os, i ) && os[ i ].rows.length === 1 ) {
+					n[ ns[ i ].rows[ 0 ] ] = {
+						text: n[ ns[ i ].rows[ 0 ] ],
+						row: os[ i ].rows[ 0 ]
 					};
-					o[ os[i].rows[0] ] = {
-						text: o[ os[i].rows[0] ],
-						row: ns[i].rows[0]
+					o[ os[ i ].rows[ 0 ] ] = {
+						text: o[ os[ i ].rows[ 0 ] ],
+						row: ns[ i ].rows[ 0 ]
 					};
 				}
 			}
 		}
 
 		for ( i = 0; i < n.length - 1; i++ ) {
-			if ( n[i].text != null && n[ i + 1 ].text == null && n[i].row + 1 < o.length && o[ n[i].row + 1 ].text == null &&
-						n[ i + 1 ] == o[ n[i].row + 1 ] ) {
+			if ( n[ i ].text != null && n[ i + 1 ].text == null && n[ i ].row + 1 < o.length && o[ n[ i ].row + 1 ].text == null &&
+				n[ i + 1 ] == o[ n[ i ].row + 1 ] ) {
 
 				n[ i + 1 ] = {
 					text: n[ i + 1 ],
-					row: n[i].row + 1
+					row: n[ i ].row + 1
 				};
-				o[ n[i].row + 1 ] = {
-					text: o[ n[i].row + 1 ],
+				o[ n[ i ].row + 1 ] = {
+					text: o[ n[ i ].row + 1 ],
 					row: i + 1
 				};
 			}
 		}
 
 		for ( i = n.length - 1; i > 0; i-- ) {
-			if ( n[i].text != null && n[ i - 1 ].text == null && n[i].row > 0 && o[ n[i].row - 1 ].text == null &&
-						n[ i - 1 ] == o[ n[i].row - 1 ]) {
+			if ( n[ i ].text != null && n[ i - 1 ].text == null && n[ i ].row > 0 && o[ n[ i ].row - 1 ].text == null &&
+				n[ i - 1 ] == o[ n[ i ].row - 1 ] ) {
 
 				n[ i - 1 ] = {
 					text: n[ i - 1 ],
-					row: n[i].row - 1
+					row: n[ i ].row - 1
 				};
-				o[ n[i].row - 1 ] = {
-					text: o[ n[i].row - 1 ],
+				o[ n[ i ].row - 1 ] = {
+					text: o[ n[ i ].row - 1 ],
 					row: i - 1
 				};
 			}
@@ -96,48 +96,45 @@ QUnit.diff = (function() {
 
 		var i, pre,
 			str = "",
-			out = diff( o === "" ? [] : o.split(/\s+/), n === "" ? [] : n.split(/\s+/) ),
-			oSpace = o.match(/\s+/g),
-			nSpace = n.match(/\s+/g);
+			out = diff( o === "" ? [] : o.split( /\s+/ ), n === "" ? [] : n.split( /\s+/ ) ),
+			oSpace = o.match( /\s+/g ),
+			nSpace = n.match( /\s+/g );
 
 		if ( oSpace == null ) {
 			oSpace = [ " " ];
-		}
-		else {
+		} else {
 			oSpace.push( " " );
 		}
 
 		if ( nSpace == null ) {
 			nSpace = [ " " ];
-		}
-		else {
+		} else {
 			nSpace.push( " " );
 		}
 
 		if ( out.n.length === 0 ) {
 			for ( i = 0; i < out.o.length; i++ ) {
-				str += "<del>" + out.o[i] + oSpace[i] + "</del>";
+				str += "<del>" + out.o[ i ] + oSpace[ i ] + "</del>";
 			}
-		}
-		else {
-			if ( out.n[0].text == null ) {
-				for ( n = 0; n < out.o.length && out.o[n].text == null; n++ ) {
-					str += "<del>" + out.o[n] + oSpace[n] + "</del>";
+		} else {
+			if ( out.n[ 0 ].text == null ) {
+				for ( n = 0; n < out.o.length && out.o[ n ].text == null; n++ ) {
+					str += "<del>" + out.o[ n ] + oSpace[ n ] + "</del>";
 				}
 			}
 
 			for ( i = 0; i < out.n.length; i++ ) {
-				if (out.n[i].text == null) {
-					str += "<ins>" + out.n[i] + nSpace[i] + "</ins>";
-				}
-				else {
+				if ( out.n[ i ].text == null ) {
+					str += "<ins>" + out.n[ i ] + nSpace[ i ] + "</ins>";
+				} else {
+					
 					// `pre` initialized at top of scope
 					pre = "";
 
-					for ( n = out.n[i].row + 1; n < out.o.length && out.o[n].text == null; n++ ) {
-						pre += "<del>" + out.o[n] + oSpace[n] + "</del>";
+					for ( n = out.n[ i ].row + 1; n < out.o.length && out.o[ n ].text == null; n++ ) {
+						pre += "<del>" + out.o[ n ] + oSpace[ n ] + "</del>";
 					}
-					str += " " + out.n[i].text + nSpace[i] + pre;
+					str += " " + out.n[ i ].text + nSpace[ i ] + pre;
 				}
 			}
 		}

--- a/src/dump.js
+++ b/src/dump.js
@@ -18,20 +18,21 @@ QUnit.jsDump = (function() {
 	function join( pre, arr, post ) {
 		var s = jsDump.separator(),
 			base = jsDump.indent(),
-			inner = jsDump.indent(1);
+			inner = jsDump.indent( 1 );
 		if ( arr.join ) {
 			arr = arr.join( "," + s + inner );
 		}
 		if ( !arr ) {
 			return pre + post;
 		}
-		return [ pre, inner + arr, base + post ].join(s);
+		return [ pre, inner + arr, base + post ].join( s );
 	}
 	function array( arr, stack ) {
-		var i = arr.length, ret = new Array(i);
+		var i = arr.length,
+			ret = new Array( i );
 		this.up();
 		while ( i-- ) {
-			ret[i] = this.parse( arr[i] , undefined , stack);
+			ret[ i ] = this.parse( arr[ i ], undefined, stack );
 		}
 		this.down();
 		return join( "[", ret, "]" );
@@ -41,17 +42,17 @@ QUnit.jsDump = (function() {
 		jsDump = {
 			// type is used mostly internally, you can fix a (custom)type in advance
 			parse: function( obj, type, stack ) {
-				stack = stack || [ ];
+				stack = stack || [];
 				var inStack, res,
-					parser = this.parsers[ type || this.typeOf(obj) ];
+					parser = this.parsers[ type || this.typeOf( obj ) ];
 
 				type = typeof parser;
 				inStack = inArray( obj, stack );
 
 				if ( inStack !== -1 ) {
-					return "recursion(" + (inStack - stack.length) + ")";
+					return "recursion(" + ( inStack - stack.length ) + ")";
 				}
-				if ( type === "function" )  {
+				if ( type === "function" ) {
 					stack.push( obj );
 					res = parser.call( this, obj, stack );
 					stack.pop();
@@ -65,11 +66,11 @@ QUnit.jsDump = (function() {
 					type = "null";
 				} else if ( typeof obj === "undefined" ) {
 					type = "undefined";
-				} else if ( QUnit.is( "regexp", obj) ) {
+				} else if ( QUnit.is( "regexp", obj ) ) {
 					type = "regexp";
-				} else if ( QUnit.is( "date", obj) ) {
+				} else if ( QUnit.is( "date", obj ) ) {
 					type = "date";
-				} else if ( QUnit.is( "function", obj) ) {
+				} else if ( QUnit.is( "function", obj ) ) {
 					type = "function";
 				} else if ( typeof obj.setInterval !== undefined && typeof obj.document !== "undefined" && typeof obj.nodeType === "undefined" ) {
 					type = "window";
@@ -78,10 +79,12 @@ QUnit.jsDump = (function() {
 				} else if ( obj.nodeType ) {
 					type = "node";
 				} else if (
+
 					// native arrays
 					toString.call( obj ) === "[object Array]" ||
+
 					// NodeList objects
-					( typeof obj.length === "number" && typeof obj.item !== "undefined" && ( obj.length ? obj.item(0) === obj[0] : ( obj.item( 0 ) === null && typeof obj[0] === "undefined" ) ) )
+					( typeof obj.length === "number" && typeof obj.item !== "undefined" && ( obj.length ? obj.item( 0 ) === obj[ 0 ] : ( obj.item( 0 ) === null && typeof obj[ 0 ] === "undefined" ) ) )
 				) {
 					type = "array";
 				} else if ( obj.constructor === Error.prototype.constructor ) {
@@ -92,7 +95,7 @@ QUnit.jsDump = (function() {
 				return type;
 			},
 			separator: function() {
-				return this.multiline ?	this.HTML ? "<br />" : "\n" : this.HTML ? "&nbsp;" : " ";
+				return this.multiline ? this.HTML ? "<br />" : "\n" : this.HTML ? "&nbsp;" : " ";
 			},
 			// extra can be a number, shortcut for increasing-calling-decreasing
 			indent: function( extra ) {
@@ -103,7 +106,7 @@ QUnit.jsDump = (function() {
 				if ( this.HTML ) {
 					chr = chr.replace( /\t/g, "   " ).replace( / /g, "&nbsp;" );
 				}
-				return new Array( this.depth + ( extra || 0 ) ).join(chr);
+				return new Array( this.depth + ( extra || 0 ) ).join( chr );
 			},
 			up: function( a ) {
 				this.depth += a || 1;
@@ -112,7 +115,7 @@ QUnit.jsDump = (function() {
 				this.depth -= a || 1;
 			},
 			setParser: function( name, parser ) {
-				this.parsers[name] = parser;
+				this.parsers[ name ] = parser;
 			},
 			// The next 3 are exposed so you can use them
 			quote: quote,
@@ -124,7 +127,7 @@ QUnit.jsDump = (function() {
 			parsers: {
 				window: "[Window]",
 				document: "[Document]",
-				error: function(error) {
+				error: function( error ) {
 					return "Error(\"" + error.message + "\")";
 				},
 				unknown: "[Unknown]",
@@ -133,7 +136,7 @@ QUnit.jsDump = (function() {
 				"function": function( fn ) {
 					var ret = "function",
 						// functions never have name in IE
-						name = "name" in fn ? fn.name : (reName.exec(fn) || [])[1];
+						name = "name" in fn ? fn.name : ( reName.exec( fn ) || [] )[ 1 ];
 
 					if ( name ) {
 						ret += " " + name;
@@ -141,14 +144,14 @@ QUnit.jsDump = (function() {
 					ret += "( ";
 
 					ret = [ ret, QUnit.jsDump.parse( fn, "functionArgs" ), "){" ].join( "" );
-					return join( ret, QUnit.jsDump.parse(fn,"functionCode" ), "}" );
+					return join( ret, QUnit.jsDump.parse( fn, "functionCode" ), "}" );
 				},
 				array: array,
 				nodelist: array,
 				"arguments": array,
 				object: function( map, stack ) {
 					/*jshint forin:false */
-					var ret = [ ], keys, key, val, i;
+					var ret = [], keys, key, val, i;
 					QUnit.jsDump.up();
 					keys = [];
 					for ( key in map ) {
@@ -173,11 +176,12 @@ QUnit.jsDump = (function() {
 
 					if ( attrs ) {
 						for ( i = 0, len = attrs.length; i < len; i++ ) {
-							val = attrs[i].nodeValue;
+							val = attrs[ i ].nodeValue;
+
 							// IE6 includes all attributes in .attributes, even ones not explicitly set.
 							// Those have values like undefined, null, 0, false, "" or "inherit".
 							if ( val && val !== "inherit" ) {
-								ret += " " + attrs[i].nodeName + "=" + QUnit.jsDump.parse( val, "attribute" );
+								ret += " " + attrs[ i ].nodeName + "=" + QUnit.jsDump.parse( val, "attribute" );
 							}
 						}
 					}
@@ -190,6 +194,7 @@ QUnit.jsDump = (function() {
 
 					return ret + open + "/" + tag + close;
 				},
+
 				// function calls it internally, it's the arguments part of the function
 				functionArgs: function( fn ) {
 					var args,
@@ -199,10 +204,11 @@ QUnit.jsDump = (function() {
 						return "";
 					}
 
-					args = new Array(l);
+					args = new Array( l );
 					while ( l-- ) {
+
 						// 97 is 'a'
-						args[l] = String.fromCharCode(97+l);
+						args[ l ] = String.fromCharCode( 97 + l );
 					}
 					return " " + args.join( ", " ) + " ";
 				},

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -16,22 +16,26 @@ QUnit.equiv = (function() {
 
 	// the real equiv function
 	var innerEquiv,
+
 		// stack to decide between skip/abort functions
 		callers = [],
+
 		// stack to avoiding loops from circular referencing
 		parents = [],
 		parentsB = [],
 
-		getProto = Object.getPrototypeOf || function ( obj ) {
+		getProto = Object.getPrototypeOf || function( obj ) {
 			/* jshint camelcase: false, proto: true */
 			return obj.__proto__;
 		},
-		callbacks = (function () {
+		callbacks = (function() {
 
 			// for string, boolean, number and null
 			function useStrictEquality( b, a ) {
+
 				/*jshint eqeqeq:false */
 				if ( b instanceof a.constructor || a instanceof b.constructor ) {
+
 					// to catch short annotation VS 'new' annotation of a
 					// declaration
 					// e.g. var i = 1;
@@ -59,10 +63,13 @@ QUnit.equiv = (function() {
 
 				"regexp": function( b, a ) {
 					return QUnit.objectType( b ) === "regexp" &&
+
 						// the regex itself
 						a.source === b.source &&
+
 						// and its modifiers
 						a.global === b.global &&
+
 						// (gmi) ...
 						a.ignoreCase === b.ignoreCase &&
 						a.multiline === b.multiline &&
@@ -73,7 +80,7 @@ QUnit.equiv = (function() {
 				// - abort otherwise,
 				// initial === would have catch identical references anyway
 				"function": function() {
-					var caller = callers[callers.length - 1];
+					var caller = callers[ callers.length - 1 ];
 					return caller !== Object && typeof caller !== "undefined";
 				},
 
@@ -97,10 +104,10 @@ QUnit.equiv = (function() {
 					for ( i = 0; i < len; i++ ) {
 						loop = false;
 						for ( j = 0; j < parents.length; j++ ) {
-							aCircular = parents[j] === a[i];
-							bCircular = parentsB[j] === b[i];
+							aCircular = parents[ j ] === a[ i ];
+							bCircular = parentsB[ j ] === b[ i ];
 							if ( aCircular || bCircular ) {
-								if ( a[i] === b[i] || aCircular && bCircular ) {
+								if ( a[ i ] === b[ i ] || aCircular && bCircular ) {
 									loop = true;
 								} else {
 									parents.pop();
@@ -109,7 +116,7 @@ QUnit.equiv = (function() {
 								}
 							}
 						}
-						if ( !loop && !innerEquiv(a[i], b[i]) ) {
+						if ( !loop && !innerEquiv( a[ i ], b[ i ] ) ) {
 							parents.pop();
 							parentsB.pop();
 							return false;
@@ -121,6 +128,7 @@ QUnit.equiv = (function() {
 				},
 
 				"object": function( b, a ) {
+
 					/*jshint forin:false */
 					var i, j, loop, aCircular, bCircular,
 						// Default to true
@@ -131,11 +139,12 @@ QUnit.equiv = (function() {
 					// comparing constructors is more strict than using
 					// instanceof
 					if ( a.constructor !== b.constructor ) {
+
 						// Allow objects with no prototype to be equivalent to
 						// objects with Object as their constructor.
-						if ( !(( getProto(a) === null && getProto(b) === Object.prototype ) ||
-							( getProto(b) === null && getProto(a) === Object.prototype ) ) ) {
-								return false;
+						if ( !( ( getProto( a ) === null && getProto( b ) === Object.prototype ) ||
+							( getProto( b ) === null && getProto( a ) === Object.prototype ) ) ) {
+							return false;
 						}
 					}
 
@@ -150,10 +159,10 @@ QUnit.equiv = (function() {
 					for ( i in a ) {
 						loop = false;
 						for ( j = 0; j < parents.length; j++ ) {
-							aCircular = parents[j] === a[i];
-							bCircular = parentsB[j] === b[i];
+							aCircular = parents[ j ] === a[ i ];
+							bCircular = parentsB[ j ] === b[ i ];
 							if ( aCircular || bCircular ) {
-								if ( a[i] === b[i] || aCircular && bCircular ) {
+								if ( a[ i ] === b[ i ] || aCircular && bCircular ) {
 									loop = true;
 								} else {
 									eq = false;
@@ -161,8 +170,8 @@ QUnit.equiv = (function() {
 								}
 							}
 						}
-						aProperties.push(i);
-						if ( !loop && !innerEquiv(a[i], b[i]) ) {
+						aProperties.push( i );
+						if ( !loop && !innerEquiv( a[ i ], b[ i ] ) ) {
 							eq = false;
 							break;
 						}
@@ -188,19 +197,21 @@ QUnit.equiv = (function() {
 			return true; // end transition
 		}
 
-		return (function( a, b ) {
+		return ( function( a, b ) {
 			if ( a === b ) {
 				return true; // catch the most you can
 			} else if ( a === null || b === null || typeof a === "undefined" ||
 					typeof b === "undefined" ||
-					QUnit.objectType(a) !== QUnit.objectType(b) ) {
-				return false; // don't lose time with error prone cases
+					QUnit.objectType( a ) !== QUnit.objectType( b ) ) {
+
+				// don't lose time with error prone cases
+				return false;
 			} else {
-				return bindCallbacks(a, callbacks, [ b, a ]);
+				return bindCallbacks( a, callbacks, [ b, a ] );
 			}
 
 			// apply transition with (1..n) arguments
-		}( args[0], args[1] ) && innerEquiv.apply( this, args.splice(1, args.length - 1 )) );
+		}( args[ 0 ], args[ 1 ] ) && innerEquiv.apply( this, args.splice( 1, args.length - 1 ) ) );
 	};
 
 	return innerEquiv;

--- a/src/test.js
+++ b/src/test.js
@@ -18,7 +18,7 @@ Test.prototype = {
 			// `a` initialized at top of scope
 			a = document.createElement( "a" );
 			a.innerHTML = "Rerun";
-			a.href = QUnit.url({ testNumber: this.testNumber });
+			a.href = QUnit.url( { testNumber: this.testNumber } );
 
 			li = document.createElement( "li" );
 			li.appendChild( b );
@@ -31,8 +31,10 @@ Test.prototype = {
 	},
 	setup: function() {
 		if (
+
 			// Emit moduleStart when we're switching from one module to another
 			this.module !== config.previousModule ||
+
 				// They could be equal (both undefined) but if the previousModule property doesn't
 				// yet exist it means this is the first test in a suite that isn't wrapped in a
 				// module, in which case we'll just emit a moduleStart event for 'undefined'.
@@ -69,7 +71,6 @@ Test.prototype = {
 
 		/*jshint camelcase:false */
 
-
 		/**
 		 * Expose the current test environment.
 		 *
@@ -88,7 +89,7 @@ Test.prototype = {
 		}
 		try {
 			this.testEnvironment.setup.call( this.testEnvironment, QUnit.assert );
-		} catch( e ) {
+		} catch ( e ) {
 			QUnit.pushFailure( "Setup failed on " + this.testName + ": " + ( e.message || e ), extractStacktrace( e, 1 ) );
 		}
 	},
@@ -116,10 +117,11 @@ Test.prototype = {
 		try {
 			this.callback.call( this.testEnvironment, QUnit.assert );
 			this.callbackRuntime = now() - this.callbackStarted;
-		} catch( e ) {
+		} catch ( e ) {
 			this.callbackRuntime = now() - this.callbackStarted;
 
-			QUnit.pushFailure( "Died on test #" + (this.assertions.length + 1) + " " + this.stack + ": " + ( e.message || e ), extractStacktrace( e, 0 ) );
+			QUnit.pushFailure( "Died on test #" + ( this.assertions.length + 1 ) + " " + this.stack + ": " + ( e.message || e ), extractStacktrace( e, 0 ) );
+
 			// else next test will carry the responsibility
 			saveGlobal();
 
@@ -140,7 +142,7 @@ Test.prototype = {
 		} else {
 			try {
 				this.testEnvironment.teardown.call( this.testEnvironment, QUnit.assert );
-			} catch( e ) {
+			} catch ( e ) {
 				QUnit.pushFailure( "Teardown failed on " + this.testName + ": " + ( e.message || e ), extractStacktrace( e, 1 ) );
 			}
 		}
@@ -171,7 +173,7 @@ Test.prototype = {
 			ol.className = "qunit-assert-list";
 
 			for ( i = 0; i < this.assertions.length; i++ ) {
-				assertion = this.assertions[i];
+				assertion = this.assertions[ i ];
 
 				li = document.createElement( "li" );
 				li.className = assertion.result ? "pass" : "fail";
@@ -204,19 +206,19 @@ Test.prototype = {
 			b = document.createElement( "strong" );
 			b.innerHTML = this.nameHtml + " <b class='counts'>(<b class='failed'>" + bad + "</b>, <b class='passed'>" + good + "</b>, " + this.assertions.length + ")</b>";
 
-			addEvent(b, "click", function() {
+			addEvent( b, "click", function() {
 				var next = b.parentNode.lastChild,
 					collapsed = hasClass( next, "qunit-collapsed" );
 				( collapsed ? removeClass : addClass )( next, "qunit-collapsed" );
 			});
 
-			addEvent(b, "dblclick", function( e ) {
+			addEvent( b, "dblclick", function( e ) {
 				var target = e && e.target ? e.target : window.event.srcElement;
 				if ( target.nodeName.toLowerCase() === "span" || target.nodeName.toLowerCase() === "b" ) {
 					target = target.parentNode;
 				}
 				if ( window.location && target.nodeName.toLowerCase() === "strong" ) {
-					window.location = QUnit.url({ testNumber: test.testNumber });
+					window.location = QUnit.url( { testNumber: test.testNumber } );
 				}
 			});
 
@@ -234,10 +236,9 @@ Test.prototype = {
 			li.appendChild( a );
 			li.appendChild( time );
 			li.appendChild( ol );
-
 		} else {
 			for ( i = 0; i < this.assertions.length; i++ ) {
-				if ( !this.assertions[i].result ) {
+				if ( !this.assertions[ i ].result ) {
 					bad++;
 					config.stats.bad++;
 					config.moduleStats.bad++;
@@ -252,6 +253,7 @@ Test.prototype = {
 			passed: this.assertions.length - bad,
 			total: this.assertions.length,
 			runtime: this.runtime,
+
 			// DEPRECATED: this property will be removed in 2.0.0, use runtime instead
 			duration: this.runtime
 		});
@@ -287,7 +289,7 @@ Test.prototype = {
 		// `bad` initialized at top of scope
 		// defer when previous test run passed, if storage is available
 		bad = QUnit.config.reorder && defined.sessionStorage &&
-						+sessionStorage.getItem( "qunit-test-" + this.module + "-" + this.testName );
+				+sessionStorage.getItem( "qunit-test-" + this.module + "-" + this.testName );
 
 		if ( bad ) {
 			run();

--- a/test/async.js
+++ b/test/async.js
@@ -1,6 +1,6 @@
 QUnit.start();
 
-test("just a test", function( assert ) {
-	expect(1);
-	assert.ok(true);
+test( "just a test", function( assert ) {
+	expect( 1 );
+	assert.ok( true );
 });

--- a/test/deepEqual.js
+++ b/test/deepEqual.js
@@ -1,200 +1,202 @@
-QUnit.module("equiv");
+QUnit.module( "equiv" );
 
+test( "Primitive types and constants", function( assert ) {
+	assert.equal( QUnit.equiv( null, null ), true, "null" );
+	assert.equal( QUnit.equiv( null, {} ), false, "null" );
+	assert.equal( QUnit.equiv( null, undefined ), false, "null" );
+	assert.equal( QUnit.equiv( null, 0 ), false, "null" );
+	assert.equal( QUnit.equiv( null, false ), false, "null" );
+	assert.equal( QUnit.equiv( null, "" ), false, "null" );
+	assert.equal( QUnit.equiv( null, [] ), false, "null" );
 
-test("Primitive types and constants", function ( assert ) {
-	assert.equal(QUnit.equiv(null, null), true, "null");
-	assert.equal(QUnit.equiv(null, {}), false, "null");
-	assert.equal(QUnit.equiv(null, undefined), false, "null");
-	assert.equal(QUnit.equiv(null, 0), false, "null");
-	assert.equal(QUnit.equiv(null, false), false, "null");
-	assert.equal(QUnit.equiv(null, ""), false, "null");
-	assert.equal(QUnit.equiv(null, []), false, "null");
-
-	assert.equal(QUnit.equiv(undefined, undefined), true, "undefined");
-	assert.equal(QUnit.equiv(undefined, null), false, "undefined");
-	assert.equal(QUnit.equiv(undefined, 0), false, "undefined");
-	assert.equal(QUnit.equiv(undefined, false), false, "undefined");
-	assert.equal(QUnit.equiv(undefined, {}), false, "undefined");
-	assert.equal(QUnit.equiv(undefined, []), false, "undefined");
-	assert.equal(QUnit.equiv(undefined, ""), false, "undefined");
+	assert.equal( QUnit.equiv( undefined, undefined ), true, "undefined" );
+	assert.equal( QUnit.equiv( undefined, null ), false, "undefined" );
+	assert.equal( QUnit.equiv( undefined, 0 ), false, "undefined" );
+	assert.equal( QUnit.equiv( undefined, false ), false, "undefined" );
+	assert.equal( QUnit.equiv( undefined, {} ), false, "undefined" );
+	assert.equal( QUnit.equiv( undefined, [] ), false, "undefined" );
+	assert.equal( QUnit.equiv( undefined, "" ), false, "undefined" );
 
 	// Nan usually doest not equal to Nan using the '==' operator.
 	// Only isNaN() is able to do it.
-	assert.equal(QUnit.equiv(0/0, 0/0), true, "NaN"); // NaN VS NaN
-	assert.equal(QUnit.equiv(1/0, 2/0), true, "Infinity"); // Infinity VS Infinity
-	assert.equal(QUnit.equiv(-1/0, 2/0), false, "-Infinity, Infinity"); // -Infinity VS Infinity
-	assert.equal(QUnit.equiv(-1/0, -2/0), true, "-Infinity, -Infinity"); // -Infinity VS -Infinity
-	assert.equal(QUnit.equiv(0/0, 1/0), false, "NaN, Infinity"); // Nan VS Infinity
-	assert.equal(QUnit.equiv(1/0, 0/0), false, "NaN, Infinity"); // Nan VS Infinity
-	assert.equal(QUnit.equiv(0/0, null), false, "NaN");
-	assert.equal(QUnit.equiv(0/0, undefined), false, "NaN");
-	assert.equal(QUnit.equiv(0/0, 0), false, "NaN");
-	assert.equal(QUnit.equiv(0/0, false), false, "NaN");
-	assert.equal(QUnit.equiv(0/0, function () {}), false, "NaN");
-	assert.equal(QUnit.equiv(1/0, null), false, "NaN, Infinity");
-	assert.equal(QUnit.equiv(1/0, undefined), false, "NaN, Infinity");
-	assert.equal(QUnit.equiv(1/0, 0), false, "NaN, Infinity");
-	assert.equal(QUnit.equiv(1/0, 1), false, "NaN, Infinity");
-	assert.equal(QUnit.equiv(1/0, false), false, "NaN, Infinity");
-	assert.equal(QUnit.equiv(1/0, true), false, "NaN, Infinity");
-	assert.equal(QUnit.equiv(1/0, function () {}), false, "NaN, Infinity");
+	assert.equal( QUnit.equiv( 0 / 0, 0 / 0 ), true, "NaN" ); // NaN VS NaN
+	assert.equal( QUnit.equiv( 1 / 0, 2 / 0 ), true, "Infinity" ); // Infinity VS Infinity
+	assert.equal( QUnit.equiv( -1 / 0, 2 / 0 ), false, "-Infinity, Infinity" ); // -Infinity VS Infinity
+	assert.equal( QUnit.equiv( -1 / 0, -2 / 0 ), true, "-Infinity, -Infinity" ); // -Infinity VS -Infinity
+	assert.equal( QUnit.equiv( 0 / 0, 1 / 0 ), false, "NaN, Infinity" ); // Nan VS Infinity
+	assert.equal( QUnit.equiv( 1 / 0, 0 / 0 ), false, "NaN, Infinity" ); // Nan VS Infinity
+	assert.equal( QUnit.equiv( 0 / 0, null ), false, "NaN" );
+	assert.equal( QUnit.equiv( 0 / 0, undefined ), false, "NaN" );
+	assert.equal( QUnit.equiv( 0 / 0, 0 ), false, "NaN" );
+	assert.equal( QUnit.equiv( 0 / 0, false ), false, "NaN" );
+	assert.equal( QUnit.equiv( 0 / 0, function() {} ), false, "NaN" );
+	assert.equal( QUnit.equiv( 1 / 0, null ), false, "NaN, Infinity" );
+	assert.equal( QUnit.equiv( 1 / 0, undefined ), false, "NaN, Infinity" );
+	assert.equal( QUnit.equiv( 1 / 0, 0 ), false, "NaN, Infinity" );
+	assert.equal( QUnit.equiv( 1 / 0, 1 ), false, "NaN, Infinity" );
+	assert.equal( QUnit.equiv( 1 / 0, false ), false, "NaN, Infinity" );
+	assert.equal( QUnit.equiv( 1 / 0, true ), false, "NaN, Infinity" );
+	assert.equal( QUnit.equiv( 1 / 0, function() {} ), false, "NaN, Infinity" );
 
-	assert.equal(QUnit.equiv(0, 0), true, "number");
-	assert.equal(QUnit.equiv(0, 1), false, "number");
-	assert.equal(QUnit.equiv(1, 0), false, "number");
-	assert.equal(QUnit.equiv(1, 1), true, "number");
-	assert.equal(QUnit.equiv(1.1, 1.1), true, "number");
-	assert.equal(QUnit.equiv(0.0000005, 0.0000005), true, "number");
-	assert.equal(QUnit.equiv(0, ""), false, "number");
-	assert.equal(QUnit.equiv(0, "0"), false, "number");
-	assert.equal(QUnit.equiv(1, "1"), false, "number");
-	assert.equal(QUnit.equiv(0, false), false, "number");
-	assert.equal(QUnit.equiv(1, true), false, "number");
+	assert.equal( QUnit.equiv( 0, 0 ), true, "number" );
+	assert.equal( QUnit.equiv( 0, 1 ), false, "number" );
+	assert.equal( QUnit.equiv( 1, 0 ), false, "number" );
+	assert.equal( QUnit.equiv( 1, 1 ), true, "number" );
+	assert.equal( QUnit.equiv( 1.1, 1.1 ), true, "number" );
+	assert.equal( QUnit.equiv( 0.0000005, 0.0000005 ), true, "number" );
+	assert.equal( QUnit.equiv( 0, "" ), false, "number" );
+	assert.equal( QUnit.equiv( 0, "0" ), false, "number" );
+	assert.equal( QUnit.equiv( 1, "1" ), false, "number" );
+	assert.equal( QUnit.equiv( 0, false ), false, "number" );
+	assert.equal( QUnit.equiv( 1, true ), false, "number" );
 
-	assert.equal(QUnit.equiv(true, true), true, "boolean");
-	assert.equal(QUnit.equiv(true, false), false, "boolean");
-	assert.equal(QUnit.equiv(false, true), false, "boolean");
-	assert.equal(QUnit.equiv(false, 0), false, "boolean");
-	assert.equal(QUnit.equiv(false, null), false, "boolean");
-	assert.equal(QUnit.equiv(false, undefined), false, "boolean");
-	assert.equal(QUnit.equiv(true, 1), false, "boolean");
-	assert.equal(QUnit.equiv(true, null), false, "boolean");
-	assert.equal(QUnit.equiv(true, undefined), false, "boolean");
+	assert.equal( QUnit.equiv( true, true ), true, "boolean" );
+	assert.equal( QUnit.equiv( true, false ), false, "boolean" );
+	assert.equal( QUnit.equiv( false, true ), false, "boolean" );
+	assert.equal( QUnit.equiv( false, 0 ), false, "boolean" );
+	assert.equal( QUnit.equiv( false, null ), false, "boolean" );
+	assert.equal( QUnit.equiv( false, undefined ), false, "boolean" );
+	assert.equal( QUnit.equiv( true, 1 ), false, "boolean" );
+	assert.equal( QUnit.equiv( true, null ), false, "boolean" );
+	assert.equal( QUnit.equiv( true, undefined ), false, "boolean" );
 
-	assert.equal(QUnit.equiv("", ""), true, "string");
-	assert.equal(QUnit.equiv("a", "a"), true, "string");
-	assert.equal(QUnit.equiv("foobar", "foobar"), true, "string");
-	assert.equal(QUnit.equiv("foobar", "foo"), false, "string");
-	assert.equal(QUnit.equiv("", 0), false, "string");
-	assert.equal(QUnit.equiv("", false), false, "string");
-	assert.equal(QUnit.equiv("", null), false, "string");
-	assert.equal(QUnit.equiv("", undefined), false, "string");
+	assert.equal( QUnit.equiv( "", "" ), true, "string" );
+	assert.equal( QUnit.equiv( "a", "a" ), true, "string" );
+	assert.equal( QUnit.equiv( "foobar", "foobar" ), true, "string" );
+	assert.equal( QUnit.equiv( "foobar", "foo" ), false, "string" );
+	assert.equal( QUnit.equiv( "", 0 ), false, "string" );
+	assert.equal( QUnit.equiv( "", false ), false, "string" );
+	assert.equal( QUnit.equiv( "", null ), false, "string" );
+	assert.equal( QUnit.equiv( "", undefined ), false, "string" );
 
 	// Rename for lint validation.
 	// We know this is bad, we are asserting whether we can coop with bad code like this.
-	var SafeNumber = Number, SafeString = String, SafeBoolean = Boolean, SafeObject = Object;
+	var SafeNumber = Number,
+		SafeString = String,
+		SafeBoolean = Boolean,
+		SafeObject = Object;
 
 	// primitives vs. objects
 
-	assert.equal(QUnit.equiv(0, new SafeNumber()), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv(new SafeNumber(), 0), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv(1, new SafeNumber(1)), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv(new SafeNumber(1), 1), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv(new SafeNumber(0), 1), false, "primitives vs. objects");
-	assert.equal(QUnit.equiv(0, new SafeNumber(1)), false, "primitives vs. objects");
+	assert.equal( QUnit.equiv( 0, new SafeNumber() ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( new SafeNumber(), 0 ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( 1, new SafeNumber( 1 ) ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( new SafeNumber( 1 ), 1 ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( new SafeNumber( 0 ), 1 ), false, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( 0, new SafeNumber( 1 ) ), false, "primitives vs. objects" );
 
-	assert.equal(QUnit.equiv(new SafeString(), ""), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv("", new SafeString()), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv(new SafeString("My String"), "My String"), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv("My String", new SafeString("My String")), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv("Bad String", new SafeString("My String")), false, "primitives vs. objects");
-	assert.equal(QUnit.equiv(new SafeString("Bad String"), "My String"), false, "primitives vs. objects");
+	assert.equal( QUnit.equiv( new SafeString(), "" ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( "", new SafeString() ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( new SafeString( "My String" ), "My String" ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( "My String", new SafeString( "My String" ) ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( "Bad String", new SafeString( "My String" ) ), false, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( new SafeString( "Bad String" ), "My String" ), false, "primitives vs. objects" );
 
-	assert.equal(QUnit.equiv(false, new SafeBoolean()), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv(new SafeBoolean(), false), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv(true, new SafeBoolean(true)), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv(new SafeBoolean(true), true), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv(true, new SafeBoolean(1)), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv(false, new SafeBoolean(false)), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv(new SafeBoolean(false), false), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv(false, new SafeBoolean(0)), true, "primitives vs. objects");
-	assert.equal(QUnit.equiv(true, new SafeBoolean(false)), false, "primitives vs. objects");
-	assert.equal(QUnit.equiv(new SafeBoolean(false), true), false, "primitives vs. objects");
+	assert.equal( QUnit.equiv( false, new SafeBoolean() ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( new SafeBoolean(), false ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( true, new SafeBoolean( true ) ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( new SafeBoolean( true ), true ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( true, new SafeBoolean( 1 ) ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( false, new SafeBoolean( false ) ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( new SafeBoolean( false ), false ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( false, new SafeBoolean( 0 ) ), true, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( true, new SafeBoolean( false ) ), false, "primitives vs. objects" );
+	assert.equal( QUnit.equiv( new SafeBoolean( false ), true ), false, "primitives vs. objects" );
 
-	assert.equal(QUnit.equiv(new SafeObject(), {}), true, "object literal vs. instantiation");
-	assert.equal(QUnit.equiv({}, new SafeObject()), true, "object literal vs. instantiation");
-	assert.equal(QUnit.equiv(new SafeObject(), {a:1}), false, "object literal vs. instantiation");
-	assert.equal(QUnit.equiv({a:1}, new SafeObject()), false, "object literal vs. instantiation");
-	assert.equal(QUnit.equiv({a:undefined}, new SafeObject()), false, "object literal vs. instantiation");
-	assert.equal(QUnit.equiv(new SafeObject(), {a:undefined}), false, "object literal vs. instantiation");
+	assert.equal( QUnit.equiv( new SafeObject(), {} ), true, "object literal vs. instantiation" );
+	assert.equal( QUnit.equiv( {}, new SafeObject() ), true, "object literal vs. instantiation" );
+	assert.equal( QUnit.equiv( new SafeObject(), { a: 1 } ), false, "object literal vs. instantiation" );
+	assert.equal( QUnit.equiv( { a: 1 }, new SafeObject() ), false, "object literal vs. instantiation" );
+	assert.equal( QUnit.equiv( { a: undefined }, new SafeObject() ), false, "object literal vs. instantiation" );
+	assert.equal( QUnit.equiv( new SafeObject(), { a: undefined } ), false, "object literal vs. instantiation" );
 });
 
-test("Objects basics", function( assert ) {
-	assert.equal(QUnit.equiv({}, {}), true);
-	assert.equal(QUnit.equiv({}, null), false);
-	assert.equal(QUnit.equiv({}, undefined), false);
-	assert.equal(QUnit.equiv({}, 0), false);
-	assert.equal(QUnit.equiv({}, false), false);
+test( "Objects basics", function( assert ) {
+	assert.equal( QUnit.equiv( {}, {} ), true );
+	assert.equal( QUnit.equiv( {}, null ), false );
+	assert.equal( QUnit.equiv( {}, undefined ), false );
+	assert.equal( QUnit.equiv( {}, 0 ), false );
+	assert.equal( QUnit.equiv( {}, false ), false );
 
 	// This test is a hard one, it is very important
 	// REASONS:
 	//      1) They are of the same type "object"
 	//      2) [] instanceof Object is true
 	//      3) Their properties are the same (doesn't exists)
-	assert.equal(QUnit.equiv({}, []), false);
+	assert.equal( QUnit.equiv( {}, [] ), false );
 
-	assert.equal(QUnit.equiv({a:1}, {a:1}), true);
-	assert.equal(QUnit.equiv({a:1}, {a:"1"}), false);
-	assert.equal(QUnit.equiv({a:[]}, {a:[]}), true);
-	assert.equal(QUnit.equiv({a:{}}, {a:null}), false);
-	assert.equal(QUnit.equiv({a:1}, {}), false);
-	assert.equal(QUnit.equiv({}, {a:1}), false);
+	assert.equal( QUnit.equiv( { a: 1 }, { a: 1 } ), true );
+	assert.equal( QUnit.equiv( { a: 1 }, { a: "1" } ), false );
+	assert.equal( QUnit.equiv( { a: [] }, { a: [] } ), true );
+	assert.equal( QUnit.equiv( { a: {} }, { a: null } ), false );
+	assert.equal( QUnit.equiv( { a: 1 }, {} ), false );
+	assert.equal( QUnit.equiv( {}, { a: 1 } ), false );
 
 	// Hard ones
-	assert.equal(QUnit.equiv({a:undefined}, {}), false);
-	assert.equal(QUnit.equiv({}, {a:undefined}), false);
-	assert.equal(QUnit.equiv(
+	assert.equal( QUnit.equiv( { a: undefined }, {} ), false );
+	assert.equal( QUnit.equiv( {}, { a: undefined } ), false );
+	assert.equal( QUnit.equiv(
 		{
-			a: [{ bar: undefined }]
+			a: [ { bar: undefined } ]
 		},
 		{
-			a: [{ bat: undefined }]
+			a: [ { bat: undefined } ]
 		}
-	), false);
+	), false );
 
 	// Objects with no prototype, created via Object.create(null), are used e.g. as dictionaries.
 	// Being able to test equivalence against object literals is quite useful.
-	if (typeof Object.create === "function") {
-		assert.equal(QUnit.equiv(Object.create(null), {}), true, "empty object without prototype VS empty object");
+	if ( typeof Object.create === "function" ) {
+		assert.equal( QUnit.equiv( Object.create( null ), {} ), true, "empty object without prototype VS empty object" );
 
-		var nonEmptyWithNoProto = Object.create(null);
+		var nonEmptyWithNoProto = Object.create( null );
 		nonEmptyWithNoProto.foo = "bar";
 
-		assert.equal(QUnit.equiv(nonEmptyWithNoProto, { foo: "bar" }), true, "object without prototype VS object");
+		assert.equal( QUnit.equiv( nonEmptyWithNoProto, { foo: "bar" } ), true, "object without prototype VS object" );
 	}
 });
 
 
-test("Arrays basics", function( assert ) {
+test( "Arrays basics", function( assert ) {
 
-	assert.equal(QUnit.equiv([], []), true);
+	assert.equal( QUnit.equiv( [], [] ), true );
 
 	// May be a hard one, can invoke a crash at execution.
 	// because their types are both "object" but null isn't
 	// like a true object, it doesn't have any property at all.
-	assert.equal(QUnit.equiv([], null), false);
+	assert.equal( QUnit.equiv( [], null ), false );
 
-	assert.equal(QUnit.equiv([], undefined), false);
-	assert.equal(QUnit.equiv([], false), false);
-	assert.equal(QUnit.equiv([], 0), false);
-	assert.equal(QUnit.equiv([], ""), false);
+	assert.equal( QUnit.equiv( [], undefined ), false );
+	assert.equal( QUnit.equiv( [], false ), false );
+	assert.equal( QUnit.equiv( [], 0 ), false );
+	assert.equal( QUnit.equiv( [], "" ), false );
 
 	// May be a hard one, but less hard
 	// than {} with [] (note the order)
-	assert.equal(QUnit.equiv([], {}), false);
+	assert.equal( QUnit.equiv( [], {} ), false );
 
-	assert.equal(QUnit.equiv([null],[]), false);
-	assert.equal(QUnit.equiv([undefined],[]), false);
-	assert.equal(QUnit.equiv([],[null]), false);
-	assert.equal(QUnit.equiv([],[undefined]), false);
-	assert.equal(QUnit.equiv([null],[undefined]), false);
-	assert.equal(QUnit.equiv([[]],[[]]), true);
-	assert.equal(QUnit.equiv([[],[],[]],[[],[],[]]), true);
-	assert.equal(QUnit.equiv(
-							[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
-							[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]),
-							true);
-	assert.equal(QUnit.equiv(
-							[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
-							[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]), // shorter
-							false);
-	assert.equal(QUnit.equiv(
-							[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[{}]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
-							[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]), // deepest element not an array
-							false);
+	assert.equal( QUnit.equiv( [ null ], [] ), false );
+	assert.equal( QUnit.equiv( [ undefined ], [] ), false );
+	assert.equal( QUnit.equiv( [], [ null ] ), false );
+	assert.equal( QUnit.equiv( [], [ undefined ] ), false );
+	assert.equal( QUnit.equiv( [ null ], [ undefined ]), false );
+	assert.equal( QUnit.equiv( [ [] ], [ [] ] ), true );
+	assert.equal( QUnit.equiv( [ [], [], [] ], [ [], [], [] ] ), true );
+	assert.equal( QUnit.equiv(
+					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
+					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]),
+					true );
+	assert.equal( QUnit.equiv(
+					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
+					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]), // shorter
+					false );
+	assert.equal( QUnit.equiv(
+					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[{}]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
+					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]), // deepest element not an array
+					false );
 
 	// same multidimensional
-	assert.equal(QUnit.equiv(
+	assert.equal( QUnit.equiv(
 							[1,2,3,4,5,6,7,8,9, [
 								1,2,3,4,5,6,7,8,9, [
 									1,2,3,4,5,[
@@ -237,10 +239,10 @@ test("Arrays basics", function( assert ) {
 									]
 								]
 							]]]),
-							true, "Multidimensional");
+							true, "Multidimensional" );
 
 	// different multidimensional
-	assert.equal(QUnit.equiv(
+	assert.equal( QUnit.equiv(
 							[1,2,3,4,5,6,7,8,9, [
 								1,2,3,4,5,6,7,8,9, [
 									1,2,3,4,5,[
@@ -283,10 +285,10 @@ test("Arrays basics", function( assert ) {
 									]
 								]
 							]]]),
-							false, "Multidimensional");
+							false, "Multidimensional" );
 
 	// different multidimensional
-	assert.equal(QUnit.equiv(
+	assert.equal( QUnit.equiv(
 							[1,2,3,4,5,6,7,8,9, [
 								1,2,3,4,5,6,7,8,9, [
 									1,2,3,4,5,[
@@ -329,58 +331,62 @@ test("Arrays basics", function( assert ) {
 									]
 								]
 							]]]),
-							false, "Multidimensional");
+							false, "Multidimensional" );
 });
 
-test("Functions", function( assert ) {
-	var f0 = function () {},
-		f1 = function () {},
+test( "Functions", function( assert ) {
+	var f0 = function() {},
+		f1 = function() {},
 
-	// f2 and f3 have the same code, formatted differently
-		f2 = function () {return 0;},
-		f3 = function () {
+		// f2 and f3 have the same code, formatted differently
+		f2 = function() { return 0; },
+		f3 = function() {
+
 			/* jshint asi:true */
 			return 0 // this comment and no semicoma as difference
 		};
 
-	assert.equal(QUnit.equiv(function() {}, function() {}), false, "Anonymous functions"); // exact source code
-	assert.equal(QUnit.equiv(function() {}, function() {return true;}), false, "Anonymous functions");
+	assert.equal( QUnit.equiv( function() {}, function() {} ), false, "Anonymous functions" ); // exact source code
+	assert.equal( QUnit.equiv(function() {}, function() {
+		return true;
+	}), false, "Anonymous functions" );
 
-	assert.equal(QUnit.equiv(f0, f0), true, "Function references"); // same references
-	assert.equal(QUnit.equiv(f0, f1), false, "Function references"); // exact source code, different references
-	assert.equal(QUnit.equiv(f2, f3), false, "Function references"); // equivalent source code, different references
-	assert.equal(QUnit.equiv(f1, f2), false, "Function references"); // different source code, different references
-	assert.equal(QUnit.equiv(function() {}, true), false);
-	assert.equal(QUnit.equiv(function() {}, undefined), false);
-	assert.equal(QUnit.equiv(function() {}, null), false);
-	assert.equal(QUnit.equiv(function() {}, {}), false);
+	assert.equal( QUnit.equiv( f0, f0 ), true, "Function references" ); // same references
+	assert.equal( QUnit.equiv( f0, f1 ), false, "Function references" ); // exact source code, different references
+	assert.equal( QUnit.equiv( f2, f3 ), false, "Function references" ); // equivalent source code, different references
+	assert.equal( QUnit.equiv( f1, f2 ), false, "Function references" ); // different source code, different references
+	assert.equal( QUnit.equiv( function() {}, true ), false );
+	assert.equal( QUnit.equiv( function() {}, undefined ), false );
+	assert.equal( QUnit.equiv( function() {}, null ), false );
+	assert.equal( QUnit.equiv( function() {}, {} ), false );
 });
 
+test( "Date instances", function( assert ) {
 
-test("Date instances", function( assert ) {
 	// Date, we don't need to test Date.parse() because it returns a number.
 	// Only test the Date instances by setting them a fix date.
 	// The date use is midnight January 1, 1970
 	var d1, d2, d3;
 
 	d1 = new Date();
-	d1.setTime(0); // fix the date
+	d1.setTime( 0 ); // fix the date
 
 	d2 = new Date();
-	d2.setTime(0); // fix the date
+	d2.setTime( 0 ); // fix the date
 
 	d3 = new Date(); // The very now
 
 	// Anyway their types differs, just in case the code fails in the order in which it deals with date
-	assert.equal(QUnit.equiv(d1, 0), false); // d1.valueOf() returns 0, but d1 and 0 are different
+	assert.equal( QUnit.equiv( d1, 0 ), false ); // d1.valueOf() returns 0, but d1 and 0 are different
+
 	// test same values date and different instances equality
-	assert.equal(QUnit.equiv(d1, d2), true);
+	assert.equal( QUnit.equiv( d1, d2 ), true );
+
 	// test different date and different instances difference
-	assert.equal(QUnit.equiv(d1, d3), false);
+	assert.equal( QUnit.equiv( d1, d3 ), false );
 });
 
-
-test("RegExp", function( assert ) {
+test( "RegExp", function( assert ) {
 	// Must test cases that imply those traps:
 	// var a = /./;
 	// a instanceof Object;        // Oops
@@ -403,40 +409,40 @@ test("RegExp", function( assert ) {
 		rg1 = /foo/g,
 		rg2 = /foo/g;
 
-	assert.equal(QUnit.equiv(r2, r3), true, "Modifier order");
-	assert.equal(QUnit.equiv(r2, r4), true, "Modifier order");
-	assert.equal(QUnit.equiv(r2, r5), true, "Modifier order");
-	assert.equal(QUnit.equiv(r2, r6), true, "Modifier order");
-	assert.equal(QUnit.equiv(r2, r7), true, "Modifier order");
-	assert.equal(QUnit.equiv(r1, r2), false, "Modifier");
+	assert.equal( QUnit.equiv( r2, r3 ), true, "Modifier order" );
+	assert.equal( QUnit.equiv( r2, r4 ), true, "Modifier order" );
+	assert.equal( QUnit.equiv( r2, r5 ), true, "Modifier order" );
+	assert.equal( QUnit.equiv( r2, r6 ), true, "Modifier order" );
+	assert.equal( QUnit.equiv( r2, r7 ), true, "Modifier order" );
+	assert.equal( QUnit.equiv( r1, r2 ), false, "Modifier" );
 
-	assert.equal(QUnit.equiv(ri1, ri2), true, "Modifier");
-	assert.equal(QUnit.equiv(r1, ri1), false, "Modifier");
-	assert.equal(QUnit.equiv(ri1, rm1), false, "Modifier");
-	assert.equal(QUnit.equiv(r1, rm1), false, "Modifier");
-	assert.equal(QUnit.equiv(rm1, ri1), false, "Modifier");
-	assert.equal(QUnit.equiv(rm1, rm2), true, "Modifier");
-	assert.equal(QUnit.equiv(rg1, rm1), false, "Modifier");
-	assert.equal(QUnit.equiv(rm1, rg1), false, "Modifier");
-	assert.equal(QUnit.equiv(rg1, rg2), true, "Modifier");
+	assert.equal( QUnit.equiv( ri1, ri2 ), true, "Modifier" );
+	assert.equal( QUnit.equiv( r1, ri1 ), false, "Modifier" );
+	assert.equal( QUnit.equiv( ri1, rm1 ), false, "Modifier" );
+	assert.equal( QUnit.equiv( r1, rm1 ), false, "Modifier" );
+	assert.equal( QUnit.equiv( rm1, ri1 ), false, "Modifier" );
+	assert.equal( QUnit.equiv( rm1, rm2 ), true, "Modifier" );
+	assert.equal( QUnit.equiv( rg1, rm1 ), false, "Modifier" );
+	assert.equal( QUnit.equiv( rm1, rg1 ), false, "Modifier" );
+	assert.equal( QUnit.equiv( rg1, rg2 ), true, "Modifier" );
 
 	// Different regex, same modifiers
 	r1 = /[a-z]/gi;
 	r2 = /[0-9]/gi; // oops! different
-	assert.equal(QUnit.equiv(r1, r2), false, "Regex pattern");
+	assert.equal( QUnit.equiv( r1, r2 ), false, "Regex pattern" );
 
 	r1 = /0/ig;
 	r2 = /"0"/ig; // oops! different
-	assert.equal(QUnit.equiv(r1, r2), false, "Regex pattern");
+	assert.equal( QUnit.equiv( r1, r2 ), false, "Regex pattern" );
 
 	r1 = /[\n\r\u2028\u2029]/g;
 	r2 = /[\n\r\u2028\u2029]/g;
 	r3 = /[\n\r\u2028\u2028]/g; // differs from r1
-	r4 = /[\n\r\u2028\u2029]/;  // differs from r1
+	r4 = /[\n\r\u2028\u2029]/; // differs from r1
 
-	assert.equal(QUnit.equiv(r1, r2), true, "Regex pattern");
-	assert.equal(QUnit.equiv(r1, r3), false, "Regex pattern");
-	assert.equal(QUnit.equiv(r1, r4), false, "Regex pattern");
+	assert.equal( QUnit.equiv( r1, r2 ), true, "Regex pattern" );
+	assert.equal( QUnit.equiv( r1, r3 ), false, "Regex pattern" );
+	assert.equal( QUnit.equiv( r1, r4 ), false, "Regex pattern" );
 
 	// More complex regex
 	regex1 = "^[-_.a-z0-9]+@([-_a-z0-9]+\\.)+([A-Za-z][A-Za-z]|[A-Za-z][A-Za-z][A-Za-z])|(([0-9][0-9]?|[0-1][0-9][0-9]|[2][0-4][0-9]|[2][5][0-5]))$";
@@ -444,25 +450,24 @@ test("RegExp", function( assert ) {
 	// regex 3 is different: '.' not escaped
 	regex3 = "^[-_.a-z0-9]+@([-_a-z0-9]+.)+([A-Za-z][A-Za-z]|[A-Za-z][A-Za-z][A-Za-z])|(([0-9][0-9]?|[0-1][0-9][0-9]|[2][0-4][0-9]|[2][5][0-5]))$";
 
-	r1 = new RegExp(regex1);
-	r2 = new RegExp(regex2);
-	r3 = new RegExp(regex3); // diff from r21, not same pattern
-	r3a = new RegExp(regex3, "gi"); // diff from r23, not same modifier
-	r3b = new RegExp(regex3, "ig"); // same as r23a
+	r1 = new RegExp( regex1 );
+	r2 = new RegExp( regex2 );
+	r3 = new RegExp( regex3 ); // diff from r21, not same pattern
+	r3a = new RegExp( regex3, "gi" ); // diff from r23, not same modifier
+	r3b = new RegExp( regex3, "ig" ); // same as r23a
 
-	assert.equal(QUnit.equiv(r1, r2), true, "Complex Regex");
-	assert.equal(QUnit.equiv(r1, r3), false, "Complex Regex");
-	assert.equal(QUnit.equiv(r3, r3a), false, "Complex Regex");
-	assert.equal(QUnit.equiv(r3a, r3b), true, "Complex Regex");
+	assert.equal( QUnit.equiv( r1, r2 ), true, "Complex Regex" );
+	assert.equal( QUnit.equiv( r1, r3 ), false, "Complex Regex" );
+	assert.equal( QUnit.equiv( r3, r3a ), false, "Complex Regex" );
+	assert.equal( QUnit.equiv( r3a, r3b ), true, "Complex Regex" );
 
 	// typeof r1 is "function" in some browsers and "object" in others so we must cover this test
 	r1 = / /;
-	assert.equal(QUnit.equiv(r1, function () {}), false, "Regex internal");
-	assert.equal(QUnit.equiv(r1, {}), false, "Regex internal");
+	assert.equal( QUnit.equiv( r1, function() {} ), false, "Regex internal" );
+	assert.equal( QUnit.equiv( r1, {} ), false, "Regex internal" );
 });
 
-
-test("Complex objects", function( assert ) {
+test( "Complex objects", function( assert ) {
 
 	function fn1() {
 		return "fn1";
@@ -473,7 +478,7 @@ test("Complex objects", function( assert ) {
 
 	// Try to invert the order of some properties to make sure it is covered.
 	// It can failed when properties are compared between unsorted arrays.
-	assert.equal(QUnit.equiv(
+	assert.equal( QUnit.equiv(
 		{
 			a: 1,
 			b: null,
@@ -568,7 +573,7 @@ test("Complex objects", function( assert ) {
 		}
 	), true);
 
-	assert.equal(QUnit.equiv(
+	assert.equal( QUnit.equiv(
 		{
 			a: 1,
 			b: null,
@@ -663,7 +668,7 @@ test("Complex objects", function( assert ) {
 		}
 	), false);
 
-	assert.equal(QUnit.equiv(
+	assert.equal( QUnit.equiv(
 		{
 			a: 1,
 			b: null,
@@ -758,7 +763,7 @@ test("Complex objects", function( assert ) {
 		}
 	), false);
 
-	assert.equal(QUnit.equiv(
+	assert.equal( QUnit.equiv(
 		{
 			a: 1,
 			b: null,
@@ -851,7 +856,7 @@ test("Complex objects", function( assert ) {
 			h: "h",
 			i: []
 		}
-	), false);
+	), false );
 
 	var same1 = {
 			a: [
@@ -958,28 +963,27 @@ test("Complex objects", function( assert ) {
 			c: fn2 // different: fn2 instead of fn1
 		};
 
-	assert.equal(QUnit.equiv(same1, same2), true);
-	assert.equal(QUnit.equiv(same2, same1), true);
-	assert.equal(QUnit.equiv(same2, diff1), false);
-	assert.equal(QUnit.equiv(diff1, same2), false);
+	assert.equal( QUnit.equiv( same1, same2 ), true );
+	assert.equal( QUnit.equiv( same2, same1 ), true );
+	assert.equal( QUnit.equiv( same2, diff1 ), false );
+	assert.equal( QUnit.equiv( diff1, same2 ), false );
 
-	assert.equal(QUnit.equiv(same1, diff1), false);
-	assert.equal(QUnit.equiv(same1, diff2), false);
-	assert.equal(QUnit.equiv(same1, diff3), false);
-	assert.equal(QUnit.equiv(same1, diff3), false);
-	assert.equal(QUnit.equiv(same1, diff4), false);
-	assert.equal(QUnit.equiv(same1, diff5), false);
-	assert.equal(QUnit.equiv(same1, diff6), false);
-	assert.equal(QUnit.equiv(diff5, diff1), false);
+	assert.equal( QUnit.equiv( same1, diff1 ), false );
+	assert.equal( QUnit.equiv( same1, diff2 ), false );
+	assert.equal( QUnit.equiv( same1, diff3 ), false );
+	assert.equal( QUnit.equiv( same1, diff3 ), false );
+	assert.equal( QUnit.equiv( same1, diff4 ), false );
+	assert.equal( QUnit.equiv( same1, diff5 ), false );
+	assert.equal( QUnit.equiv( same1, diff6 ), false );
+	assert.equal( QUnit.equiv( diff5, diff1 ), false );
 });
 
 
-test("Complex Arrays", function( assert ) {
+test( "Complex Arrays", function( assert ) {
 
-	function fn() {
-	}
+	function fn() {}
 
-	assert.equal(QUnit.equiv(
+	assert.equal( QUnit.equiv(
 				[1, 2, 3, true, {}, null, [
 					{
 						a: ["", "1", 0]
@@ -994,7 +998,7 @@ test("Complex Arrays", function( assert ) {
 				], "foo"]),
 			true);
 
-	assert.equal(QUnit.equiv(
+	assert.equal( QUnit.equiv(
 				[1, 2, 3, true, {}, null, [
 					{
 						a: ["", "1", 0]
@@ -1033,7 +1037,7 @@ test("Complex Arrays", function( assert ) {
 		}
 	}, {}]]];
 
-	assert.equal(QUnit.equiv(a,
+	assert.equal( QUnit.equiv(a,
 			[{
 				b: fn,
 				c: false,
@@ -1058,7 +1062,7 @@ test("Complex Arrays", function( assert ) {
 				}
 			}, {}]]]), true);
 
-	assert.equal(QUnit.equiv(a,
+	assert.equal( QUnit.equiv(a,
 			[{
 				b: fn,
 				c: false,
@@ -1083,7 +1087,7 @@ test("Complex Arrays", function( assert ) {
 				}
 			}, {}]]]), false);
 
-	assert.equal(QUnit.equiv(a,
+	assert.equal( QUnit.equiv(a,
 			[{
 				b: fn,
 				c: false,
@@ -1108,7 +1112,7 @@ test("Complex Arrays", function( assert ) {
 				}
 			}, {}]]]), false);
 
-	assert.equal(QUnit.equiv(a,
+	assert.equal( QUnit.equiv(a,
 			[{
 				b: fn,
 				c: false,
@@ -1133,7 +1137,7 @@ test("Complex Arrays", function( assert ) {
 				}
 			}, {}]]]), false);
 
-	assert.equal(QUnit.equiv(a,
+	assert.equal( QUnit.equiv(a,
 			[{
 				b: fn,
 				c: false,
@@ -1160,41 +1164,41 @@ test("Complex Arrays", function( assert ) {
 });
 
 
-test("Prototypal inheritance", function( assert ) {
-	function Gizmo(id) {
+test( "Prototypal inheritance", function( assert ) {
+	function Gizmo( id ) {
 		this.id = id;
 	}
 
-	function Hoozit(id) {
+	function Hoozit( id ) {
 		this.id = id;
 	}
 	Hoozit.prototype = new Gizmo();
 
-	var gizmo = new Gizmo("ok"),
-		hoozit = new Hoozit("ok");
+	var gizmo = new Gizmo( "ok" ),
+		hoozit = new Hoozit( "ok" );
 
 	// Try this test many times after test on instances that hold function
 	// to make sure that our code does not mess with last object constructor memoization.
-	assert.equal(QUnit.equiv(function () {}, function () {}), false);
+	assert.equal( QUnit.equiv( function() {}, function() {} ), false );
 
 	// Hoozit inherit from Gizmo
 	// hoozit instanceof Hoozit; // true
 	// hoozit instanceof Gizmo; // true
-	assert.equal(QUnit.equiv(hoozit, gizmo), true);
+	assert.equal( QUnit.equiv( hoozit, gizmo ), true );
 
 	Gizmo.prototype.bar = true; // not a function just in case we skip them
 
 	// Hoozit inherit from Gizmo
 	// They are equivalent
-	assert.equal(QUnit.equiv(hoozit, gizmo), true);
+	assert.equal( QUnit.equiv( hoozit, gizmo ), true );
 
 	// Make sure this is still true !important
 	// The reason for this is that I forgot to reset the last
 	// caller to where it were called from.
-	assert.equal(QUnit.equiv(function () {}, function () {}), false);
+	assert.equal( QUnit.equiv( function() {}, function() {} ), false );
 
 	// Make sure this is still true !important
-	assert.equal(QUnit.equiv(hoozit, gizmo), true);
+	assert.equal( QUnit.equiv( hoozit, gizmo ), true );
 
 	Hoozit.prototype.foo = true; // not a function just in case we skip them
 
@@ -1202,14 +1206,14 @@ test("Prototypal inheritance", function( assert ) {
 	// gizmo instanceof Gizmo; // true
 	// gizmo instanceof Hoozit; // false
 	// They are not equivalent
-	assert.equal(QUnit.equiv(hoozit, gizmo), false);
+	assert.equal( QUnit.equiv( hoozit, gizmo ), false );
 
 	// Make sure this is still true !important
-	assert.equal(QUnit.equiv(function () {}, function () {}), false);
+	assert.equal( QUnit.equiv( function() {}, function() {} ), false );
 });
 
 
-test("Instances", function( assert ) {
+test( "Instances", function( assert ) {
 	var a1, a2, b1, b2, car, carSame, carDiff, human;
 
 	function A() {}
@@ -1217,19 +1221,19 @@ test("Instances", function( assert ) {
 	a2 = new A();
 
 	function B() {
-		this.fn = function () {};
+		this.fn = function() {};
 	}
 	b1 = new B();
 	b2 = new B();
 
-	assert.equal(QUnit.equiv(a1, a2), true, "Same property, same constructor");
+	assert.equal( QUnit.equiv( a1, a2 ), true, "Same property, same constructor" );
 
 	// b1.fn and b2.fn are functions but they are different references
 	// But we decided to skip function for instances.
-	assert.equal(QUnit.equiv(b1, b2), true, "Same property, same constructor");
-	assert.equal(QUnit.equiv(a1, b1), false, "Same properties but different constructor"); // failed
+	assert.equal( QUnit.equiv( b1, b2 ), true, "Same property, same constructor" );
+	assert.equal( QUnit.equiv( a1, b1 ), false, "Same properties but different constructor" ); // failed
 
-	function Car(year) {
+	function Car( year ) {
 		var privateVar = 0;
 		this.year = year;
 		this.isOld = function() {
@@ -1237,7 +1241,7 @@ test("Instances", function( assert ) {
 		};
 	}
 
-	function Human(year) {
+	function Human( year ) {
 		var privateVar = 1;
 		this.year = year;
 		this.isOld = function() {
@@ -1245,10 +1249,10 @@ test("Instances", function( assert ) {
 		};
 	}
 
-	car = new Car(30);
-	carSame = new Car(30);
-	carDiff = new Car(10);
-	human = new Human(30);
+	car = new Car( 30 );
+	carSame = new Car( 30 );
+	carDiff = new Car( 10 );
+	human = new Human( 30 );
 
 	/**
 	 * difference:
@@ -1258,38 +1262,38 @@ test("Instances", function( assert ) {
 	 *   - isOld: function () {}
 	 */
 
-	assert.equal(QUnit.equiv(car, car), true);
-	assert.equal(QUnit.equiv(car, carDiff), false);
-	assert.equal(QUnit.equiv(car, carSame), true);
-	assert.equal(QUnit.equiv(car, human), false);
+	assert.equal( QUnit.equiv( car, car ), true );
+	assert.equal( QUnit.equiv( car, carDiff ), false );
+	assert.equal( QUnit.equiv( car, carSame ), true );
+	assert.equal( QUnit.equiv( car, human ), false );
 });
 
 
-test("Complex instance nesting (with function values in literals and/or in nested instances)", function( assert ) {
+test( "Complex instance nesting (with function values in literals and/or in nested instances)", function( assert ) {
 	var a1, a2, b1, b2, c1, c2, d1, d2, e1, e2;
 
-	function A(fn) {
+	function A( fn ) {
 		this.a = {};
 		this.fn = fn;
-		this.b = {a: []};
+		this.b = { a: [] };
 		this.o = {};
 		this.fn1 = fn;
 	}
-	function B(fn) {
+	function B( fn ) {
 		this.fn = fn;
-		this.fn1 = function () {};
-		this.a = new A(function () {});
+		this.fn1 = function() {};
+		this.a = new A(function() {});
 	}
 
 	function fnOutside() {
 	}
 
-	function C(fn) {
+	function C( fn ) {
 		function fnInside() {
 		}
 		this.x = 10;
 		this.fn = fn;
-		this.fn1 = function () {};
+		this.fn1 = function() {};
 		this.fn2 = fnInside;
 		this.fn3 = {
 			a: true,
@@ -1300,7 +1304,7 @@ test("Complex instance nesting (with function values in literals and/or in neste
 		// This function will be ignored.
 		// Even if it is not visible for all instances (e.g. locked in a closures),
 		// it is from a  property that makes part of an instance (e.g. from the C constructor)
-		this.b1 = new B(function () {});
+		this.b1 = new B(function() {});
 		this.b2 = new B({
 			x: {
 				b2: new B(function() {})
@@ -1308,12 +1312,12 @@ test("Complex instance nesting (with function values in literals and/or in neste
 		});
 	}
 
-	function D(fn) {
+	function D( fn ) {
 		function fnInside() {
 		}
 		this.x = 10;
 		this.fn = fn;
-		this.fn1 = function () {};
+		this.fn1 = function() {};
 		this.fn2 = fnInside;
 		this.fn3 = {
 			a: true,
@@ -1329,7 +1333,7 @@ test("Complex instance nesting (with function values in literals and/or in neste
 		// This function will be ignored.
 		// Even if it is not visible for all instances (e.g. locked in a closures),
 		// it is from a  property that makes part of an instance (e.g. from the C constructor)
-		this.b1 = new B(function () {});
+		this.b1 = new B(function() {});
 		this.b2 = new B({
 			x: {
 				b2: new B(function() {})
@@ -1337,12 +1341,12 @@ test("Complex instance nesting (with function values in literals and/or in neste
 		});
 	}
 
-	function E(fn) {
+	function E( fn ) {
 		function fnInside() {
 		}
 		this.x = 10;
 		this.fn = fn;
-		this.fn1 = function () {};
+		this.fn1 = function() {};
 		this.fn2 = fnInside;
 		this.fn3 = {
 			a: true,
@@ -1353,122 +1357,127 @@ test("Complex instance nesting (with function values in literals and/or in neste
 		// This function will be ignored.
 		// Even if it is not visible for all instances (e.g. locked in a closures),
 		// it is from a  property that makes part of an instance (e.g. from the C constructor)
-		this.b1 = new B(function () {});
+		this.b1 = new B(function() {});
 		this.b2 = new B({
 			x: {
-				b1: new B({a: function() {}}),
+				b1: new B( { a: function() {} } ),
 				b2: new B(function() {})
 			}
 		});
 	}
 
 
-	a1 = new A(function () {});
-	a2 = new A(function () {});
-	assert.equal(QUnit.equiv(a1, a2), true);
+	a1 = new A(function() {});
+	a2 = new A(function() {});
+	assert.equal( QUnit.equiv( a1, a2 ), true );
 
-	assert.equal(QUnit.equiv(a1, a2), true); // different instances
+	assert.equal( QUnit.equiv( a1, a2 ), true ); // different instances
 
-	b1 = new B(function () {});
-	b2 = new B(function () {});
-	assert.equal(QUnit.equiv(b1, b2), true);
+	b1 = new B(function() {});
+	b2 = new B(function() {});
+	assert.equal( QUnit.equiv( b1, b2 ), true );
 
-	c1 = new C(function () {});
-	c2 = new C(function () {});
-	assert.equal(QUnit.equiv(c1, c2), true);
+	c1 = new C(function() {});
+	c2 = new C(function() {});
+	assert.equal( QUnit.equiv( c1, c2 ), true );
 
-	d1 = new D(function () {});
-	d2 = new D(function () {});
-	assert.equal(QUnit.equiv(d1, d2), false);
+	d1 = new D(function() {});
+	d2 = new D(function() {});
+	assert.equal( QUnit.equiv( d1, d2 ), false );
 
-	e1 = new E(function () {});
-	e2 = new E(function () {});
-	assert.equal(QUnit.equiv(e1, e2), false);
+	e1 = new E(function() {});
+	e2 = new E(function() {});
+	assert.equal( QUnit.equiv( e1, e2 ), false );
 
 });
 
 
-test("Object with circular references", function( assert ) {
+test( "Object with circular references", function( assert ) {
 	var circularA = {
-		abc: null
-	}, circularB = {
-		abc: null
-	};
+			abc: null
+		},
+		circularB = {
+			abc: null
+		};
 	circularA.abc = circularA;
 	circularB.abc = circularB;
-	assert.equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object (ambiguous test)");
+	assert.equal( QUnit.equiv( circularA, circularB ), true, "Should not repeat test on object (ambiguous test)" );
 
 	circularA.def = 1;
 	circularB.def = 1;
-	assert.equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object (ambiguous test)");
+	assert.equal( QUnit.equiv( circularA, circularB ), true, "Should not repeat test on object (ambiguous test)" );
 
 	circularA.def = 1;
 	circularB.def = 0;
-	assert.equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on object (unambiguous test)");
+	assert.equal( QUnit.equiv( circularA, circularB ), false, "Should not repeat test on object (unambiguous test)" );
 });
 
-test("Array with circular references", function( assert ) {
+test( "Array with circular references", function( assert ) {
 	var circularA = [],
 		circularB = [];
-	circularA.push(circularA);
-	circularB.push(circularB);
-	assert.equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on array (ambiguous test)");
+	circularA.push( circularA );
+	circularB.push( circularB );
+	assert.equal( QUnit.equiv( circularA, circularB ), true, "Should not repeat test on array (ambiguous test)" );
 
 	circularA.push( "abc" );
 	circularB.push( "abc" );
-	assert.equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on array (ambiguous test)");
+	assert.equal( QUnit.equiv( circularA, circularB ), true, "Should not repeat test on array (ambiguous test)" );
 
 	circularA.push( "hello" );
 	circularB.push( "goodbye" );
-	assert.equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on array (unambiguous test)");
+	assert.equal( QUnit.equiv( circularA, circularB ), false, "Should not repeat test on array (unambiguous test)" );
 });
 
-test("Mixed object/array with references to self wont loop", function( assert ) {
-	var circularA = [{abc:null}],
-		circularB = [{abc:null}];
-	circularA[0].abc = circularA;
-	circularB[0].abc = circularB;
+test( "Mixed object/array with references to self wont loop", function( assert ) {
+	var circularA = [{
+			abc: null
+		}],
+		circularB = [{
+			abc: null
+		}];
+	circularA[ 0 ].abc = circularA;
+	circularB[ 0 ].abc = circularB;
 
-	circularA.push(circularA);
-	circularB.push(circularB);
-	assert.equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object/array (ambiguous test)");
+	circularA.push( circularA );
+	circularB.push( circularB );
+	assert.equal( QUnit.equiv( circularA, circularB ), true, "Should not repeat test on object/array (ambiguous test)" );
 
-	circularA[0].def = 1;
-	circularB[0].def = 1;
-	assert.equal(QUnit.equiv(circularA, circularB), true, "Should not repeat test on object/array (ambiguous test)");
+	circularA[ 0 ].def = 1;
+	circularB[ 0 ].def = 1;
+	assert.equal( QUnit.equiv( circularA, circularB ), true, "Should not repeat test on object/array (ambiguous test)" );
 
-	circularA[0].def = 1;
-	circularB[0].def = 0;
-	assert.equal(QUnit.equiv(circularA, circularB), false, "Should not repeat test on object/array (unambiguous test)");
+	circularA[ 0 ].def = 1;
+	circularB[ 0 ].def = 0;
+	assert.equal( QUnit.equiv( circularA, circularB ), false, "Should not repeat test on object/array (unambiguous test)" );
 });
 
-test("Compare self-referent to tree", function ( assert ) {
+test( "Compare self-referent to tree", function( assert ) {
 	var temp,
-		circularA = [0],
-		treeA = [0, null],
+		circularA = [ 0 ],
+		treeA = [ 0, null ],
 		circularO = {},
 		treeO = {
 			o: null
 		};
 
-	circularA[1] = circularA;
+	circularA[ 1 ] = circularA;
 	circularO.o = circularO;
 
-	assert.equal(QUnit.equiv(circularA, treeA), false, "Array: Should not consider circular equal to tree");
-	assert.equal(QUnit.equiv(circularO, treeO), false, "Object: Should not consider circular equal to tree");
+	assert.equal( QUnit.equiv( circularA, treeA ), false, "Array: Should not consider circular equal to tree" );
+	assert.equal( QUnit.equiv( circularO, treeO ), false, "Object: Should not consider circular equal to tree" );
 
 	temp = [ 0, circularA ];
-	assert.equal(QUnit.equiv(circularA, temp), true, "Array: Reference is circular for one, but equal on other");
-	assert.equal(QUnit.equiv(temp, circularA), true, "Array: Reference is circular for one, but equal on other");
+	assert.equal( QUnit.equiv( circularA, temp ), true, "Array: Reference is circular for one, but equal on other" );
+	assert.equal( QUnit.equiv( temp, circularA ), true, "Array: Reference is circular for one, but equal on other" );
 
 	temp = {
 		o: circularO
 	};
-	assert.equal(QUnit.equiv(circularO, temp), true, "Object: Reference is circular for one, but equal on other");
-	assert.equal(QUnit.equiv(temp, circularO), true, "Object: Reference is circular for one, but equal on other");
+	assert.equal( QUnit.equiv( circularO, temp ), true, "Object: Reference is circular for one, but equal on other" );
+	assert.equal( QUnit.equiv( temp, circularO ), true, "Object: Reference is circular for one, but equal on other" );
 });
 
-test("Test that must be done at the end because they extend some primitive's prototype", function( assert ) {
+test( "Test that must be done at the end because they extend some primitive's prototype", function( assert ) {
 	// Try that a function looks like our regular expression.
 	// This tests if we check that a and b are really both instance of RegExp
 	Function.prototype.global = true;
@@ -1476,8 +1485,8 @@ test("Test that must be done at the end because they extend some primitive's pro
 	Function.prototype.ignoreCase = false;
 	Function.prototype.source = "my regex";
 	var re = /my regex/gm;
-	assert.equal(QUnit.equiv(re, function () {}), false, "A function that looks that a regex isn't a regex");
+	assert.equal( QUnit.equiv( re, function() {}), false, "A function that looks that a regex isn't a regex" );
 	// This test will ensures it works in both ways, and ALSO especially that we can make differences
 	// between RegExp and Function constructor because typeof on a RegExpt instance is "function"
-	assert.equal(QUnit.equiv(function () {}, re), false, "Same conversely, but ensures that function and regexp are distinct because their constructor are different");
+	assert.equal( QUnit.equiv(function() {}, re ), false, "Same conversely, but ensures that function and regexp are distinct because their constructor are different" );
 });

--- a/test/logs.js
+++ b/test/logs.js
@@ -19,30 +19,30 @@ QUnit.begin(function( args ) {
 });
 QUnit.done(function() {
 });
-QUnit.moduleStart(function(context) {
+QUnit.moduleStart(function( context ) {
 	moduleStart++;
 	moduleContext = context;
 });
-QUnit.moduleDone(function(context) {
+QUnit.moduleDone(function( context ) {
 	moduleDone++;
 	moduleDoneContext = context;
 });
-QUnit.testStart(function(context) {
+QUnit.testStart(function( context ) {
 	testStart++;
 	testContext = context;
 });
-QUnit.testDone(function(context) {
+QUnit.testDone(function( context ) {
 	testDone++;
 	testDoneContext = context;
 });
-QUnit.log(function(context) {
+QUnit.log(function( context ) {
 	log++;
 	logContext = context;
 });
 
-QUnit.module("logs1");
+QUnit.module( "logs1" );
 
-test("test1", function( assert ) {
+test( "test1", function( assert ) {
 	expect( 16 );
 
 	assert.equal( typeof totalTests, "number", "QUnit.begin should pass total amount of tests to callback" );
@@ -61,7 +61,7 @@ test("test1", function( assert ) {
 	}, "log context after equal(actual, expected, message)" );
 
 	assert.equal( "foo", "foo" );
-	assert.deepEqual(logContext, {
+	assert.deepEqual( logContext, {
 		name: "test1",
 		module: "logs1",
 		result: true,
@@ -91,7 +91,7 @@ test("test1", function( assert ) {
 	assert.equal( log, 15, "QUnit.log calls" );
 });
 
-test("test2", function( assert ) {
+test( "test2", function( assert ) {
 	expect( 11 );
 	assert.equal( begin, 1, "QUnit.begin calls" );
 	assert.equal( moduleStart, 1, "QUnit.moduleStart calls" );
@@ -99,7 +99,7 @@ test("test2", function( assert ) {
 	assert.equal( testDone, 1, "QUnit.testDone calls" );
 	assert.equal( moduleDone, 0, "QUnit.moduleDone calls" );
 
-	assert.equal( typeof testDoneContext.runtime, "number" , "testDone context: runtime" );
+	assert.equal( typeof testDoneContext.runtime, "number", "testDone context: runtime" );
 	delete testDoneContext.runtime;
 	// DEPRECATED: remove this delete when removing the duration property
 	delete testDoneContext.duration;
@@ -122,7 +122,7 @@ test("test2", function( assert ) {
 	assert.equal( log, 26, "QUnit.log calls" );
 });
 
-QUnit.module("logs2");
+QUnit.module( "logs2" );
 
 test( "test1", function( assert ) {
 	expect( 9 );

--- a/test/narwhal-test.js
+++ b/test/narwhal-test.js
@@ -1,25 +1,25 @@
 /*jshint node:true, undef:false */
 /*globals QUnit:true */
 // Run with: $ narwhal test/narwhal-test.js
-var QUnit = require("../dist/qunit");
+var QUnit = require( "../dist/qunit" );
 
-QUnit.log(function(details) {
-	if (!details.result) {
-		var output = "FAILED: " + (details.message ? details.message + ", " : "");
-		if (details.actual) {
+QUnit.log(function( details ) {
+	if ( !details.result ) {
+		var output = "FAILED: " + ( details.message ? details.message + ", " : "" );
+		if ( details.actual ) {
 			output += "expected: " + details.expected + ", actual: " + details.actual;
 		}
-		if (details.source) {
+		if ( details.source ) {
 			output += ", " + details.source;
 		}
-		print(output);
+		print( output );
 	}
 });
 
-QUnit.test("fail twice with stacktrace", function(assert) {
+QUnit.test( "fail twice with stacktrace", function( assert ) {
 	/*jshint expr:true */
-	assert.equal(true, false);
-	assert.equal(true, false, "gotta fail");
+	assert.equal( true, false );
+	assert.equal( true, false, "gotta fail" );
 	// Throws ReferenceError
 	x.y.z;
 });

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -1,25 +1,25 @@
 /*jshint node:true, undef:false */
 /*globals QUnit:true */
 // Run with: $ node test/node-test.js
-var QUnit = require("../dist/qunit");
+var QUnit = require( "../dist/qunit" );
 
-QUnit.log(function(details) {
-	if (!details.result) {
-		var output = "FAILED: " + (details.message ? details.message + ", " : "");
-		if (details.actual) {
+QUnit.log(function( details ) {
+	if ( !details.result ) {
+		var output = "FAILED: " + ( details.message ? details.message + ", " : "" );
+		if ( details.actual ) {
 			output += "expected: " + details.expected + ", actual: " + details.actual;
 		}
-		if (details.source) {
+		if ( details.source ) {
 			output += ", " + details.source;
 		}
-		console.log(output);
+		console.log( output );
 	}
 });
 
-QUnit.test("fail twice with stacktrace", function(assert) {
+QUnit.test( "fail twice with stacktrace", function( assert ) {
 	/*jshint expr:true */
-	assert.equal(true, false);
-	assert.equal(true, false, "gotta fail");
+	assert.equal( true, false );
+	assert.equal( true, false, "gotta fail" );
 	// Throws ReferenceError
 	x.y.z;
 });

--- a/test/setTimeout.js
+++ b/test/setTimeout.js
@@ -12,8 +12,8 @@ module( "Module that mucks with time", {
 });
 
 test( "just a test", function( assert ) {
-	assert.ok(true);
+	assert.ok( true );
 });
 test( "just a test", function( assert ) {
-	assert.ok(true);
+	assert.ok( true );
 });

--- a/test/swarminject.js
+++ b/test/swarminject.js
@@ -1,10 +1,10 @@
 // load testswarm agent
 (function() {
-    var url = window.location.search;
-	url = decodeURIComponent( url.slice( url.indexOf("swarmURL=") + 9 ) );
-	if ( !url || url.indexOf("http") !== 0 ) {
+	var url = window.location.search;
+	url = decodeURIComponent( url.slice( url.indexOf( "swarmURL=" ) + 9 ) );
+	if ( !url || url.indexOf( "http" ) !== 0 ) {
 		return;
 	}
 	/*jshint evil:true */
-    document.write("<scr" + "ipt src='http://swarm.jquery.org/js/inject.js?" + (new Date()).getTime() + "'></scr" + "ipt>");
+	document.write( "<scr" + "ipt src='http://swarm.jquery.org/js/inject.js?" + ( new Date() ).getTime() + "'></scr" + "ipt>" );
 })();

--- a/test/test.js
+++ b/test/test.js
@@ -8,31 +8,31 @@ function getPreviousTests( rTestName, rModuleName ) {
 		i = 0,
 		rModule = /(^| )module-name( |$)/,
 		testNames = typeof document.getElementsByClassName !== "undefined" ?
-			document.getElementsByClassName("test-name") :
+			document.getElementsByClassName( "test-name" ) :
 			(function( spans ) {
 				var span,
 					tests = [],
 					i = 0,
 					rTest = /(^| )test-name( |$)/;
-				for ( ; (span = spans[i]); i++ ) {
+				for ( ; ( span = spans[ i ] ); i++ ) {
 					if ( rTest.test( span.className ) ) {
 						tests.push( span );
 					}
 				}
 				return tests;
-			})( document.getElementsByTagName("span") );
+			})( document.getElementsByTagName( "span" ) );
 
-	for ( ; (testSpan = testNames[i]); i++ ) {
+	for ( ; ( testSpan = testNames[ i ] ); i++ ) {
 		moduleSpan = testSpan;
-		while ( (moduleSpan = moduleSpan.previousSibling) ) {
+		while ( ( moduleSpan = moduleSpan.previousSibling ) ) {
 			if ( rModule.test( moduleSpan.className ) ) {
 				break;
 			}
 		}
-		if ( (!rTestName || rTestName.test( testSpan.innerHTML )) &&
-			(!rModuleName || moduleSpan && rModuleName.test( moduleSpan.innerHTML )) ) {
+		if ( ( !rTestName || rTestName.test( testSpan.innerHTML ) ) &&
+			( !rModuleName || moduleSpan && rModuleName.test( moduleSpan.innerHTML ) ) ) {
 
-			while ( (testSpan = testSpan.parentNode) ) {
+			while ( ( testSpan = testSpan.parentNode ) ) {
 				if ( testSpan.nodeName.toLowerCase() === "li" ) {
 					matches.push( testSpan );
 				}
@@ -42,30 +42,30 @@ function getPreviousTests( rTestName, rModuleName ) {
 	return matches;
 }
 
-test("module without setup/teardown (default)", function( assert ) {
-	expect(1);
-	assert.ok(true);
-});
-
-test("expect in test", function( assert ) {
-	expect( 3 );
-	assert.ok(true);
-	assert.ok(true);
-	assert.ok(true);
-});
-
-test("expect in test", function( assert ) {
+test( "module without setup/teardown (default)", function( assert ) {
 	expect( 1 );
-	assert.ok(true);
+	assert.ok( true );
 });
 
-test("expect query and multiple issue", function( assert ) {
-	expect(2);
-	assert.ok(true);
+test( "expect in test", function( assert ) {
+	expect( 3 );
+	assert.ok( true );
+	assert.ok( true );
+	assert.ok( true );
+});
+
+test( "expect in test", function( assert ) {
+	expect( 1 );
+	assert.ok( true );
+});
+
+test( "expect query and multiple issue", function( assert ) {
+	expect( 2 );
+	assert.ok( true );
 	var expected = expect();
-	assert.equal(expected, 2);
-	expect(expected + 1);
-	assert.ok(true);
+	assert.equal( expected, 2 );
+	expect( expected + 1 );
+	assert.ok( true );
 });
 
 QUnit.module( "assertion helpers" );
@@ -90,18 +90,18 @@ QUnit.test( "QUnit.assert compatibility", function( assert ) {
 
 QUnit.module( "setup test", {
 	setup: function( assert ) {
-		assert.ok(true);
+		assert.ok( true );
 	}
 });
 
-test("module with setup", function( assert ) {
-	expect(2);
-	assert.ok(true);
+test( "module with setup", function( assert ) {
+	expect( 2 );
+	assert.ok( true );
 });
 
-test("module with setup, expect in test call", function( assert ) {
+test( "module with setup, expect in test call", function( assert ) {
 	expect( 2 );
-	assert.ok(true);
+	assert.ok( true );
 });
 
 // TODO: More to the html-reporter test once we have that.
@@ -134,13 +134,12 @@ if ( typeof document !== "undefined" ) {
 		expect( 1 );
 		assert.ok( true, "<script id='qunit-unescaped-asassertionsert'>'assertion';</script>" );
 	});
-
 }
 
 QUnit.module( "setup/teardown test", {
 	setup: function( assert ) {
 		state = true;
-		assert.ok(true);
+		assert.ok( true );
 
 		// Assert that we can introduce and delete globals in setup/teardown
 		// without noglobals sounding any alarm.
@@ -159,7 +158,7 @@ QUnit.module( "setup/teardown test", {
 		@*/
 	},
 	teardown: function( assert ) {
-		assert.ok(true);
+		assert.ok( true );
 
 		/*@cc_on
 			@if (@_jscript_version < 9)
@@ -171,22 +170,22 @@ QUnit.module( "setup/teardown test", {
 	}
 });
 
-test("module with setup/teardown", function( assert ) {
-	expect(3);
-	assert.ok(true);
+test( "module with setup/teardown", function( assert ) {
+	expect( 3 );
+	assert.ok( true );
 });
 
 QUnit.module( "setup/teardown test 2" );
 
-test("module without setup/teardown", function( assert ) {
-	expect(1);
-	assert.ok(true);
+test( "module without setup/teardown", function( assert ) {
+	expect( 1 );
+	assert.ok( true );
 });
 
 QUnit.module( "Date test", {
 	setup: function( assert ) {
 		OrgDate = Date;
-		window.Date = function () {
+		window.Date = function() {
 			assert.ok( false, "QUnit should internally be independent from Date-related manipulation and testing" );
 			return new OrgDate();
 		};
@@ -196,67 +195,67 @@ QUnit.module( "Date test", {
 	}
 });
 
-test("sample test for Date test", function ( assert ) {
-	expect(1);
-	assert.ok(true);
+test( "sample test for Date test", function( assert ) {
+	expect( 1 );
+	assert.ok( true );
 });
 
-if (typeof setTimeout !== "undefined") {
+if ( typeof setTimeout !== "undefined" ) {
 state = "fail";
 
 QUnit.module( "teardown and stop", {
 	teardown: function( assert ) {
-		assert.equal(state, "done", "Test teardown.");
+		assert.equal( state, "done", "Test teardown." );
 	}
 });
 
-test("teardown must be called after test ended", function() {
-	expect(1);
+test( "teardown must be called after test ended", function() {
+	expect( 1 );
 	stop();
 	setTimeout(function() {
 		state = "done";
 		start();
-	}, 13);
+	}, 13 );
 });
 
-test("parameter passed to stop increments semaphore n times", function() {
-	expect(1);
-	stop(3);
+test( "parameter passed to stop increments semaphore n times", function() {
+	expect( 1 );
+	stop( 3 );
 	setTimeout(function() {
 		state = "not enough starts";
 		start();
 		start();
-	}, 13);
+	}, 13 );
 	setTimeout(function() {
 		state = "done";
 		start();
-	}, 15);
+	}, 15 );
 });
 
-test("parameter passed to start decrements semaphore n times", function() {
-	expect(1);
+test( "parameter passed to start decrements semaphore n times", function() {
+	expect( 1 );
 	stop();
 	stop();
 	stop();
 	setTimeout(function() {
 		state = "done";
-		start(3);
-	}, 18);
+		start( 3 );
+	}, 18 );
 });
 
 QUnit.module( "async setup test", {
 	setup: function( assert ) {
 		stop();
 		setTimeout(function() {
-			assert.ok(true);
+			assert.ok( true );
 			start();
-		}, 500);
+		}, 500 );
 	}
 });
 
-asyncTest("module with async setup", function( assert ) {
-	expect(2);
-	assert.ok(true);
+asyncTest( "module with async setup", function( assert ) {
+	expect( 2 );
+	assert.ok( true );
 	start();
 });
 
@@ -264,66 +263,66 @@ QUnit.module( "async teardown test", {
 	teardown: function( assert ) {
 		stop();
 		setTimeout(function() {
-			assert.ok(true);
+			assert.ok( true );
 			start();
-		}, 500);
+		}, 500 );
 	}
 });
 
-asyncTest("module with async teardown", function( assert ) {
-	expect(2);
-	assert.ok(true);
+asyncTest( "module with async teardown", function( assert ) {
+	expect( 2 );
+	assert.ok( true );
 	start();
 });
 
 QUnit.module( "asyncTest" );
 
-asyncTest("asyncTest", function( assert ) {
+asyncTest( "asyncTest", function( assert ) {
 	expect( 2 );
-	assert.ok(true);
+	assert.ok( true );
 	setTimeout(function() {
 		state = "done";
-		assert.ok(true);
+		assert.ok( true );
 		start();
-	}, 13);
+	}, 13 );
 });
 
-asyncTest("asyncTest with expect()", function( assert ) {
-	expect(2);
-	assert.ok(true);
+asyncTest( "asyncTest with expect()", function( assert ) {
+	expect( 2 );
+	assert.ok( true );
 	setTimeout(function() {
 		state = "done";
-		assert.ok(true);
+		assert.ok( true );
 		start();
-	}, 13);
+	}, 13 );
 });
 
-test("sync", function( assert ) {
+test( "sync", function( assert ) {
 	expect( 2 );
 	stop();
 	setTimeout(function() {
-		assert.ok(true);
+		assert.ok( true );
 		start();
-	}, 13);
+	}, 13 );
 	stop();
 	setTimeout(function() {
-		assert.ok(true);
+		assert.ok( true );
 		start();
-	}, 125);
+	}, 125 );
 });
 
-test("test synchronous calls to stop", function( assert ) {
+test( "test synchronous calls to stop", function( assert ) {
 	expect( 2 );
 	stop();
 	setTimeout(function() {
-		assert.ok(true, "first");
+		assert.ok( true, "first" );
 		start();
 		stop();
 		setTimeout(function() {
-			assert.ok(true, "second");
+			assert.ok( true, "second" );
 			start();
-		}, 150);
-	}, 150);
+		}, 150 );
+	}, 150 );
 });
 }
 
@@ -332,12 +331,12 @@ QUnit.module( "save scope", {
 		this.foo = "bar";
 	},
 	teardown: function( assert ) {
-		assert.deepEqual(this.foo, "bar");
+		assert.deepEqual( this.foo, "bar" );
 	}
 });
-test("scope check", function( assert ) {
-	expect(2);
-	assert.deepEqual(this.foo, "bar");
+test( "scope check", function( assert ) {
+	expect( 2 );
+	assert.deepEqual( this.foo, "bar" );
 });
 
 QUnit.module( "simple testEnvironment setup", {
@@ -345,40 +344,40 @@ QUnit.module( "simple testEnvironment setup", {
 	// example of meta-data
 	bugid: "#5311"
 });
-test("scope check", function( assert ) {
-	assert.deepEqual(this.foo, "bar");
+test( "scope check", function( assert ) {
+	assert.deepEqual( this.foo, "bar" );
 });
-test("modify testEnvironment", function() {
-	expect(0);
+test( "modify testEnvironment", function() {
+	expect( 0 );
 	this.foo = "hamster";
 });
-test("testEnvironment reset for next test", function( assert ) {
-	assert.deepEqual(this.foo, "bar");
+test( "testEnvironment reset for next test", function( assert ) {
+	assert.deepEqual( this.foo, "bar" );
 });
 
 QUnit.module( "testEnvironment with object", {
 	options: {
 		recipe: "soup",
-		ingredients: ["hamster", "onions"]
+		ingredients: [ "hamster", "onions" ]
 	}
 });
-test("scope check", function( assert ) {
-	assert.deepEqual(this.options, {
+test( "scope check", function( assert ) {
+	assert.deepEqual( this.options, {
 		recipe: "soup",
-		ingredients: ["hamster", "onions"]
+		ingredients: [ "hamster", "onions" ]
 	});
 });
-test("modify testEnvironment",function() {
-	expect(0);
+test( "modify testEnvironment", function() {
+	expect( 0 );
 	// since we only do a shallow copy, nested children of testEnvironment can be modified
 	// and survice
-	this.options.ingredients.push("carrots");
+	this.options.ingredients.push( "carrots" );
 });
-test("testEnvironment reset for next test",function( assert ) {
-	assert.deepEqual(this.options, {
+test( "testEnvironment reset for next test", function( assert ) {
+	assert.deepEqual( this.options, {
 		recipe: "soup",
-		ingredients: ["hamster", "onions", "carrots"]
-	}, "Is this a bug or a feature? Could do a deep copy") ;
+		ingredients: [ "hamster", "onions", "carrots" ]
+	}, "Is this a bug or a feature? Could do a deep copy" );
 });
 
 
@@ -387,39 +386,39 @@ QUnit.module( "testEnvironment tests" );
 function makeurl() {
 	var testEnv = QUnit.config.current.testEnvironment,
 		url = testEnv.url || "http://example.com/search",
-		q   = testEnv.q   || "a search test";
-	return url + "?q=" + encodeURIComponent(q);
+		q = testEnv.q || "a search test";
+	return url + "?q=" + encodeURIComponent( q );
 }
 
-test("makeurl working", function( assert ) {
+test( "makeurl working", function( assert ) {
 	expect( 2 );
-	assert.equal( QUnit.config.current.testEnvironment, this, "The current testEnvironment QUnit.config");
-	assert.equal( makeurl(), "http://example.com/search?q=a%20search%20test", "makeurl returns a default url if nothing specified in the testEnvironment");
+	assert.equal( QUnit.config.current.testEnvironment, this, "The current testEnvironment QUnit.config" );
+	assert.equal( makeurl(), "http://example.com/search?q=a%20search%20test", "makeurl returns a default url if nothing specified in the testEnvironment" );
 });
 
 QUnit.module( "testEnvironment with makeurl settings", {
 	url: "http://google.com/",
 	q: "another_search_test"
 });
-test("makeurl working with settings from testEnvironment", function( assert ) {
-	assert.equal( makeurl(), "http://google.com/?q=another_search_test", "rather than passing arguments, we use test metadata to from the url");
+test( "makeurl working with settings from testEnvironment", function( assert ) {
+	assert.equal( makeurl(), "http://google.com/?q=another_search_test", "rather than passing arguments, we use test metadata to from the url" );
 });
 
 QUnit.module( "jsDump" );
-test("jsDump output", function( assert ) {
-	assert.equal( QUnit.jsDump.parse([1, 2]), "[\n  1,\n  2\n]" );
-	assert.equal( QUnit.jsDump.parse({top: 5, left: 0}), "{\n  \"left\": 0,\n  \"top\": 5\n}" );
-	if (typeof document !== "undefined" && document.getElementById("qunit-header")) {
-		assert.equal( QUnit.jsDump.parse(document.getElementById("qunit-header")), "<h1 id=\"qunit-header\"></h1>" );
-		assert.equal( QUnit.jsDump.parse(document.getElementsByTagName("h1")), "[\n  <h1 id=\"qunit-header\"></h1>\n]" );
+test( "jsDump output", function( assert ) {
+	assert.equal( QUnit.jsDump.parse( [ 1, 2 ] ), "[\n  1,\n  2\n]" );
+	assert.equal( QUnit.jsDump.parse( { top: 5, left: 0 } ), "{\n  \"left\": 0,\n  \"top\": 5\n}" );
+	if ( typeof document !== "undefined" && document.getElementById( "qunit-header" ) ) {
+		assert.equal( QUnit.jsDump.parse( document.getElementById( "qunit-header" ) ), "<h1 id=\"qunit-header\"></h1>" );
+		assert.equal( QUnit.jsDump.parse( document.getElementsByTagName( "h1" ) ), "[\n  <h1 id=\"qunit-header\"></h1>\n]" );
 	}
 });
 
 QUnit.module( "assertions" );
 
-test("propEqual", function( assert ) {
+test( "propEqual", function( assert ) {
 	expect( 5 );
-	var objectCreate = Object.create || function ( origin ) {
+	var objectCreate = Object.create || function( origin ) {
 		function O() {}
 		O.prototype = origin;
 		var r = new O();
@@ -431,8 +430,8 @@ test("propEqual", function( assert ) {
 		this.y = y;
 		this.z = z;
 	}
-	Foo.prototype.doA = function () {};
-	Foo.prototype.doB = function () {};
+	Foo.prototype.doA = function() {};
+	Foo.prototype.doB = function() {};
 	Foo.prototype.bar = "prototype";
 
 	function Bar() {
@@ -494,8 +493,8 @@ test("propEqual", function( assert ) {
 	);
 });
 
-test("throws", function( assert ) {
-	expect(10);
+test( "throws", function( assert ) {
+	expect( 10 );
 	function CustomError( message ) {
 		this.message = message;
 	}
@@ -521,7 +520,7 @@ test("throws", function( assert ) {
 	// implement Error.prototype.toString
 	assert.throws(
 		function() {
-			throw new Error("error message");
+			throw new Error( "error message" );
 		},
 		/error message/,
 		"use regexp against instance of Error"
@@ -537,7 +536,7 @@ test("throws", function( assert ) {
 
 	assert.throws(
 		function() {
-			throw new CustomError("some error description");
+			throw new CustomError( "some error description" );
 		},
 		/description/,
 		"use a regex to match against the stringified error"
@@ -545,10 +544,10 @@ test("throws", function( assert ) {
 
 	assert.throws(
 		function() {
-			throw new CustomError("some error description");
+			throw new CustomError( "some error description" );
 		},
 		function( err ) {
-			if ( (err instanceof CustomError) && /description/.test(err) ) {
+			if ( ( err instanceof CustomError ) && /description/.test( err ) ) {
 				return true;
 			}
 		},
@@ -559,7 +558,7 @@ test("throws", function( assert ) {
 		function() {
 			/*jshint evil:true */
 			( window.execScript || function( data ) {
-				window["eval"].call( window, data );
+				window[ "eval" ].call( window, data );
 			})( "throw 'error';" );
 		},
 		"globally-executed errors caught"
@@ -569,7 +568,7 @@ test("throws", function( assert ) {
 
 	assert.throws(
 		function() {
-			throw new this.CustomError("some error description");
+			throw new this.CustomError( "some error description" );
 		},
 		/description/,
 		"throw error from property of 'this' context"
@@ -592,25 +591,25 @@ test("throws", function( assert ) {
 	);
 });
 
-if (typeof document !== "undefined") {
+if ( typeof document !== "undefined" ) {
 
 QUnit.module( "fixture" );
-test("setup", function() {
-	expect(0);
-	document.getElementById("qunit-fixture").innerHTML = "foobar";
+test( "setup", function() {
+	expect( 0 );
+	document.getElementById( "qunit-fixture" ).innerHTML = "foobar";
 });
 
-test("basics", function( assert ) {
-	assert.equal( document.getElementById("qunit-fixture").innerHTML, "test markup", "automatically reset" );
+test( "basics", function( assert ) {
+	assert.equal( document.getElementById( "qunit-fixture" ).innerHTML, "test markup", "automatically reset" );
 });
 
-test("running test name displayed", function( assert ) {
-	expect(2);
+test( "running test name displayed", function( assert ) {
+	expect( 2 );
 
-	var displaying = document.getElementById("qunit-testresult");
+	var displaying = document.getElementById( "qunit-testresult" );
 
-	assert.ok( /running test name displayed/.test(displaying.innerHTML), "Expect test name to be found in displayed text" );
-	assert.ok( /fixture/.test(displaying.innerHTML), "Expect module name to be found in displayed text" );
+	assert.ok( /running test name displayed/.test( displaying.innerHTML ), "Expect test name to be found in displayed text" );
+	assert.ok( /fixture/.test( displaying.innerHTML ), "Expect module name to be found in displayed text" );
 });
 
 (function() {
@@ -629,23 +628,23 @@ test("running test name displayed", function( assert ) {
 		}
 	});
 
-	test("setup", function() {
+	test( "setup", function() {
 		expect( 0 );
 		delayNextSetup = true;
 	});
 
-	test("basics", function( assert ) {
+	test( "basics", function( assert ) {
 		expect( 2 );
-		var previous = getPreviousTests(/^setup$/, /^timing$/)[0],
+		var previous = getPreviousTests( /^setup$/, /^timing$/ )[ 0 ],
 			runtime = previous.lastChild.previousSibling;
 		assert.ok( /(^| )runtime( |$)/.test( runtime.className ), "Runtime element exists" );
 		assert.ok( /^\d+ ms$/.test( runtime.innerHTML ), "Runtime reported in ms" );
 	});
 
-	test("values", function( assert ) {
+	test( "values", function( assert ) {
 		expect( 2 );
-		var basics = getPreviousTests(/^setup$/, /^timing$/)[0],
-			slow = getPreviousTests(/^basics$/, /^timing$/)[0];
+		var basics = getPreviousTests( /^setup$/, /^timing$/ )[ 0 ],
+			slow = getPreviousTests( /^basics$/, /^timing$/ )[ 0 ];
 		assert.ok( parseInt( basics.lastChild.previousSibling.innerHTML, 10 ) < 50, "Fast runtime for trivial test" );
 		assert.ok( parseInt( slow.lastChild.previousSibling.innerHTML, 10 ) > 250, "Runtime includes setup" );
 	});
@@ -669,118 +668,121 @@ QUnit.module( "custom assertions" );
 
 QUnit.module( "recursions" );
 
-function Wrap(x) {
+function Wrap( x ) {
 	this.wrap = x;
-	if (x === undefined) {
+	if ( x === undefined ) {
 		this.first = true;
 	}
 }
 
-function chainwrap(depth, first, prev) {
+function chainwrap( depth, first, prev ) {
 	depth = depth || 0;
 	var last = prev || new Wrap();
 	first = first || last;
 
-	if (depth === 1) {
+	if ( depth === 1 ) {
 		first.wrap = last;
 	}
-	if (depth > 1) {
-		last = chainwrap(depth-1, first, new Wrap(last));
+	if ( depth > 1 ) {
+		last = chainwrap( depth - 1, first, new Wrap( last ) );
 	}
 
 	return last;
 }
 
-test("Check jsDump recursion", function( assert ) {
-	expect(4);
+test( "Check jsDump recursion", function( assert ) {
+	expect( 4 );
 
 	var noref, nodump, selfref, selfdump, parentref, parentdump, circref, circdump;
 
-	noref = chainwrap(0);
-	nodump = QUnit.jsDump.parse(noref);
-	assert.equal(nodump, "{\n  \"first\": true,\n  \"wrap\": undefined\n}");
+	noref = chainwrap( 0 );
+	nodump = QUnit.jsDump.parse( noref );
+	assert.equal( nodump, "{\n  \"first\": true,\n  \"wrap\": undefined\n}" );
 
-	selfref = chainwrap(1);
-	selfdump = QUnit.jsDump.parse(selfref);
-	assert.equal(selfdump, "{\n  \"first\": true,\n  \"wrap\": recursion(-1)\n}");
+	selfref = chainwrap( 1 );
+	selfdump = QUnit.jsDump.parse( selfref );
+	assert.equal( selfdump, "{\n  \"first\": true,\n  \"wrap\": recursion(-1)\n}" );
 
-	parentref = chainwrap(2);
-	parentdump = QUnit.jsDump.parse(parentref);
-	assert.equal(parentdump, "{\n  \"wrap\": {\n    \"first\": true,\n    \"wrap\": recursion(-2)\n  }\n}");
+	parentref = chainwrap( 2 );
+	parentdump = QUnit.jsDump.parse( parentref );
+	assert.equal( parentdump, "{\n  \"wrap\": {\n    \"first\": true,\n    \"wrap\": recursion(-2)\n  }\n}" );
 
-	circref = chainwrap(10);
-	circdump = QUnit.jsDump.parse(circref);
-	assert.ok(new RegExp("recursion\\(-10\\)").test(circdump), "(" +circdump + ") should show -10 recursion level");
+	circref = chainwrap( 10 );
+	circdump = QUnit.jsDump.parse( circref );
+	assert.ok( new RegExp( "recursion\\(-10\\)" ).test( circdump ), "(" + circdump + ") should show -10 recursion level" );
 });
 
-test("Check equal/deepEqual recursion", function( assert ) {
+test( "Check equal/deepEqual recursion", function( assert ) {
 	var noRecursion, selfref, circref;
 
-	noRecursion = chainwrap(0);
-	assert.equal(noRecursion, noRecursion, "I should be equal to me.");
-	assert.deepEqual(noRecursion, noRecursion, "... and so in depth.");
+	noRecursion = chainwrap( 0 );
+	assert.equal( noRecursion, noRecursion, "I should be equal to me." );
+	assert.deepEqual( noRecursion, noRecursion, "... and so in depth." );
 
-	selfref = chainwrap(1);
-	assert.equal(selfref, selfref, "Even so if I nest myself.");
-	assert.deepEqual(selfref, selfref, "... into the depth.");
+	selfref = chainwrap( 1 );
+	assert.equal( selfref, selfref, "Even so if I nest myself." );
+	assert.deepEqual( selfref, selfref, "... into the depth." );
 
-	circref = chainwrap(10);
-	assert.equal(circref, circref, "Or hide that through some levels of indirection.");
-	assert.deepEqual(circref, circref, "... and checked on all levels!");
+	circref = chainwrap( 10 );
+	assert.equal( circref, circref, "Or hide that through some levels of indirection." );
+	assert.deepEqual( circref, circref, "... and checked on all levels!" );
 });
 
-
-test("Circular reference with arrays", function( assert ) {
+test( "Circular reference with arrays", function( assert ) {
 	var arr, arrdump, obj, childarr, objdump, childarrdump;
 
 	// pure array self-ref
 	arr = [];
-	arr.push(arr);
+	arr.push( arr );
 
-	arrdump = QUnit.jsDump.parse(arr);
+	arrdump = QUnit.jsDump.parse( arr );
 
-	assert.equal(arrdump, "[\n  recursion(-1)\n]");
-	assert.equal(arr, arr[0], "no endless stack when trying to dump arrays with circular ref");
+	assert.equal( arrdump, "[\n  recursion(-1)\n]" );
+	assert.equal( arr, arr[ 0 ], "no endless stack when trying to dump arrays with circular ref" );
 
 
 	// mix obj-arr circular ref
 	obj = {};
-	childarr = [obj];
+	childarr = [ obj ];
 	obj.childarr = childarr;
 
-	objdump = QUnit.jsDump.parse(obj);
-	childarrdump = QUnit.jsDump.parse(childarr);
+	objdump = QUnit.jsDump.parse( obj );
+	childarrdump = QUnit.jsDump.parse( childarr );
 
-	assert.equal(objdump, "{\n  \"childarr\": [\n    recursion(-2)\n  ]\n}");
-	assert.equal(childarrdump, "[\n  {\n    \"childarr\": recursion(-2)\n  }\n]");
+	assert.equal( objdump, "{\n  \"childarr\": [\n    recursion(-2)\n  ]\n}" );
+	assert.equal( childarrdump, "[\n  {\n    \"childarr\": recursion(-2)\n  }\n]" );
 
-	assert.equal(obj.childarr, childarr, "no endless stack when trying to dump array/object mix with circular ref");
-	assert.equal(childarr[0], obj, "no endless stack when trying to dump array/object mix with circular ref");
+	assert.equal( obj.childarr, childarr, "no endless stack when trying to dump array/object mix with circular ref" );
+	assert.equal( childarr[ 0 ], obj, "no endless stack when trying to dump array/object mix with circular ref" );
 
 });
 
 
-test("Circular reference - test reported by soniciq in #105", function( assert ) {
+test( "Circular reference - test reported by soniciq in #105", function( assert ) {
 	var a, b, barr,
-		MyObject = function() {};
-	MyObject.prototype.parent = function(obj) {
-		if (obj === undefined) { return this._parent; }
+		MyObject = function(){};
+	MyObject.prototype.parent = function( obj ) {
+		if ( obj === undefined ) {
+			return this._parent;
+		}
 		this._parent = obj;
 	};
-	MyObject.prototype.children = function(obj) {
-		if (obj === undefined) { return this._children; }
+	MyObject.prototype.children = function( obj ) {
+		if ( obj === undefined ) {
+			return this._children;
+		}
 		this._children = obj;
 	};
 
 	a = new MyObject();
 	b = new MyObject();
 
-	barr = [b];
-	a.children(barr);
-	b.parent(a);
+	barr = [ b ];
+	a.children( barr );
+	b.parent( a );
 
-	assert.equal(a.children(), barr);
-	assert.deepEqual(a.children(), [b]);
+	assert.equal( a.children(), barr );
+	assert.deepEqual( a.children(), [ b ] );
 });
 
 function testAfterDone() {
@@ -791,45 +793,44 @@ function testAfterDone() {
 		// Because when this does happen, the assertion count parameter doesn't actually
 		// work we use this test to check the assertion count.
 		QUnit.module( "check previous test's assertion counts" );
-		test("count previous two test's assertions", function ( assert ) {
-			var tests = getPreviousTests(/^ensure has correct number of assertions/, /^Synchronous test after load of page$/);
+		test( "count previous two test's assertions", function( assert ) {
+			var tests = getPreviousTests( /^ensure has correct number of assertions/, /^Synchronous test after load of page$/ );
 
-			assert.equal(tests[0].firstChild.lastChild.getElementsByTagName("b")[1].innerHTML, "99");
-			assert.equal(tests[1].firstChild.lastChild.getElementsByTagName("b")[1].innerHTML, "99");
+			assert.equal( tests[ 0 ].firstChild.lastChild.getElementsByTagName( "b" )[ 1 ].innerHTML, "99" );
+			assert.equal( tests[ 1 ].firstChild.lastChild.getElementsByTagName( "b" )[ 1 ].innerHTML, "99" );
 		});
 	}
 	QUnit.config.done = [];
-	QUnit.done(secondAfterDoneTest);
+	QUnit.done( secondAfterDoneTest );
 
 	QUnit.module( "Synchronous test after load of page" );
 
-	asyncTest("Async test", function( assert ) {
+	asyncTest( "Async test", function( assert ) {
 		start();
 		for (var i = 1; i < 100; i++) {
-			assert.ok(i);
+			assert.ok( i );
 		}
 	});
 
-	test(testName, function( assert ) {
+	test( testName, function( assert ) {
 		expect( 99 );
 		for (var i = 1; i < 100; i++) {
-			assert.ok(i);
+			assert.ok( i );
 		}
 	});
 
 	// We need two of these types of tests in order to ensure that assertions
 	// don't move between tests.
-	test(testName + " 2", function( assert ) {
+	test( testName + " 2", function( assert ) {
 		expect( 99 );
 		for (var i = 1; i < 100; i++) {
-			assert.ok(i);
+			assert.ok( i );
 		}
 	});
-
 }
 
-if (typeof setTimeout !== "undefined") {
-	QUnit.done(testAfterDone);
+if ( typeof setTimeout !== "undefined" ) {
+	QUnit.done( testAfterDone );
 }
 
 


### PR DESCRIPTION
I've been playing with [ESFormatter](https://github.com/millermedeiros/esformatter) and used this on QUnit code to fix current inconsistencies in the code style.

It wasn't automatically as I would like to, I got this step by step, reviewing each change. Although, it's not perfect, as I jumped some steps at `test/deepEqual.js` as you can see.

There's no new feature, not even a bug fix here. All should be treated separated. 
