### PR TITLE
Assert: Allow expected to be a string in `throws`.

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -135,7 +135,7 @@ assert = QUnit.assert = {
 			ok = false;
 
 		// 'expected' is optional
-		if ( !message && typeof expected === "string" ) {
+		if ( !message && typeof expected === "string" && arguments.length < 3 ) {
 			message = expected;
 			expected = null;
 		}

--- a/test/test.js
+++ b/test/test.js
@@ -549,7 +549,7 @@ QUnit.test( "propEqual", function( assert ) {
 });
 
 QUnit.test( "throws", function( assert ) {
-	assert.expect( 10 );
+	assert.expect( 11 );
 	function CustomError( message ) {
 		this.message = message;
 	}
@@ -643,6 +643,14 @@ QUnit.test( "throws", function( assert ) {
 		},
 		new Error( "foo" ),
 		"assert when a function throws an 'Error' object"
+	);
+
+	assert.throws(
+		function() {
+			throw new CustomError( "some error description" );
+		},
+		"some error description",
+		"use a regex to match against the stringified error"
 	);
 });
 


### PR DESCRIPTION
Prior to this the following would ignore the third param (the intended message):

``` javascript
throws(
  function() {
    throw new Error('my expected error string');
  },
  'my expected error string',
  'throws the correct error');
```

The documentation states that a string value is acceptable.

![screenshot](http://monosnap.com/image/Dxav7TZEulBJ92RtZRiSh7T890kX6t.png)
