### PR TITLE
Build: Support CommonJS non-module exports

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -18,6 +18,7 @@
 
 	"globals": {
 		"QUnit": false,
+		"exports": false,
 		"module": false
 	}
 }

--- a/src/export.js
+++ b/src/export.js
@@ -48,7 +48,12 @@ if ( typeof window !== "undefined" ) {
 	window.QUnit = QUnit;
 }
 
-// For CommonJS environments, export everything
+// For nodejs
 if ( typeof module !== "undefined" && module.exports ) {
 	module.exports = QUnit;
+}
+
+// For CommonJS with exports, but without module.exports, like Rhino
+if ( typeof exports !== "undefined" ) {
+	exports.QUnit = QUnit;
 }

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -3,6 +3,16 @@
 // Run with: $ node test/node-test.js
 var QUnit = require( "../dist/qunit" );
 
+QUnit.testStart(function( details ) {
+	var output = "- ";
+	if ( details.module ) {
+		output += details.module + ": ";
+	}
+	console.log( output + details.name );
+});
+
+QUnit.module( "Node" );
+
 QUnit.log(function( details ) {
 	if ( !details.result ) {
 		var output = "FAILED: " + ( details.message ? details.message + ", " : "" );

--- a/test/rhino-test.js
+++ b/test/rhino-test.js
@@ -1,7 +1,17 @@
 /*jshint node:true, undef:false */
 /*globals QUnit:true */
-// Run with: $ narwhal test/narwhal-test.js
-var QUnit = require( "../dist/qunit" );
+// Run with: $ rhino -require test/rhino-test.js
+var QUnit = require( "../dist/qunit" ).QUnit;
+
+QUnit.testStart(function( details ) {
+	var output = "- ";
+	if ( details.module ) {
+		output += details.module + ": ";
+	}
+	print( output + details.name );
+});
+
+QUnit.module( "Rhino" );
 
 QUnit.log(function( details ) {
 	if ( !details.result ) {


### PR DESCRIPTION
Replaces the narwhal test file with instructions for testing with Rhino.

Fixes #521

cc @jdalton
