### PR TITLE
Build: Updating BrowserStack config to run all test pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 build/report
+browserstack-run.pid

--- a/browserstack.json
+++ b/browserstack.json
@@ -2,7 +2,12 @@
 	"username": "BROWSERSTACK_USERNAME",
 	"key": "BROWSERSTACK_KEY",
 	"test_framework": "qunit",
-	"test_path": ["test/index.html"],
+	"test_path": [
+		"test/index.html",
+		"test/async.html",
+		"test/logs.html",
+		"test/setTimeout.html"
+	],
 	"browsers": [
 		"chrome_previous",
 		"chrome_latest",


### PR DESCRIPTION
I've noticed that `browserstack-runner` is capable of running multiple test suite pages but we were only running the "index.html" test suite page.

This PR updates the configuration to run all of the test suite pages when using `browserstack-runner`.
