### PR TITLE
added QUnit.precision existence check in number comparison to handle floats

### DIFF
--- a/src/equiv.js
+++ b/src/equiv.js
@@ -45,11 +45,19 @@ QUnit.equiv = (function() {
 					return a === b;
 				}
 			}
+			
+			function usePrecisionEquality(b, a) {
+				if (typeof QUnit.precision !== "undefined" && QUnit.precision > 0) {
+					return Math.abs(b - a) < QUnit.precision;
+				} else {
+					return useStrictEquality(b, a);
+				}
+			}
 
 			return {
 				"string": useStrictEquality,
 				"boolean": useStrictEquality,
-				"number": useStrictEquality,
+				"number": usePrecisionEquality,
 				"null": useStrictEquality,
 				"undefined": useStrictEquality,
 

--- a/test/deepEqual.js
+++ b/test/deepEqual.js
@@ -109,6 +109,32 @@ QUnit.test( "Primitive types and constants", function( assert ) {
 	assert.equal( QUnit.equiv( { a: 1 }, new SafeObject() ), false, "object literal vs. instantiation" );
 	assert.equal( QUnit.equiv( { a: undefined }, new SafeObject() ), false, "object literal vs. instantiation" );
 	assert.equal( QUnit.equiv( new SafeObject(), { a: undefined } ), false, "object literal vs. instantiation" );
+	
+	
+	assert.equal( QUnit.equiv( 0.0000000001, 0.0000000002 ), false, "float" ); //these numbers are almost the same
+	
+	QUnit.precision = 1e-9; //setting precision
+	assert.equal( QUnit.equiv( 0.0000000001, 0.0000000002 ), true, "float" ); //difference of the numbers is less than the precision, so equiv returns true
+	
+	QUnit.precision = 1e-10; //setting precision
+	assert.equal( QUnit.equiv( 0.0000000001, 0.0000000002 ), false, "float" ); //difference of the numbers is greater than the precision, so equiv returns false
+	
+	QUnit.precision = 0; //turning off the precision check
+	assert.equal( QUnit.equiv( 0.0000000001, 0.0000000002 ), false, "float" ); //these numbers are almost the same
+	
+	QUnit.precision = 1e-9; //turning back the precision check
+	assert.equal( QUnit.equiv( 1.2 + 1.4, 2.6 ), true, "float" ); //usually the sum of (1.2 + 1.4) is something around 2.5999999999999996
+	assert.equal( QUnit.equiv( 1.2 + 1.4, new SafeNumber( 2.6 ) ), true, "float vs object" );
+	
+	assert.equal( QUnit.equiv( 
+							{n: 1.2 + 1.4, m: 2.5999999999999996},
+							{n: 2.6, m: 2.6}),
+							true, "object containing float" );
+	
+	assert.equal( QUnit.equiv( 
+							[1.2 + 1.4, 2.5999999999999996],
+							[2.6, 2.6]),
+							true, "array containing float" );
 });
 
 QUnit.test( "Objects basics", function( assert ) {


### PR DESCRIPTION
Strict comparison of numbers is making tests unstable if they are validating calculation results.
In single cases it is possible to write 
ok(2.6 - 2.59999999996 < 1e-6);
but is case of arrays or objects containing floats the above is not going to work

The change is adding precision support into QUnit.
The default behavior is not changed
