### PR TITLE
Use eslint-plugin-html to lint HTML files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
-# JS files must always use LF for tools to work
+# JS and HTML files must always use LF for tools to work
 *.js eol=lf
 *.json eol=lf
+*.html eol=lf

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,7 +49,10 @@ grunt.initConfig( {
 
 			"test/**/*.js",
 			"build/*.js",
-			"build/tasks/**/*.js"
+			"build/tasks/**/*.js",
+
+			// Linting HTML files via eslint-plugin-html
+			"test/**/*.html"
 		]
 	},
 	search: {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "browserstack-runner": "0.4.3",
     "commitplease": "2.3.0",
     "eslint-config-jquery": "1.0.0",
-    "eslint-plugin-html": "1.6.0",
+    "eslint-plugin-html": "1.7.0",
     "eslint-plugin-qunit": "2.2.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "browserstack-runner": "0.4.3",
     "commitplease": "2.3.0",
     "eslint-config-jquery": "1.0.0",
+    "eslint-plugin-html": "1.6.0",
     "eslint-plugin-qunit": "2.2.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -7,6 +7,9 @@
 		"html",
 		"qunit"
 	],
+	"parserOptions": {
+		"sourceType": "script"
+	},
 	"globals": {
 		"QUnit": false,
 		"console": false

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -4,6 +4,7 @@
 		"browser": true
 	},
 	"plugins": [
+		"html",
 		"qunit"
 	],
 	"globals": {

--- a/test/amd.html
+++ b/test/amd.html
@@ -9,9 +9,9 @@
 <body>
 	<div id="qunit"></div>
 	<script>
-	var beginData;
+	/* eslint-env amd */
 
-	require.config({
+	require.config( {
 		paths: {
 			qunit: "../dist/qunit"
 		}
@@ -19,7 +19,7 @@
 
 	require( [ "qunit", "./amd" ], function( QUnit, tests ) {
 		QUnit.begin( function( data ) {
-			beginData = data;
+			window.beginData = data;
 		} );
 		tests();
 		QUnit.start();

--- a/test/amd.js
+++ b/test/amd.js
@@ -1,5 +1,4 @@
 /* eslint-env amd */
-/* global beginData */
 define( [ "qunit" ], function( QUnit ) {
 
 return function() {
@@ -11,7 +10,7 @@ return function() {
 
 	QUnit.test( "Prove the test run started as expected", function( assert ) {
 		assert.expect( 2 );
-		assert.strictEqual( beginData.totalTests, 1, "Should have expected 1 test" );
+		assert.strictEqual( window.beginData.totalTests, 1, "Should have expected 1 test" );
 	} );
 
 	setTimeout( function() {

--- a/test/autostart.html
+++ b/test/autostart.html
@@ -9,8 +9,7 @@
 	<div id="qunit"></div>
 	<script src="../dist/qunit.js"></script>
 	<script>
-	var beginData,
-		times = {};
+	window.times = {};
 
 	( function() {
 		var now = Date.now || function() {
@@ -21,7 +20,7 @@
 		QUnit.config.autostart = false;
 
 		// Mark the current time
-		times.autostartOff = now() + asyncDelay;
+		window.times.autostartOff = now() + asyncDelay;
 
 		// Simulate a delay in loading the tests, as when they are loaded
 		// asynchronously using requirejs, steal, etc.
@@ -32,8 +31,8 @@
 		}, asyncDelay );
 
 		QUnit.begin( function( data ) {
-			beginData = data;
-			times.runStarted = now();
+			window.beginData = data;
+			window.times.runStarted = now();
 		} );
 	}() );
 	</script>

--- a/test/autostart.js
+++ b/test/autostart.js
@@ -1,11 +1,9 @@
-/*global times, beginData */
-
 QUnit.start();
 
 QUnit.module( "autostart" );
 
 QUnit.test( "Prove the test run started as expected", function( assert ) {
 	assert.expect( 2 );
-	assert.ok( times.autostartOff <= times.runStarted );
-	assert.strictEqual( beginData.totalTests, 1, "Should have expected 1 test" );
+	assert.ok( window.times.autostartOff <= window.times.runStarted );
+	assert.strictEqual( window.beginData.totalTests, 1, "Should have expected 1 test" );
 } );

--- a/test/headless.html
+++ b/test/headless.html
@@ -8,18 +8,18 @@
 	<script src="main/test.js"></script>
 	<script src="main/deepEqual.js"></script>
 	<script>
-		( function () {
-			function createCallback(logType) {
-				QUnit[logType]( function () {
-					console.log(logType, arguments);
+		( function() {
+			function createCallback( logType ) {
+				QUnit[ logType ]( function() {
+					console.log( logType, arguments );
 				} );
 			}
 
-			var logs = ["begin", "testStart", "testDone", "log", "moduleStart", "moduleDone", "done"];
-			for (var i = 0; i < logs.length; i++) {
-				createCallback(logs[i]);
+			var logs = [ "begin", "testStart", "testDone", "log", "moduleStart", "moduleDone", "done" ];
+			for ( var i = 0; i < logs.length; i++ ) {
+				createCallback( logs[ i ] );
 			}
-		}());
+		}() );
 	</script>
 </head>
 <body>

--- a/test/reorderError1.html
+++ b/test/reorderError1.html
@@ -13,18 +13,18 @@
 	// 2. First test failed in second module.
 	// 3. Test count should be 3.
 	if ( window.sessionStorage ) {
-		var totalCount = 0;
+		window.totalCount = 0;
 		sessionStorage[ "qunit-test-First fail module-1-should be fail" ] = 1;
 		sessionStorage[ "qunit-test-Second fail module-1-should be fail" ] = 1;
 		QUnit.done( function( details ) {
-			totalCount = details.total;
+			window.totalCount = details.total;
 			delete sessionStorage[ "qunit-test-First fail module-1-should be fail" ];
 			delete sessionStorage[ "qunit-test-Second fail module-1-should be fail" ];
 		} );
 
 		QUnit.module( "First fail module-1" );
 		QUnit.test( "should pass", function( assert ) {
-			assert.ok( true )
+			assert.ok( true );
 		} );
 		QUnit.test( "should be fail", function( assert ) {
 			assert.ok( false );

--- a/test/reorderError2.html
+++ b/test/reorderError2.html
@@ -13,11 +13,11 @@
 	// 2. First test failed in second module.
 	// 3. Test count should be 2.
 	if ( window.sessionStorage ) {
-		var totalCount = 0;
+		window.totalCount = 0;
 		sessionStorage[ "qunit-test-First fail module-2-should be fail" ] = 1;
 		sessionStorage[ "qunit-test-Second fail module-2-should be fail" ] = 1;
 		QUnit.done( function( details ) {
-			totalCount = details.failed;
+			window.totalCount = details.failed;
 			delete sessionStorage[ "qunit-test-First fail module-2-should be fail" ];
 			delete sessionStorage[ "qunit-test-Second fail module-2-should be fail" ];
 		} );

--- a/test/startError.html
+++ b/test/startError.html
@@ -10,20 +10,17 @@
 	<script src="../dist/qunit.js"></script>
 	<script>
 
-		/* exported autostartStartError, tooManyStartsError */
-		var autostartStartError, tooManyStartsError;
-
 		try {
 			QUnit.config.autostart = true;
 			QUnit.start();
 		} catch ( thrownError ) {
-			autostartStartError = thrownError;
+			window.autostartStartError = thrownError;
 		}
 
 		try {
 			QUnit.start();
 		} catch ( thrownError ) {
-			tooManyStartsError = thrownError;
+			window.tooManyStartsError = thrownError;
 		}
 
 		// Delete QUnit global so we can reload it

--- a/test/startError.html
+++ b/test/startError.html
@@ -9,20 +9,20 @@
 	<div id="qunit"></div>
 	<script src="../dist/qunit.js"></script>
 	<script>
+
+		/* exported autostartStartError, tooManyStartsError */
 		var autostartStartError, tooManyStartsError;
 
 		try {
 			QUnit.config.autostart = true;
 			QUnit.start();
-		}
-		catch ( thrownError ) {
+		} catch ( thrownError ) {
 			autostartStartError = thrownError;
 		}
 
 		try {
 			QUnit.start();
-		}
-		catch ( thrownError ) {
+		} catch ( thrownError ) {
 			tooManyStartsError = thrownError;
 		}
 

--- a/test/startError.js
+++ b/test/startError.js
@@ -1,16 +1,14 @@
-/*global autostartStartError, tooManyStartsError */
-
 QUnit.module( "global start unrecoverable errors" );
 
 QUnit.test( "start() throws when QUnit.config.autostart === true", function( assert ) {
 	assert.expect( 1 );
-	assert.equal( autostartStartError.message,
+	assert.equal( window.autostartStartError.message,
 		"Called start() outside of a test context when QUnit.config.autostart was true" );
 } );
 
 QUnit.test( "Throws after calling start() too many times outside of a test context",
 		function( assert ) {
 	assert.expect( 1 );
-	assert.equal( tooManyStartsError.message,
+	assert.equal( window.tooManyStartsError.message,
 		"Called start() outside of a test context too many times" );
 } );


### PR DESCRIPTION
**This should now be safe to merge.**

This PR uses [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html) to run ESLint on the JavaScript snippets in our HTML files.

Some notes:

1. I edited .gitattributes to make sure our HTML files were treated as having linefeeds on checkout. (From what I can tell, all the HTML files have LF line endings in the repository, but my local Git was checking them out with CRLF due to being on Windows.) I did this to satisfy the ESLint `linebreak-style` rule.
1. Inspired by [this PR review](https://github.com/qunitjs/qunit/pull/1060#pullrequestreview-8301003), I've favored assigning to `window` instead of using implicit global var declarations.
1. There is currently a bug in eslint-plugin-html which causes bogus lint errors to appear before a closing `</script>` tag if there is another opening `<script>` tag further down. I've submitted [this PR](https://github.com/BenoitZugmeyer/eslint-plugin-html/pull/37) to fix the upstream issue.

When the plugin issue is fixed and a new patch release is cut, I'll push another commit to consume that version, and then hopefully CI will pass and this can be merged. (I pushed the PR before that so it could get early review, and I can abandon the branch if this is rejected.)