### PR TITLE
Dump: Configurable limit for object depth

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -407,7 +407,11 @@ QUnit.test( "makeurl working with settings from testEnvironment", function( asse
 	);
 });
 
-QUnit.module( "dump" );
+QUnit.module( "dump", {
+	teardown: function() {
+		QUnit.dump.maxDepth = null;
+	}
+});
 
 QUnit.test( "dump output", function( assert ) {
 	assert.equal( QUnit.dump.parse( [ 1, 2 ] ), "[\n  1,\n  2\n]" );
@@ -422,6 +426,38 @@ QUnit.test( "dump output", function( assert ) {
 			"[\n  <h1 id=\"qunit-header\"></h1>\n]"
 		);
 	}
+});
+
+QUnit.test( "dump output, shallow", function( assert ) {
+	var obj = {
+		top: {
+			middle: {
+				bottom: 0
+			}
+		},
+		left: 0
+	};
+	assert.expect( 4 );
+	QUnit.dump.maxDepth = 1;
+	assert.equal( QUnit.dump.parse( obj ), "{\n  \"left\": 0,\n  \"top\": [object Object]\n}" );
+
+	QUnit.dump.maxDepth = 2;
+	assert.equal(
+		QUnit.dump.parse( obj ),
+		"{\n  \"left\": 0,\n  \"top\": {\n    \"middle\": [object Object]\n  }\n}"
+	);
+
+	QUnit.dump.maxDepth = 3;
+	assert.equal(
+		QUnit.dump.parse( obj ),
+		"{\n  \"left\": 0,\n  \"top\": {\n    \"middle\": {\n      \"bottom\": 0\n    }\n  }\n}"
+	);
+
+	QUnit.dump.maxDepth = 5;
+	assert.equal(
+		QUnit.dump.parse( obj ),
+		"{\n  \"left\": 0,\n  \"top\": {\n    \"middle\": {\n      \"bottom\": 0\n    }\n  }\n}"
+	);
 });
 
 QUnit.test( "dump, TypeError properties", function( assert ) {


### PR DESCRIPTION
In projects with deep object graphs, like Ember, walking all properties
of an an object recursively can end up walking most of memory. This
causes the browser to run out of memory and kill the tab/thread.

This introduces a maxDepth config for the parse function, which is used in
places where strictly accurate output of an object is not needed, for
instance, when showing two un-equal object in test output.

Closes #578 
#578 was missing only a rebase and moving the `maxDepth` default to a `QUnit.dump` property. This should be good to land now. I've ran tests with `browserstack-runner`, everything is passing. Looking for another review round from @leobalter @JamesMGreene and @Krinkle.
