### PR TITLE
Build: Fix copyright notice in src/, should include first year as well

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -2,7 +2,7 @@
  * QUnit @VERSION
  * http://qunitjs.com/
  *
- * Copyright 2014 jQuery Foundation and other contributors
+ * Copyright 2006, 2014 jQuery Foundation and other contributors
  * Released under the MIT license
  * http://jquery.org/license
  *

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -2,7 +2,7 @@
  * QUnit @VERSION
  * http://qunitjs.com/
  *
- * Copyright 2014 jQuery Foundation and other contributors
+ * Copyright 2006, 2014 jQuery Foundation and other contributors
  * Released under the MIT license
  * http://jquery.org/license
  *


### PR DESCRIPTION
Fixes #695 

bc616098c26b60eaf67a458db59c8a6164036277 is the first commit, dated 2008, though LICENSE.txt lists 2006, so I went with that.
