### PR TITLE
Add support for assert.throws expecting any arbitary object

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -148,8 +148,8 @@ QUnit.assert = Assert.prototype = {
 				ok = true;
 
 			// expected is an Error object
-			} else if ( expectedType === "object" && expected instanceof Error ) {
-				ok = actual instanceof Error &&
+			} else if ( expectedType === "object" ) {
+				ok = actual instanceof expected.constructor &&
 					actual.name === expected.name &&
 					actual.message === expected.message;
 

--- a/test/test.js
+++ b/test/test.js
@@ -529,7 +529,7 @@ QUnit.test( "propEqual", function( assert ) {
 });
 
 QUnit.test( "throws", function( assert ) {
-	assert.expect( 14 );
+	assert.expect( 16 );
 	function CustomError( message ) {
 		this.message = message;
 	}
@@ -619,6 +619,25 @@ QUnit.test( "throws", function( assert ) {
 		},
 		new Error( "foo" ),
 		"thrown error object is similar to the expected Error object"
+	);
+
+	assert.throws(
+		function() {
+			throw new CustomError( "some error description" );
+		},
+		new CustomError( "some error description" ),
+		"thrown error object is similar to the expected CustomError object"
+	);
+
+	assert.throws(
+		function() {
+			throw {
+				name: "SomeName",
+				message: "some message"
+			};
+		},
+		{ name: "SomeName", message: "some message" },
+		"thrown error object is similar to the expected plain object"
 	);
 
 	assert.throws(


### PR DESCRIPTION
Including plain objects or instances of custom constructors that didn't inherit from Error.

Fixes #609
