### PR TITLE
Reporter: Reimplements deprecated QUnit.init and QUnit.reset

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -58,6 +58,25 @@ QUnit.init = function() {
 	}
 };
 
+// Resets the test setup. Useful for tests that modify the DOM.
+/*
+DEPRECATED: Use multiple tests instead of resetting inside a test.
+Use testStart or testDone for custom cleanup.
+This method will throw an error in 2.0, and will be removed in 2.1
+*/
+QUnit.reset = function() {
+	// Return on non-browser environments
+	// This is necessary to not break on node tests
+	if ( typeof window === "undefined" ) {
+		return;
+	}
+
+	var fixture = id( "qunit-fixture" );
+	if ( fixture ) {
+		fixture.innerHTML = config.fixture;
+	}
+};
+
 // Don't load the HTML Reporter on non-Browser environments
 if ( typeof window === "undefined" ) {
 	return;

--- a/test/logs.js
+++ b/test/logs.js
@@ -233,4 +233,20 @@ QUnit.test( "after QUnit.init()", function( assert ) {
 	assert.deepEqual( QUnit.config.moduleStats, { all: 0, bad: 0 }, "clean module statistics" );
 });
 
+QUnit.test( "QUnit.reset()", function( assert ) {
+
+	// Skip non-browsers
+	if ( typeof window === "undefined" || !window.document ) {
+		assert.expect( 0 );
+		return;
+	}
+
+	var myFixture = document.getElementById( "qunit-fixture" );
+
+	myFixture.innerHTML = "<em>something different from QUnit.config.fixture</em>";
+
+	QUnit.reset();
+
+	assert.strictEqual( myFixture.innerHTML, QUnit.config.fixture, "restores #qunit-fixture" );
+});
 


### PR DESCRIPTION
This aims for **backwards compatibility**

This pull request reimplements `QUnit.init` and `QUnit.reset` mentioning their deprecated using, it should be removed only on 2.0 and the docs need to be prepared first.

I got this on the reporter because of the using of scoped functions as `id()` and `escapedText()` that are not more present outside.

I also used the `test/logs.js` for tests because it cleans the tests log and it gives a painful mess that I wouldn't like to see on the main tests.

It's also working on all browserstack browsers (changed the html to run)

Closes #530 
Ref #453
