### PR TITLE
Grunt: update commitplease for compatibility with `git commit -v`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "commitplease": "1.7.0",
+    "commitplease": "1.10.1",
     "grunt": "0.4.2",
     "grunt-contrib-concat": "0.3.0",
     "grunt-contrib-jshint": "0.10.0",


### PR DESCRIPTION
commitplease had a bug before v1.9.0 where it didn't properly handle the verbose flag to `git commit`. This would lead to git diff for preview getting subjected to commit message validation, which could abort commits if it failed.

See https://github.com/jzaefferer/commitplease/pull/19#issuecomment-45204680
