### PR TITLE
Perf: Use `Error#stack` without throwing when available

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -552,12 +552,19 @@ function extractStacktrace( e, offset ) {
 		return e.sourceURL + ":" + e.line;
 	}
 }
+
 function sourceFromStacktrace( offset ) {
-	try {
-		throw new Error();
-	} catch ( e ) {
-		return extractStacktrace( e, offset );
+	var error = new Error();
+	if ( !error.stack ) {
+		try {
+			throw error;
+		} catch ( thrownError ) {
+
+			// This should already be true in most browsers
+			error = thrownError;
+		}
 	}
+	return extractStacktrace( error, offset );
 }
 
 function synchronize( callback, last ) {


### PR DESCRIPTION
Fixes #636.
