### PR TITLE
Core: Support a predefined QUnit.config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -99,6 +99,7 @@ grunt.initConfig( {
 			"test/only.html",
 			"test/seed.html",
 			"test/overload.html",
+			"test/preconfigured.html",
 			"test/regex-filter.html",
 			"test/regex-exclude-filter.html",
 			"test/string-filter.html"

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -1,4 +1,5 @@
-import { sessionStorage } from "../globals";
+import { window, sessionStorage } from "../globals";
+import { extend } from "./utilities";
 
 /**
  * Config object: Maintain internal state
@@ -55,6 +56,14 @@ const config = {
 	// The storage module to use for reordering tests
 	storage: sessionStorage
 };
+
+// take a predefined QUnit.config and extend the defaults
+var globalConfig = window && window.QUnit && window.QUnit.config;
+
+// only extend the global config if there is no QUnit overload
+if ( window && window.QUnit && !window.QUnit.version ) {
+	extend( config, globalConfig );
+}
 
 // Push a loose unnamed module to the modules collection
 config.modules.push( config.currentModule );

--- a/src/export.js
+++ b/src/export.js
@@ -47,7 +47,9 @@ Object.defineProperty( QUnit, "reset", {
 } );
 
 if ( defined.document ) {
-	if ( window.QUnit ) {
+
+	// QUnit may be defined when it is preconfigured but then only QUnit and QUnit.config may be defined.
+	if ( window.QUnit && window.QUnit.version ) {
 		throw new Error( "QUnit has already been defined." );
 	}
 

--- a/test/preconfigured.html
+++ b/test/preconfigured.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<title>QUnit Preconfigured Test Suite</title>
+	<link rel="stylesheet" href="../dist/qunit.css">
+	<script>
+		window.QUnit = {
+			config: {
+				autostart: false,
+				reorder: false
+			}
+		};
+	</script>
+	<script src="../dist/qunit.js"></script>
+	<script src="preconfigured.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+</body>
+</html>

--- a/test/preconfigured.js
+++ b/test/preconfigured.js
@@ -1,0 +1,21 @@
+window.addEventListener( "load", function() {
+
+	// make sure QUnit has started if autostart would be true
+	setTimeout( function() {
+		QUnit.module( "QUnit.preconfigured.asyncTests" );
+		QUnit.test( "QUnit.config should have an expected default", function( assert ) {
+			assert.ok( QUnit.config.scrolltop, "The scrolltop default is true" );
+		} );
+
+		QUnit.test( "Qunit.config.reorder default was overwritten", function( assert ) {
+			assert.notOk( QUnit.config.reorder, "reorder was overwritten" );
+		} );
+
+		QUnit.start();
+	}, 100 );
+} );
+
+QUnit.module( "QUnit.preconfigured" );
+QUnit.test( "Autostart is false", function( assert ) {
+	assert.notOk( QUnit.config.autostart, "The global autostart setting is applied" );
+} );


### PR DESCRIPTION
If a global QUnit.config object is present before QUnit is loaded,
the default config values will be extended.
The use case is to configure QUnit before it is loaded.

Closes #1059
