### PR TITLE
Async: Make tests Promise-aware

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -206,6 +206,7 @@ grunt.registerTask( "test-on-node", function() {
 	require( "./test/logs" );
 	require( "./test/test" );
 	require( "./test/async" );
+	require( "./test/promise" );
 	require( "./test/modules" );
 	require( "./test/deepEqual" );
 	require( "./test/globals" );

--- a/src/core.js
+++ b/src/core.js
@@ -604,7 +604,6 @@ function process( last ) {
 }
 
 function resumeProcessing() {
-
 	runStarted = true;
 
 	// A slight delay to allow this iteration of the event loop to finish (more assertions, etc.)

--- a/test/index.html
+++ b/test/index.html
@@ -7,6 +7,7 @@
 	<script src="../dist/qunit.js"></script>
 	<script src="test.js"></script>
 	<script src="async.js"></script>
+	<script src="promise.js"></script>
 	<script src="dump.js"></script>
 	<script src="modules.js"></script>
 	<script src="deepEqual.js"></script>

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,0 +1,74 @@
+// NOTE: Adds 1 assertion
+function createMockPromise( assert ) {
+
+	// Return a mock self-fulfilling Promise ("thenable")
+	var thenable = {
+		then: function( fulfilledCallback /*, rejectedCallback */ ) {
+			assert.strictEqual( this, thenable, "`then` was invoked with the Promise as the context" );
+			setTimeout( function() {
+				return fulfilledCallback.call( thenable, {} );
+			}, 13 );
+		}
+	};
+	return thenable;
+}
+
+QUnit.module( "Module with Promise-aware beforeEach", {
+	beforeEach: function( assert ) {
+		assert.ok( true );
+		return {};
+	}
+});
+
+QUnit.test( "non-Promise", function( assert ) {
+	assert.expect( 1 );
+});
+
+QUnit.module( "Module with Promise-aware beforeEach", {
+	beforeEach: function( assert ) {
+
+		// Adds 1 assertion
+		return createMockPromise( assert );
+	}
+});
+
+QUnit.test( "fulfilled Promise", function( assert ) {
+	assert.expect( 1 );
+});
+
+QUnit.module( "Module with Promise-aware afterEach", {
+	afterEach: function( assert ) {
+		assert.ok( true );
+		return {};
+	}
+});
+
+QUnit.test( "non-Promise", function( assert ) {
+	assert.expect( 1 );
+});
+
+QUnit.module( "Module with Promise-aware afterEach", {
+	afterEach: function( assert ) {
+
+		// Adds 1 assertion
+		return createMockPromise( assert );
+	}
+});
+
+QUnit.test( "fulfilled Promise", function( assert ) {
+	assert.expect( 1 );
+});
+
+QUnit.module( "Promise-aware return values without beforeEach/afterEach" );
+
+QUnit.test( "non-Promise", function( assert ) {
+	assert.expect( 0 );
+	return {};
+});
+
+QUnit.test( "fulfilled Promise", function( assert ) {
+	assert.expect( 1 );
+
+	// Adds 1 assertion
+	return createMockPromise( assert );
+});


### PR DESCRIPTION
Fixes #632.
Ref #534.

~~I'm **not** loving how un-DRY the `Test#run` function is... but that's not _new_, only exacerbated by this PR.~~

**Updated:** This makes the `setup`, `teardown`, and `test` methods all aware that their return value may be a Promise in need of asynchronous resolution (`resolve`-ing).

Criticism or other suggestions welcomed, as usual.

cc: @domenic @stefanpenner
