### PR TITLE
Core: Implement QUnit.todo

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-concurrent": "2.3.1",
     "grunt-contrib-connect": "1.0.2",
     "grunt-contrib-copy": "1.0.0",
-    "grunt-contrib-qunit": "1.2.0",
+    "grunt-contrib-qunit": "1.3.0",
     "grunt-contrib-watch": "1.0.0",
     "grunt-coveralls": "1.0.1",
     "grunt-eslint": "19.0.0",

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -2,6 +2,13 @@ import QUnit from "../src/core";
 import { window, navigator } from "../src/globals";
 import "./urlparams";
 
+const stats = {
+	passedTests: 0,
+	failedTests: 0,
+	skippedTests: 0,
+	todoTests: 0
+};
+
 // Escape text for attribute or text content.
 export function escapeText( s ) {
 	if ( !s ) {
@@ -620,10 +627,18 @@ QUnit.done( function( details ) {
 	var banner = id( "qunit-banner" ),
 		tests = id( "qunit-tests" ),
 		abortButton = id( "qunit-abort-tests-button" ),
+		totalTests = stats.passedTests + stats.skippedTests + stats.todoTests + stats.failedTests,
 		html = [
-			"Tests completed in ",
+			totalTests,
+			" tests completed in ",
 			details.runtime,
-			" milliseconds.<br />",
+			" milliseconds, with ",
+			stats.failedTests,
+			" failed, ",
+			stats.skippedTests,
+			" skipped, and ",
+			stats.todoTests,
+			" todo.<br />",
 			"<span class='passed'>",
 			details.passed,
 			"</span> assertions of <span class='total'>",
@@ -654,7 +669,7 @@ QUnit.done( function( details ) {
 	}
 
 	if ( banner && ( !abortButton || abortButton.disabled === false ) ) {
-		banner.className = details.failed ? "qunit-fail" : "qunit-pass";
+		banner.className = stats.failedTests ? "qunit-fail" : "qunit-pass";
 	}
 
 	if ( abortButton ) {
@@ -670,7 +685,7 @@ QUnit.done( function( details ) {
 		// Show ✖ for good, ✔ for bad suite result in title
 		// use escape sequences in case file gets loaded with non-utf-8-charset
 		document.title = [
-			( details.failed ? "\u2716" : "\u2714" ),
+			( stats.failedTests ? "\u2716" : "\u2714" ),
 			document.title.replace( /^[\u2714\u2716] /i, "" )
 		].join( " " );
 	}
@@ -824,7 +839,10 @@ QUnit.testDone( function( details ) {
 	good = details.passed;
 	bad = details.failed;
 
-	if ( bad === 0 ) {
+	// This test passed if it has no unexpected failed assertions
+	let testPassed = details.failed > 0 ? details.todo : !details.todo;
+
+	if ( testPassed ) {
 
 		// Collapse the passing tests
 		addClass( assertList, "qunit-collapsed" );
@@ -851,6 +869,8 @@ QUnit.testDone( function( details ) {
 		details.assertions.length + ")</b>";
 
 	if ( details.skipped ) {
+		stats.skippedTests++;
+
 		testItem.className = "skipped";
 		skipped = document.createElement( "em" );
 		skipped.className = "qunit-skipped-label";
@@ -861,12 +881,27 @@ QUnit.testDone( function( details ) {
 			toggleClass( assertList, "qunit-collapsed" );
 		} );
 
-		testItem.className = bad ? "fail" : "pass";
+		testItem.className = testPassed ? "pass" : "fail";
+
+		if ( details.todo ) {
+			let todoLabel = document.createElement( "em" );
+			todoLabel.className = "qunit-todo-label";
+			todoLabel.innerHTML = "todo";
+			testItem.insertBefore( todoLabel, testTitle );
+		}
 
 		time = document.createElement( "span" );
 		time.className = "runtime";
 		time.innerHTML = details.runtime + " ms";
 		testItem.insertBefore( time, assertList );
+
+		if ( !testPassed ) {
+			stats.failedTests++;
+		} else if ( details.todo ) {
+			stats.todoTests++;
+		} else {
+			stats.passedTests++;
+		}
 	}
 
 	// Show the source of the test when showing assertions
@@ -874,7 +909,7 @@ QUnit.testDone( function( details ) {
 		sourceName = document.createElement( "p" );
 		sourceName.innerHTML = "<strong>Source: </strong>" + details.source;
 		addClass( sourceName, "qunit-source" );
-		if ( bad === 0 ) {
+		if ( testPassed ) {
 			addClass( sourceName, "qunit-collapsed" );
 		}
 		addEvent( testTitle, "click", function() {

--- a/src/core.js
+++ b/src/core.js
@@ -3,7 +3,7 @@ import { window, setTimeout } from "./globals";
 import equiv from "./equiv";
 import dump from "./dump";
 import Assert from "./assert";
-import Test, { test, skip, only, pushFailure, generateHash } from "./test";
+import Test, { test, skip, only, todo, pushFailure, generateHash } from "./test";
 import exportQUnit from "./export";
 
 import config from "./core/config";
@@ -97,6 +97,8 @@ extend( QUnit, {
 	},
 
 	test: test,
+
+	todo: todo,
 
 	skip: skip,
 

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -384,6 +384,7 @@
 	background-color: #EBECE9;
 }
 
+#qunit-tests .qunit-todo-label,
 #qunit-tests .qunit-skipped-label {
 	background-color: #F4FF77;
 	display: inline-block;
@@ -392,6 +393,10 @@
 	line-height: 1.8em;
 	padding: 0 0.5em;
 	margin: -0.4em 0.4em -0.4em 0;
+}
+
+#qunit-tests .qunit-todo-label {
+	background-color: #EEE;
 }
 
 /** Result */

--- a/src/test.js
+++ b/src/test.js
@@ -216,6 +216,7 @@ Test.prototype = {
 			moduleName = module.name,
 			testName = this.testName,
 			skipped = !!this.skip,
+			todo = !!this.todo,
 			bad = 0,
 			storage = config.storage;
 
@@ -247,6 +248,7 @@ Test.prototype = {
 			name: testName,
 			module: moduleName,
 			skipped: skipped,
+			todo: todo,
 			failed: bad,
 			passed: this.assertions.length - bad,
 			total: this.assertions.length,
@@ -346,7 +348,8 @@ Test.prototype = {
 				expected: resultInfo.expected,
 				testId: this.testId,
 				negative: resultInfo.negative || false,
-				runtime: now() - this.started
+				runtime: now() - this.started,
+				todo: !!this.todo
 			};
 
 		if ( !resultInfo.result ) {
@@ -378,7 +381,8 @@ Test.prototype = {
 			message: message || "error",
 			actual: actual || null,
 			testId: this.testId,
-			runtime: now() - this.started
+			runtime: now() - this.started,
+			todo: !!this.todo
 		};
 
 		if ( source ) {
@@ -647,6 +651,20 @@ export function test( testName, callback ) {
 	newTest = new Test( {
 		testName: testName,
 		callback: callback
+	} );
+
+	newTest.queue();
+}
+
+export function todo( testName, callback ) {
+	if ( focused ) {
+		return;
+	}
+
+	let newTest = new Test( {
+		testName,
+		callback,
+		todo: true
 	} );
 
 	newTest.queue();

--- a/test/logs.js
+++ b/test/logs.js
@@ -2,7 +2,8 @@ QUnit.config.reorder = false;
 
 var totalTests, moduleContext, moduleDoneContext, testContext, testDoneContext, logContext,
 	testAutorun, beginModules,
-	module1Test1, module1Test2, module2Test1, module2Test2, module2Test3, module2Test4,
+	module1Test1, module1Test2, module2Test1, module2Test2,
+	module2Test3, module2Test4, module2Test5, module2Test6,
 	begin = 0,
 	moduleStart = 0,
 	moduleDone = 0,
@@ -40,6 +41,14 @@ var totalTests, moduleContext, moduleDoneContext, testContext, testDoneContext, 
 			( module2Test4 = {
 				"name": "test the log for the skipped test",
 				"testId": "d3266148"
+			} ),
+			( module2Test5 = {
+				"name": "a todo test",
+				"testId": "77a47174"
+			} ),
+			( module2Test6 = {
+				"name": "test the log for the todo test",
+				"testId": "5f5ab826"
 			} )
 		]
 	};
@@ -117,7 +126,8 @@ QUnit.test( module1Test1.name, function( assert ) {
 		actual: true,
 		expected: true,
 		negative: false,
-		testId: module1Test1.testId
+		testId: module1Test1.testId,
+		todo: false
 	}, "log context after equal(actual, expected, message)" );
 
 	assert.equal( "foo", "foo" );
@@ -131,7 +141,8 @@ QUnit.test( module1Test1.name, function( assert ) {
 		actual: "foo",
 		expected: "foo",
 		negative: false,
-		testId: module1Test1.testId
+		testId: module1Test1.testId,
+		todo: false
 	}, "log context after equal(actual, expected)" );
 
 	assert.ok( true, "ok(true, message)" );
@@ -145,7 +156,8 @@ QUnit.test( module1Test1.name, function( assert ) {
 		actual: true,
 		expected: true,
 		negative: false,
-		testId: module1Test1.testId
+		testId: module1Test1.testId,
+		todo: false
 	}, "log context after ok(true, message)" );
 
 	assert.strictEqual( testDoneContext, undefined, "testDone context" );
@@ -195,7 +207,8 @@ QUnit.test( module1Test2.name, function( assert ) {
 		passed: 18,
 		total: 18,
 		testId: module1Test1.testId,
-		skipped: false
+		skipped: false,
+		todo: false
 	}, "testDone context" );
 	assert.deepEqual( testContext, {
 		module: module1Context.name,
@@ -279,8 +292,34 @@ QUnit.test( module2Test4.name, function( assert ) {
 		passed: 0,
 		total: 0,
 		skipped: true,
+		todo: false,
 		testId: module2Test3.testId,
 		runtime: 0
+	}, "testDone context" );
+} );
+
+QUnit.todo( module2Test5.name, function( assert ) {
+	assert.ok( false );
+	assert.ok( true );
+} );
+
+QUnit.test( module2Test6.name, function( assert ) {
+	assert.expect( 1 );
+
+	delete testDoneContext.runtime;
+	delete testDoneContext.duration;
+	delete testDoneContext.source;
+	delete testDoneContext.assertions;
+
+	assert.deepEqual( testDoneContext, {
+		module: module2Context.name,
+		name: module2Test5.name,
+		failed: 1,
+		passed: 1,
+		total: 2,
+		skipped: false,
+		todo: true,
+		testId: module2Test5.testId
 	}, "testDone context" );
 } );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1339,7 +1339,7 @@ glob@^5.0.15, glob@~5.0.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.5, glob@~7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -1350,7 +1350,7 @@ glob@^7.0.0, glob@~7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@~7.0.0:
+glob@^7.0.3, glob@~7.0.0:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.6.tgz#211bafaf49e525b8cd93260d14ab136152b3f57a"
   dependencies:
@@ -1431,9 +1431,9 @@ grunt-contrib-copy@1.0.0:
     chalk "^1.1.1"
     file-sync-cmp "^0.1.0"
 
-grunt-contrib-qunit@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/grunt-contrib-qunit/-/grunt-contrib-qunit-1.2.0.tgz#76ee87ce8cc157592802bb7545392f671ccb4956"
+grunt-contrib-qunit@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/grunt-contrib-qunit/-/grunt-contrib-qunit-1.3.0.tgz#9dac628cfd4ec815998633db73b52bdb3ddbc99e"
   dependencies:
     grunt-lib-phantomjs "^1.0.0"
 
@@ -2553,15 +2553,15 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.2.8, rimraf@^2.5.2:
+rimraf@^2.2.8, rimraf@~2.2.8:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
+
+rimraf@^2.5.2:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
     glob "^7.0.5"
-
-rimraf@~2.2.8:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
 rollup-plugin-babel@2.6.1:
   version "2.6.1"


### PR DESCRIPTION
Supersedes #1006.

This takes a simpler approach to implementing `QUnit.todo`. We simply add a `todo` flag to `log` and `testDone` details that denotes if an assertion or a test was part of a `todo`. The reporter can then handle that scenario appropriately.

This approach keeps QUnit's internal logic simple and encourages reporters to report success/failure for a test suite based on the outcome of tests and _not_ on the outcome of assertions, which is inline with the thinking of js-reporters.

While this likely means most reporters will have to implement new logic to support `todo`, this change should not break existing reporters and provides a relatively clear path to supporting the new feature.

_Note: Assuming this implementation looks okay, I will open a PR to support `todo` in `grunt-contrib-qunit`._