### PR TITLE
QUnit.load is now called inside QUnit.start

### DIFF
--- a/build/tasks/test-on-node.js
+++ b/build/tasks/test-on-node.js
@@ -51,7 +51,6 @@ module.exports = function( grunt ) {
 
 		require( "../../" + file );
 
-		QUnit.load();
 		QUnit.start();
 	}
 

--- a/src/core.js
+++ b/src/core.js
@@ -121,6 +121,10 @@ extend( QUnit, {
 			} else if ( config.autostart ) {
 				throw new Error( "Called start() outside of a test context when " +
 					"QUnit.config.autostart was true" );
+			} else if ( !defined.document && !config.pageLoaded ) {
+
+				// Starts from Node even if .load was not previously called
+				QUnit.load();
 			} else if ( !config.pageLoaded ) {
 
 				// The page isn't completely loaded yet, so bail out and let `QUnit.load` handle it


### PR DESCRIPTION
Only in non-browser environments, avoiding breaking changes.

Closes gh-1081