### PR TITLE
Build: Specify valid components for commit messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "test": "grunt",
     "prepublish": "grunt build"
   },
+  "commitplease": {
+    "components": [ "Assert", "Build", "CSS", "Core", "Dump", "HTML Reporter", "Test", "Tests" ]
+  },
   "main": "qunit/qunit.js"
 }


### PR DESCRIPTION
Since the update to commitplease 1.11.0 via 5ed001d0b43960e5ba6331d075d98b1fecdf25a5, we can now specify valid components. Am I missing something? Got something wrong? 

I think in the meeting on Wednesday there was a preference of "Reporter" over "HTML Reporter". While we currently have just the one, having a separate folder for reporters justifies a specific component as well. Yay? Nay?

Should we add "License", as used in #526? Or can we dump that into "Build"?
