### PR TITLE
Implement Assert object constructor

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -1,17 +1,22 @@
-// `assert` initialized at top of scope
+function Assert( testContext ) {
+	this.test = testContext;
+}
+
 // Assert helpers
-// All of these must either call QUnit.push() or manually do:
-// - runLoggingCallbacks( "log", .. );
-// - config.current.assertions.push({ .. });
-assert = QUnit.assert = {
+QUnit.assert = Assert.prototype = {
 
 	// Specify the number of expected assertions to guarantee that failed test (no assertions are run at all) don't slip through.
 	expect: function( asserts ) {
 		if ( arguments.length === 1 ) {
-			config.current.expected = asserts;
+			this.test.expected = asserts;
 		} else {
-			return config.current.expected;
+			return this.test.expected;
 		}
+	},
+
+	// Exports test.push() to the user API
+	push: function() {
+		return this.test.push.apply( this.test, arguments );
 	},
 
 	/**
@@ -24,9 +29,9 @@ assert = QUnit.assert = {
 		message = message || ( result ? "okay" : "failed, expected argument to be truthy, was: " +
 			QUnit.dump.parse( result ) );
 		if ( !!result ) {
-			QUnit.push( true, result, true, message );
+			this.push( true, result, true, message );
 		} else {
-			QUnit.pushFailure( message, null, result );
+			this.test.pushFailure( message, null, result );
 		}
 	},
 
@@ -39,7 +44,7 @@ assert = QUnit.assert = {
 	 */
 	equal: function( actual, expected, message ) {
 		/*jshint eqeqeq:false */
-		QUnit.push( expected == actual, actual, expected, message );
+		this.push( expected == actual, actual, expected, message );
 	},
 
 	/**
@@ -48,7 +53,7 @@ assert = QUnit.assert = {
 	 */
 	notEqual: function( actual, expected, message ) {
 		/*jshint eqeqeq:false */
-		QUnit.push( expected != actual, actual, expected, message );
+		this.push( expected != actual, actual, expected, message );
 	},
 
 	/**
@@ -58,7 +63,7 @@ assert = QUnit.assert = {
 	propEqual: function( actual, expected, message ) {
 		actual = objectValues( actual );
 		expected = objectValues( expected );
-		QUnit.push( QUnit.equiv( actual, expected ), actual, expected, message );
+		this.push( QUnit.equiv( actual, expected ), actual, expected, message );
 	},
 
 	/**
@@ -68,7 +73,7 @@ assert = QUnit.assert = {
 	notPropEqual: function( actual, expected, message ) {
 		actual = objectValues( actual );
 		expected = objectValues( expected );
-		QUnit.push( !QUnit.equiv( actual, expected ), actual, expected, message );
+		this.push( !QUnit.equiv( actual, expected ), actual, expected, message );
 	},
 
 	/**
@@ -76,7 +81,7 @@ assert = QUnit.assert = {
 	 * @function
 	 */
 	deepEqual: function( actual, expected, message ) {
-		QUnit.push( QUnit.equiv( actual, expected ), actual, expected, message );
+		this.push( QUnit.equiv( actual, expected ), actual, expected, message );
 	},
 
 	/**
@@ -84,7 +89,7 @@ assert = QUnit.assert = {
 	 * @function
 	 */
 	notDeepEqual: function( actual, expected, message ) {
-		QUnit.push( !QUnit.equiv( actual, expected ), actual, expected, message );
+		this.push( !QUnit.equiv( actual, expected ), actual, expected, message );
 	},
 
 	/**
@@ -92,7 +97,7 @@ assert = QUnit.assert = {
 	 * @function
 	 */
 	strictEqual: function( actual, expected, message ) {
-		QUnit.push( expected === actual, actual, expected, message );
+		this.push( expected === actual, actual, expected, message );
 	},
 
 	/**
@@ -100,7 +105,7 @@ assert = QUnit.assert = {
 	 * @function
 	 */
 	notStrictEqual: function( actual, expected, message ) {
-		QUnit.push( expected !== actual, actual, expected, message );
+		this.push( expected !== actual, actual, expected, message );
 	},
 
 	"throws": function( block, expected, message ) {
@@ -114,13 +119,13 @@ assert = QUnit.assert = {
 			expected = null;
 		}
 
-		config.current.ignoreGlobalErrors = true;
+		this.test.ignoreGlobalErrors = true;
 		try {
-			block.call( config.current.testEnvironment );
+			block.call( this.test.testEnvironment );
 		} catch (e) {
 			actual = e;
 		}
-		config.current.ignoreGlobalErrors = false;
+		this.test.ignoreGlobalErrors = false;
 
 		if ( actual ) {
 
@@ -153,15 +158,9 @@ assert = QUnit.assert = {
 				ok = true;
 			}
 
-			QUnit.push( ok, actual, expectedOutput, message );
+			this.push( ok, actual, expectedOutput, message );
 		} else {
-			QUnit.pushFailure( message, null, "No exception was thrown." );
+			this.test.pushFailure( message, null, "No exception was thrown." );
 		}
 	}
 };
-
-/**
- * @deprecated since 1.8.0
- * Kept assertion helpers in root for backwards compatibility.
- */
-extend( QUnit.constructor.prototype, assert );

--- a/src/core.js
+++ b/src/core.js
@@ -1,5 +1,4 @@
 var QUnit,
-	assert,
 	config,
 	onErrorFnPrev,
 	testId = 0,
@@ -409,91 +408,6 @@ extend( QUnit, {
 			return "object";
 		}
 		return undefined;
-	},
-
-	push: function( result, actual, expected, message ) {
-		if ( !config.current ) {
-			throw new Error( "assertion outside test context, was " + sourceFromStacktrace() );
-		}
-
-		var output, source,
-			details = {
-				module: config.current.module,
-				name: config.current.testName,
-				result: result,
-				message: message,
-				actual: actual,
-				expected: expected
-			};
-
-		message = escapeText( message ) || ( result ? "okay" : "failed" );
-		message = "<span class='test-message'>" + message + "</span>";
-		output = message;
-
-		if ( !result ) {
-			expected = escapeText( QUnit.dump.parse( expected ) );
-			actual = escapeText( QUnit.dump.parse( actual ) );
-			output += "<table><tr class='test-expected'><th>Expected: </th><td><pre>" + expected + "</pre></td></tr>";
-
-			if ( actual !== expected ) {
-				output += "<tr class='test-actual'><th>Result: </th><td><pre>" + actual + "</pre></td></tr>";
-				output += "<tr class='test-diff'><th>Diff: </th><td><pre>" + QUnit.diff( expected, actual ) + "</pre></td></tr>";
-			}
-
-			source = sourceFromStacktrace();
-
-			if ( source ) {
-				details.source = source;
-				output += "<tr class='test-source'><th>Source: </th><td><pre>" + escapeText( source ) + "</pre></td></tr>";
-			}
-
-			output += "</table>";
-		}
-
-		runLoggingCallbacks( "log", QUnit, details );
-
-		config.current.assertions.push({
-			result: !!result,
-			message: output
-		});
-	},
-
-	pushFailure: function( message, source, actual ) {
-		if ( !config.current ) {
-			throw new Error( "pushFailure() assertion outside test context, was " + sourceFromStacktrace( 2 ) );
-		}
-
-		var output,
-			details = {
-				module: config.current.module,
-				name: config.current.testName,
-				result: false,
-				message: message
-			};
-
-		message = escapeText( message ) || "error";
-		message = "<span class='test-message'>" + message + "</span>";
-		output = message;
-
-		output += "<table>";
-
-		if ( actual ) {
-			output += "<tr class='test-actual'><th>Result: </th><td><pre>" + escapeText( actual ) + "</pre></td></tr>";
-		}
-
-		if ( source ) {
-			details.source = source;
-			output += "<tr class='test-source'><th>Source: </th><td><pre>" + escapeText( source ) + "</pre></td></tr>";
-		}
-
-		output += "</table>";
-
-		runLoggingCallbacks( "log", QUnit, details );
-
-		config.current.assertions.push({
-			result: false,
-			message: output
-		});
 	},
 
 	url: function( params ) {

--- a/test/globals.js
+++ b/test/globals.js
@@ -42,23 +42,6 @@ QUnit.test( "QUnit exported methods", function( assert ) {
 	checkExported( assert, globals );
 });
 
-QUnit.test( "Assertion exported methods", function( assert ) {
-	var methods = [
-			"expect", "ok",
-			"equal", "notEqual",
-			"propEqual", "notPropEqual",
-			"deepEqual", "notDeepEqual",
-			"strictEqual", "notStrictEqual",
-			"throws"
-		];
-
-	// 2 assertions per item on checkExported
-	// +1 assertion per item on the loop
-	assert.expect( methods.length * 3 );
-
-	checkExported( assert, methods, true );
-});
-
 // Get a reference to the global object, like window in browsers
 }( (function() {
 	return this;

--- a/test/test.js
+++ b/test/test.js
@@ -68,26 +68,6 @@ QUnit.test( "expect query and multiple issue", function( assert ) {
 	assert.ok( true );
 });
 
-QUnit.module( "assertion helpers" );
-
-QUnit.test( "QUnit.assert compatibility", function( assert ) {
-	assert.expect( 5 );
-	assert.ok( true, "Calling method on `assert` argument to test() callback" );
-
-	// Should also work, although discouraged and not documented
-	QUnit.assert.ok( true, "Calling method on QUnit.assert object" );
-
-	// Test compatibility aliases
-	QUnit.ok( true, "Calling aliased method in QUnit root object" );
-	assert.ok( true, "Calling aliased function in global namespace" );
-
-	// Regression fix for #341
-	// The assert-context way of testing discouraged global variables,
-	// it doesn't make sense of it itself to be a global variable.
-	// Only allows for mistakes (e.g. forgetting to list 'assert' as parameter)
-	assert.notStrictEqual( window.assert, QUnit.assert, "Assert does not get exposed as a global variable" );
-});
-
 QUnit.module( "setup test", {
 	setup: function( assert ) {
 		assert.ok( true );
@@ -375,7 +355,7 @@ QUnit.test( "scope check", function( assert ) {
 
 QUnit.test( "modify testEnvironment", function( assert ) {
 	assert.expect( 0 );
-	
+
 	// since we only do a shallow copy, nested children of testEnvironment can be modified
 	// and survice
 	this.options.ingredients.push( "carrots" );
@@ -424,7 +404,7 @@ QUnit.test( "dump output", function( assert ) {
 	}
 });
 
-QUnit.test( "dump, TypeError properties", function() {
+QUnit.test( "dump, TypeError properties", function( assert ) {
 	function CustomError( message ) {
 		this.message = message;
 	}
@@ -437,32 +417,32 @@ QUnit.test( "dump, TypeError properties", function() {
 		expectedCustomMessage = "\"message\": \"sad puppy\"",
 		expectedTypeMessage = "\"message\": \"crying kitten\"",
 		expectedTypeName = "\"name\": \"TypeError\"",
-		
+
 		dumpedCustomError = QUnit.dump.parse( customError ),
 		dumpedTypeError = QUnit.dump.parse( typeError ),
 		dumpedTypeErrorWithEnumerable;
-	
+
 	// Test when object has some enumerable properties by adding one
 	typeError.hasCheeseburger = true;
-	
+
 	dumpedTypeErrorWithEnumerable = QUnit.dump.parse( typeError );
-	
-	QUnit.push(
+
+	assert.push(
 			dumpedCustomError.indexOf(expectedCustomMessage) >= 0,
 			dumpedCustomError,
 			expectedCustomMessage,
 			"custom error contains message field" );
-	QUnit.push(
+	assert.push(
 			dumpedTypeError.indexOf(expectedTypeMessage) >= 0,
 			dumpedTypeError,
 			expectedTypeMessage,
 			"type error contains message field" );
-	QUnit.push(
+	assert.push(
 			dumpedTypeError.indexOf(expectedTypeName) >= 0,
 			dumpedTypeError,
 			expectedTypeName,
 			"type error contains name field" );
-	QUnit.push(
+	assert.push(
 			dumpedTypeErrorWithEnumerable.indexOf(expectedTypeMessage) >= 0,
 			dumpedTypeErrorWithEnumerable,
 			expectedTypeMessage,
@@ -709,18 +689,18 @@ QUnit.test( "running test name displayed", function( assert ) {
 }
 
 QUnit.module( "custom assertions" );
-(function() {
-	QUnit.assert.mod2 = function( value, expected, message ) {
-		var actual = value % 2;
-		QUnit.push(actual === expected, actual, expected, message);
-	};
-	QUnit.test("mod2", function( assert ) {
-		assert.expect( 2 );
-		assert.mod2(2, 0, "2 % 2 == 0");
-		assert.mod2(3, 1, "3 % 2 == 1");
-	});
-})();
 
+QUnit.assert.mod2 = function( value, expected, message ) {
+	var actual = value % 2;
+	this.push( actual === expected, actual, expected, message );
+};
+
+QUnit.test( "mod2", function( assert ) {
+	assert.expect( 2 );
+
+	assert.mod2( 2, 0, "2 % 2 == 0" );
+	assert.mod2( 3, 1, "3 % 2 == 1" );
+});
 
 QUnit.module( "recursions" );
 


### PR DESCRIPTION
This patch creates an instanced Assert object. The following characteristics:
- Exclusive to test blocks, `QUnit.assert` is now inexistent
- API `QUnit.push` is now `assert.custom`, it works on the test context.
- API `QUnit.pushFailure` is now `assert.failure`, it works on the test context.
- `assert.ok` is now equalized to other assertions and uses `Test.prototype.push` as well
- **We don't have test assertion leaks anymore (#583), although, we need to patch the reporter interface to run asynced**

Ref #583

@4852aa3 and @97c9a9c are here only for reference, they shouldn't be included in a merge.
