### PR TITLE
Build: Update Node support versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "4"
   - "6"
+  - "7"
 env:
   - NPM_SCRIPT=ci
 matrix:
@@ -22,11 +22,7 @@ matrix:
 before_install:
   - true && `base64 --decode <<< ZXhwb3J0IEJST1dTRVJTVEFDS19VU0VSTkFNRT1icm93c2Vyc3RhY2txdW5pMQo=`
   - true && `base64 --decode <<< ZXhwb3J0IEJST1dTRVJTVEFDS19LRVk9SllzeHJrVWk5aGJGVndkdW44ZUsK=`
-  # Use a recent version of Node to build
-  - nvm install 6
 script:
-  # Switch back to the version of Node we want to test against
-  - nvm use $TRAVIS_NODE_VERSION
   - npm run-script $NPM_SCRIPT
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
       "Tests"
     ]
   },
-  "main": "qunit/qunit.js"
+  "main": "qunit/qunit.js",
+  "engines": {
+    "node" : "0.12.* || 4.* || 6.* || 7.*"
+  }
 }


### PR DESCRIPTION
Includes our supported versions in package.json to clarify the current support.

This also brings our support policy in line with Rollup, so we can avoid having to switch versions for building.
    
Fixes #1067