### PR TITLE
Assert: assertions called directly from QUnit.assert

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -16,7 +16,17 @@ QUnit.assert = Assert.prototype = {
 
 	// Exports test.push() to the user API
 	push: function() {
-		return this.test.push.apply( this.test, arguments );
+		var assert = this;
+
+		// Backwards compatibility fix.
+		// Allows the direct use of global exported assertions and QUnit.assert.*
+		// Although, it's use is not recommended as it can leak assertions
+		// to other tests from async tests, because we only get a reference to the current test,
+		// not exactly the test where assertion were intended to be called.
+		if ( !( assert instanceof Assert ) ) {
+			assert = QUnit.config.current.assert;
+		}
+		return assert.test.push.apply( assert.test, arguments );
 	},
 
 	/**

--- a/test/globals.js
+++ b/test/globals.js
@@ -45,13 +45,16 @@ QUnit.test( "QUnit exported methods", function( assert ) {
 
 // Test deprecated exported Assert methods
 QUnit.test( "Exported assertions", function() {
-	QUnit.expect( 4 );
+	QUnit.expect( 6 );
 
 	QUnit.ok( true );
 	QUnit.equal( 2, 2 );
 
 	ok( true );
 	equal( 2, 2 );
+
+	QUnit.assert.ok( true );
+	QUnit.assert.equal( 2, 2 );
 });
 
 // Get a reference to the global object, like window in browsers


### PR DESCRIPTION
Found this bug on running the jQuery Core tests.

This is a backwards compatibility fix.
