### PR TITLE
jsDump: Output non-enumerable properties of TypeError.

### DIFF
--- a/src/dump.js
+++ b/src/dump.js
@@ -151,11 +151,20 @@ QUnit.jsDump = (function() {
 				"arguments": array,
 				object: function( map, stack ) {
 					/*jshint forin:false */
-					var ret = [], keys, key, val, i;
+					var ret = [], keys, key, val, i, nonEnumerableProperties;
 					QUnit.jsDump.up();
 					keys = [];
 					for ( key in map ) {
 						keys.push( key );
+					}
+
+					// Some properties are not always enumerable on Error objects.
+					nonEnumerableProperties = [ "message", "name" ];
+					for ( i in nonEnumerableProperties ) {
+						key = nonEnumerableProperties[ i ];
+						if ( key in map && !( key in keys ) ) {
+							keys.push( key );
+						}
 					}
 					keys.sort();
 					for ( i = 0; i < keys.length; i++ ) {

--- a/test/test.js
+++ b/test/test.js
@@ -414,6 +414,51 @@ test( "jsDump output", function( assert ) {
 	}
 });
 
+test( "jsDump, TypeError properties", function() {
+	function CustomError( message ) {
+		this.message = message;
+	}
+
+	CustomError.prototype.toString = function() {
+		return this.message;
+	};
+	var customError = new CustomError( "sad puppy" ),
+		typeError = new TypeError( "crying kitten" ),
+		expectedCustomMessage = "\"message\": \"sad puppy\"",
+		expectedTypeMessage = "\"message\": \"crying kitten\"",
+		expectedTypeName = "\"name\": \"TypeError\"",
+		
+		dumpedCustomError = QUnit.jsDump.parse( customError ),
+		dumpedTypeError = QUnit.jsDump.parse( typeError ),
+		dumpedTypeErrorWithEnumerable;
+	
+	// Test when object has some enumerable properties by adding one
+	typeError.hasCheeseburger = true;
+	
+	dumpedTypeErrorWithEnumerable = QUnit.jsDump.parse( typeError );
+	
+	QUnit.push(
+			dumpedCustomError.indexOf(expectedCustomMessage) >= 0,
+			dumpedCustomError,
+			expectedCustomMessage,
+			"custom error contains message field" );
+	QUnit.push(
+			dumpedTypeError.indexOf(expectedTypeMessage) >= 0,
+			dumpedTypeError,
+			expectedTypeMessage,
+			"type error contains message field" );
+	QUnit.push(
+			dumpedTypeError.indexOf(expectedTypeName) >= 0,
+			dumpedTypeError,
+			expectedTypeName,
+			"type error contains name field" );
+	QUnit.push(
+			dumpedTypeErrorWithEnumerable.indexOf(expectedTypeMessage) >= 0,
+			dumpedTypeErrorWithEnumerable,
+			expectedTypeMessage,
+			"type error with enumerable field contains message field" );
+});
+
 QUnit.module( "assertions" );
 
 test( "propEqual", function( assert ) {


### PR DESCRIPTION
Fixes #558
This another attempt after pull request #559 had to be reverted. Tests
are now more flexible to deal with inconsistencies across browsers.
