### PR TITLE
Core: Remove the newly introduced global hooks until we have consensus

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -125,6 +125,7 @@ Test.prototype = {
 		};
 	},
 
+	// Currently only used for module level hooks, can be used to add global level ones
 	hooks: function( handler ) {
 		var hooks = [];
 
@@ -133,9 +134,6 @@ Test.prototype = {
 			return hooks;
 		}
 
-		if ( QUnit.objectType( config[ handler ] ) === "function" ) {
-			hooks.push( this.queueHook( config[ handler ], handler ) );
-		}
 		if ( this.moduleTestEnvironment && QUnit.objectType( this.moduleTestEnvironment[ handler ] ) === "function" ) {
 			hooks.push( this.queueHook( this.moduleTestEnvironment[ handler ], handler ) );
 		}

--- a/test/modules.js
+++ b/test/modules.js
@@ -1,23 +1,5 @@
-// Before and after each tests
-QUnit.config.beforeEach = function() {
-	this.lastHook = "global-beforeEach";
-};
-
-QUnit.config.afterEach = function( assert ) {
-	if ( this.hooksTest ) {
-		assert.strictEqual( this.lastHook, "module-afterEach", "Global afterEach runs after module's afterEach" );
-		this.hooksTest = false;
-	}
-
-	if ( this.contextTest ) {
-		assert.ok( true );
-		this.contextTest = false;
-	}
-};
-
 QUnit.module( "beforeEach/afterEach", {
-	beforeEach: function( assert ) {
-		assert.strictEqual( this.lastHook, "global-beforeEach", "Global beforeEach runs before module's beforeEach" );
+	beforeEach: function() {
 		this.lastHook = "module-beforeEach";
 	},
 	afterEach: function( assert ) {
@@ -29,7 +11,7 @@ QUnit.module( "beforeEach/afterEach", {
 });
 
 QUnit.test( "hooks order", function( assert ) {
-	assert.expect( 4 );
+	assert.expect( 2 );
 
 	// This will trigger an assertion on the global and one on the module's afterEach
 	this.hooksTest = true;
@@ -46,14 +28,14 @@ QUnit.module( "Test context object", {
 		for ( key in this ) {
 			keys.push( key );
 		}
-		assert.deepEqual( keys, [ "helper", "lastHook" ] );
+		assert.deepEqual( keys, [ "helper" ] );
 	},
 	afterEach: function() {},
 	helper: function() {}
 });
 
 QUnit.test( "keys", function( assert ) {
-	assert.expect( 2 );
+	assert.expect( 1 );
 	this.contextTest = true;
 });
 


### PR DESCRIPTION
Between locating the hooks in `QUnit` or `QUnit.config` and making them simple setters and callback lists (like QUnit.done et al) and upcoming plans for nested suites, we decided not to release this feature, for now.

I'm keeping the abstractions for hooks in place, so it should be trivial to bring this back in whatever form we decide on later.

Effectively reverts 5ee31a083af3b17187f90cde54885bcc46d3dd8f and follow-up commits.

Fixes #665
Ref #633
Ref #635
Ref #647
