### PR TITLE
Core: change url() helper to output `?foo` instead of `?foo=true`

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -350,8 +350,11 @@ extend( QUnit, {
 
 		for ( key in params ) {
 			if ( hasOwn.call( params, key ) ) {
-				querystring += encodeURIComponent( key ) + "=" +
-					encodeURIComponent( params[ key ] ) + "&";
+				querystring += encodeURIComponent( key );
+				if ( params[ key ] !== true ) {
+					querystring += "=" + encodeURIComponent( params[ key ] );
+				}
+				querystring += "&";
 			}
 		}
 		return window.location.protocol + "//" + window.location.host +


### PR DESCRIPTION
Since the URL params parsing mechanism in QUnit treats the missing value as if the param has value of `true`, we can do the same thing in reverse. If the parameter to serialize a URL with has the value of `true`, it's safe to skip the value part of the query string.

Thus, toggling the checkboxes in the toolbar will result in:

```
test.html?noglobals&notrycatch
```

instead of:

```
test.html?noglobals=true&notrycatch=true
```

Goes well with #678
