### PR TITLE
Core: Rewrite QUnit.equiv to be breadth-first

### DIFF
--- a/src/equiv.js
+++ b/src/equiv.js
@@ -134,18 +134,42 @@ export default ( function() {
 			return true;
 		},
 
+		// Define sets a and b to be equivalent if for each element aVal in a, there
+		// is some element bVal in b such that aVal and bVal are equivalent. Element
+		// repetitions are not counted, so these are equivalent:
+		// a = new Set( [ {}, [], [] ] );
+		// b = new Set( [ {}, {}, [] ] );
 		"set": function( a, b ) {
 			var innerEq,
 				outerEq = true;
 
 			if ( a.size !== b.size ) {
+
+				// This optimization has certain quirks because of the lack of
+				// repetition counting. For instance, adding the same
+				// (reference-identical) element to two equivalent sets can
+				// make them non-equivalent.
 				return false;
 			}
 
 			a.forEach( function( aVal ) {
+
+				// Short-circuit if the result is already known. (Using for...of
+				// with a break clause would be cleaner here, but it would cause
+				// a syntax error on older Javascript implementations even if
+				// Set is unused)
+				if ( !outerEq ) {
+					return;
+				}
+
 				innerEq = false;
 
 				b.forEach( function( bVal ) {
+
+					// Likewise, short-circuit if the result is already known
+					if ( innerEq ) {
+						return;
+					}
 					if ( innerEquiv( bVal, aVal ) ) {
 						innerEq = true;
 					}
@@ -159,18 +183,44 @@ export default ( function() {
 			return outerEq;
 		},
 
+		// Define maps a and b to be equivalent if for each key-value pair (aKey, aVal)
+		// in a, there is some key-value pair (bKey, bVal) in b such that
+		// [ aKey, aVal ] and [ bKey, bVal ] are equivalent. Key repetitions are not
+		// counted, so these are equivalent:
+		// a = new Map( [ [ {}, 1 ], [ {}, 1 ], [ [], 1 ] ] );
+		// b = new Map( [ [ {}, 1 ], [ [], 1 ], [ [], 1 ] ] );
 		"map": function( a, b ) {
 			var innerEq,
 				outerEq = true;
 
 			if ( a.size !== b.size ) {
+
+				// This optimization has certain quirks because of the lack of
+				// repetition counting. For instance, adding the same
+				// (reference-identical) key-value pair to two equivalent maps
+				// can make them non-equivalent.
 				return false;
 			}
 
 			a.forEach( function( aVal, aKey ) {
+
+				// Short-circuit if the result is already known. (Using for...of
+				// with a break clause would be cleaner here, but it would cause
+				// a syntax error on older Javascript implementations even if
+				// Map is unused)
+				if ( !outerEq ) {
+					return;
+				}
+
 				innerEq = false;
 
 				b.forEach( function( bVal, bKey ) {
+
+					// Likewise, short-circuit if the result is already known
+					if ( innerEq ) {
+						return;
+					}
+
 					if ( innerEquiv( [ bVal, bKey ], [ aVal, aKey ] ) ) {
 						innerEq = true;
 					}

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -17,9 +17,11 @@ export default ( function() {
 
 	function useStrictEquality( b, a ) {
 
-		// To catch short annotation VS 'new' annotation of a declaration. e.g.:
+		// This only gets called if a and b are not strict equal, and is used to compare on
+		// the primitive values inside object wrappers. For example:
 		// `var i = 1;`
 		// `var j = new Number(1);`
+		// Neither a nor b can be null, as a !== b and they have the same type.
 		if ( typeof a === "object" ) {
 			a = a.valueOf();
 		}

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -15,7 +15,7 @@ export default ( function() {
 		return obj.__proto__;
 	};
 
-	function useStrictEquality( b, a ) {
+	function useStrictEquality( a, b ) {
 
 		// This only gets called if a and b are not strict equal, and is used to compare on
 		// the primitive values inside object wrappers. For example:
@@ -78,7 +78,7 @@ export default ( function() {
 			return true;
 		},
 
-		"regexp": function( b, a ) {
+		"regexp": function( a, b ) {
 			return a.source === b.source &&
 
 				// Include flags in the comparison
@@ -88,14 +88,14 @@ export default ( function() {
 		// - skip when the property is a method of an instance (OOP)
 		// - abort otherwise,
 		// initial === would have catch identical references anyway
-		"function": function( b, a ) {
+		"function": function( a, b ) {
 
 			var caller = callers[ callers.length - 1 ];
 			return caller !== Object && typeof caller !== "undefined" &&
 			a.toString() === b.toString();
 		},
 
-		"array": function( b, a ) {
+		"array": function( a, b ) {
 			var i, j, len, loop, aCircular, bCircular;
 
 			len = a.length;
@@ -134,7 +134,7 @@ export default ( function() {
 			return true;
 		},
 
-		"set": function( b, a ) {
+		"set": function( a, b ) {
 			var innerEq,
 				outerEq = true;
 
@@ -159,7 +159,7 @@ export default ( function() {
 			return outerEq;
 		},
 
-		"map": function( b, a ) {
+		"map": function( a, b ) {
 			var innerEq,
 				outerEq = true;
 
@@ -184,7 +184,7 @@ export default ( function() {
 			return outerEq;
 		},
 
-		"object": function( b, a ) {
+		"object": function( a, b ) {
 			var i, j, loop, aCircular, bCircular;
 
 			// Default to true
@@ -244,7 +244,7 @@ export default ( function() {
 
 	function typeEquiv( a, b ) {
 		var type = objectType( a );
-		return objectType( b ) === type && callbacks[ type ]( b, a );
+		return objectType( b ) === type && callbacks[ type ]( a, b );
 	}
 
 	// The real equiv function

--- a/test/main/deepEqual.js
+++ b/test/main/deepEqual.js
@@ -1595,6 +1595,48 @@ QUnit.test( "Compare self-referent to tree", function( assert ) {
 	);
 } );
 
+QUnit.test( "Compare differently self-referential structures", function( assert ) {
+	var x = [],
+		y = [];
+
+	x[ 0 ] = x;
+	y[ 0 ] = [ y ];
+
+	// x is [ x ], y is [ [ y ] ]
+	// So both x and y look like [ [ [ [ ... ] ] ] ]
+	assert.equal( QUnit.equiv( x, y ), true, "Equivalent arrays" );
+	y = [];
+	y[ 0 ] = [ y, 1 ];
+
+	// x looks like [ [ [ [ ...  ] ] ] ]
+	// y looks like [ [ [ [ ... , 1 ] ], 1 ] ]
+	assert.equal( QUnit.equiv( x, y ), false, "Nonequivalent arrays" );
+	x = {};
+	y = {};
+	x.val = x;
+	y.val = { val: y };
+
+	// Both x and y look like { val: { val: { ... } } }
+	assert.equal( QUnit.equiv( x, y ), true, "Equivalent objects" );
+
+	// x looks like { val: { val: { val: { val: { ... } } } } }
+	// y looks like { val: { val: { val: { val: { ... }, foo: 1 } }, foo: 1 } }
+	y.val = { val: y, foo: 1 };
+	assert.equal( QUnit.equiv( x, y ), false, "Nonequivalent objects" );
+} );
+
+QUnit.test( "Compare structures with multiple references to the same containers", function( assert ) {
+	var i,
+		x = {},
+		y = {};
+	for ( i = 0; i < 20; i++ ) {
+		x = { foo: x, bar: x, baz: x };
+		y = { foo: y, bar: y, baz: y };
+	}
+	assert.equal( QUnit.equiv( { big: x, z: [ true ] }, { big: y, z: [ true ] } ), true, "Equivalent structures" );
+	assert.equal( QUnit.equiv( { big: x, z: [ true ] }, { big: y, z: [ false ] } ), false, "Nonequivalent structures" );
+} );
+
 QUnit.test( "Test that must be done at the end because they extend some primitive's prototype",
 	function( assert ) {
 


### PR DESCRIPTION
Also:
- Redefine Map/Set equivalence to match the .has methods
- Fix recursion bugs, and add tests for failing cases
- Implement recursion for Map
- Document algorithm and rationale
