### PR TITLE
Core: Remove old JSHint setting

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -63,8 +63,6 @@ var QUnit,
 	 * @return {Object} New object with only the own properties (recursively).
 	 */
 	objectValues = function( obj ) {
-		// Grunt 0.3.x uses an older version of jshint that still has jshint/jshint#392.
-		/*jshint newcap: false */
 		var key, val,
 			vals = QUnit.is( "array", obj ) ? [] : {};
 		for ( key in obj ) {


### PR DESCRIPTION
Removed a Grunt 0.3.x workaround.
