### PR TITLE
Demonstrate what future async support in QUnit should do

### DIFF
--- a/test/future.html
+++ b/test/future.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<title>QUnit Main Test Suite</title>
+	<link rel="stylesheet" href="../dist/qunit.css">
+	<script src="../dist/qunit.js"></script>
+	<script src="future.js"></script>
+	<script src="swarminject.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+	<div id="qunit-fixture">test markup</div>
+</body>
+</html>

--- a/test/future.js
+++ b/test/future.js
@@ -1,0 +1,38 @@
+QUnit.config.reorder = false;
+
+QUnit.module( "the future" );
+
+QUnit.assert.async = QUnit.stop;
+QUnit.assert.done = QUnit.start;
+
+function catchAll() {
+	QUnit.test( "catchAll test, no assertions in here", function( assert ) {
+		assert.expect( 0 );
+		// replacing QUnit.stop();
+		assert.async();
+		setTimeout(function() {
+			// replaceing QUnit.start();
+			assert.done();
+		}, 100 );
+	});
+}
+
+// no async/done here, but any async test that executes assertions
+// after calling start/done will have the same issue
+QUnit.test( "#1 - ok test with one assertion", function( assert ) {
+	assert.expect( 1 );
+	setTimeout(function() {
+		assert.ok( true, "this belongs to test #1" );
+	});
+});
+
+catchAll();
+
+QUnit.test( "#2 - bad test with one failing assertion", function( assert ) {
+	assert.expect( 1 );
+	setTimeout(function() {
+		assert.ok( false, "this belongs to test #2" );
+	});
+});
+
+catchAll();


### PR DESCRIPTION
This is not intended to be merged, at least not as-is. The idea here is to show what the problem with async assertions is, and what it should look and behave like in the future. 

Running the testsuite from this PR currently results in this output:

![bad](http://bassistance.de/i/b2faeb.png)

This highlights an important issue with async tests right now: Assertions can leak into any other test. In this case I've constructed deterministic tests. In practice, the result is not deterministic and much worse, because the "async assertion" can end up in any other test.

The desired output here would deal with that. So that test #1 would fail with "Expected 1 assertions, but 0 were run", but also have a failing assertion with stacktrace and the original message "this belongs to test #1", in addition to something like "assertion ran outside of its own test context". The same would apply to test #2, except that the assertion here would fail for two reasons. Both "catchAll" tests would be green, having 0 assertions. This is what #374 is about.

This PR also demonstrates a possible replacement for the current `stop()`/`start()` pair, adding `async` and `done` methods to the assertion argument. As demonstrated here, that's a pretty trivial change, though it might get more interesting when combined with the above or the suggestions regarding promises in #534.

@leobalter would be great if you could take a look at this. We can then discuss some details and look into actually implementing it. Maybe @Krinkle has input, too?
