### PR TITLE
Export: Select methods to be exported to the window scope

### DIFF
--- a/src/export.js
+++ b/src/export.js
@@ -1,6 +1,34 @@
 // For browser, export only select globals
 if ( typeof window !== "undefined" ) {
-	extend( window, QUnit.constructor.prototype );
+	(function() {
+		var i, l,
+			toExport = {},
+			keys = [
+				"test",
+				"module",
+				"expect",
+				"asyncTest",
+				"start",
+				"stop",
+				"ok",
+				"equal",
+				"notEqual",
+				"propEqual",
+				"notPropEqual",
+				"deepEqual",
+				"notDeepEqual",
+				"strictEqual",
+				"notStrictEqual",
+				"throws"
+			];
+
+		for ( i = 0, l = keys.length; i < l; i++ ) {
+			toExport[ keys[ i ] ] = QUnit[ keys[ i ] ];
+		}
+
+		extend( window, toExport );
+	})();
+
 	window.QUnit = QUnit;
 }
 


### PR DESCRIPTION
Fixes #561

This patch doesn't try to solve or close the deprecation of logging callback export in https://github.com/jquery/qunit/blob/master/src/core.js#L528-L558

It only select specific methods to export to the window (global) object regarding retro-compatibility.

In another moment, we should deprecate these methods to a further use of namespaced methods, like `QUnit.*`, but that might be planned as even QUnit tests still require them. Examples: test, module, expect, etc.
