### PR TITLE
jsDump: Add a depth parameter to object parsing

### DIFF
--- a/src/dump.js
+++ b/src/dump.js
@@ -22,6 +22,11 @@ QUnit.dump = (function() {
 	function array( arr, stack ) {
 		var i = arr.length,
 			ret = new Array( i );
+
+		if ( dump.maxDepth && dump.depth > dump.maxDepth ) {
+			return "[object Array]";
+		}
+
 		this.up();
 		while ( i-- ) {
 			ret[ i ] = this.parse( arr[ i ], undefined, stack );
@@ -32,25 +37,27 @@ QUnit.dump = (function() {
 
 	var reName = /^function (\w+)/,
 		dump = {
-			// type is used mostly internally, you can fix a (custom)type in advance
-			parse: function( obj, type, stack ) {
+			// objType is used mostly internally, you can fix a (custom)type in advance
+			parse: function( obj, objType, stack ) {
 				stack = stack || [];
-				var inStack, res,
-					parser = this.parsers[ type || this.typeOf( obj ) ];
-
-				type = typeof parser;
-				inStack = inArray( obj, stack );
+				var res, parser, parserType,
+				    inStack = inArray( obj, stack );
 
 				if ( inStack !== -1 ) {
 					return "recursion(" + ( inStack - stack.length ) + ")";
 				}
-				if ( type === "function" ) {
+
+				objType = objType || this.typeOf( obj  );
+				parser = this.parsers[ objType ];
+				parserType = typeof parser;
+
+				if ( parserType === "function" ) {
 					stack.push( obj );
 					res = parser.call( this, obj, stack );
 					stack.pop();
 					return res;
 				}
-				return ( type === "string" ) ? parser : this.parsers.error;
+				return ( parserType === "string" ) ? parser : this.parsers.error;
 			},
 			typeOf: function( obj ) {
 				var type;
@@ -143,7 +150,13 @@ QUnit.dump = (function() {
 				"arguments": array,
 				object: function( map, stack ) {
 					/*jshint forin:false */
-					var ret = [], keys, key, val, i, nonEnumerableProperties;
+					var keys, key, val, i, nonEnumerableProperties,
+					    ret = [];
+
+					if ( dump.maxDepth && dump.depth > dump.maxDepth ) {
+						return "[object Object]";
+					}
+
 					dump.up();
 					keys = [];
 					for ( key in map ) {

--- a/src/test.js
+++ b/src/test.js
@@ -319,8 +319,10 @@ Test.prototype = {
 		output = message;
 
 		if ( !result ) {
+			QUnit.dump.maxDepth = 5;
 			expected = escapeText( QUnit.dump.parse( expected ) );
 			actual = escapeText( QUnit.dump.parse( actual ) );
+			QUnit.dump.maxDepth = null;
 			output += "<table><tr class='test-expected'><th>Expected: </th><td><pre>" + expected + "</pre></td></tr>";
 
 			if ( actual !== expected ) {

--- a/test/test.js
+++ b/test/test.js
@@ -404,6 +404,42 @@ QUnit.test( "dump output", function( assert ) {
 	}
 });
 
+QUnit.test( "dump output, shallow", function( assert ) {
+	var obj = {
+		top: {
+			middle: {
+				bottom: 0
+			}
+		},
+		left: 0
+	};
+	assert.expect(4);
+	try {
+		QUnit.dump.maxDepth = 1;
+		assert.equal(
+			QUnit.dump.parse( obj ),
+			"{\n  \"left\": 0,\n  \"top\": [object Object]\n}"
+		);
+		QUnit.dump.maxDepth = 2;
+		assert.equal(
+			QUnit.dump.parse( obj ),
+			"{\n  \"left\": 0,\n  \"top\": {\n    \"middle\": [object Object]\n  }\n}"
+		);
+		QUnit.dump.maxDepth = 3;
+		assert.equal(
+			QUnit.dump.parse( obj ),
+			"{\n  \"left\": 0,\n  \"top\": {\n    \"middle\": {\n      \"bottom\": 0\n    }\n  }\n}"
+		);
+		QUnit.dump.maxDepth = 5;
+		assert.equal(
+			QUnit.dump.parse( obj ),
+			"{\n  \"left\": 0,\n  \"top\": {\n    \"middle\": {\n      \"bottom\": 0\n    }\n  }\n}"
+		);
+	} finally {
+		QUnit.dump.maxDepth = null;
+	}
+});
+
 QUnit.test( "dump, TypeError properties", function( assert ) {
 	function CustomError( message ) {
 		this.message = message;


### PR DESCRIPTION
In projects with deep object graphs, like Ember, walking all properties of an an object recursively can end up walking most of memory. This causes the browser to run out of memory and kill the tab/thread.

This introduces a depth option for the parse function, which is used in places where an strictly accurate output of an object is not needed, for instance, when showing two un-equal objects in test output.

I've hard-coded the depth to 5 for output value comparisons. I think this should possibly be configurable? However I'm unsure where/how to reference that. I thought I could read a value right off `config.currentModuleTestEnvironment`?

This is the product of a long afternoon of debugging, and I'm happy to do whatever I must to save others form being bit by the same issue.
