### PR TITLE
Reporter: move urlparams import from reporter to html

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -1,5 +1,6 @@
 import QUnit from "../src/core";
 import { window, navigator } from "../src/globals";
+import "./urlparams";
 
 // Escape text for attribute or text content.
 export function escapeText( s ) {

--- a/reporter/reporter.js
+++ b/reporter/reporter.js
@@ -1,3 +1,2 @@
 import "./diff";
 import "./html";
-import "./urlparams";


### PR DESCRIPTION
> 80a14ee5ac49c7f0981884a6cbb5786dea3a9c8b implemented Rollup.
> Reporter is importing `html` before `urlparams`, but `urlparams` needs
> to be loaded before `html` as it was in the previous commit.
> 
> Tried reordering the imports within the file, but running the build task
> seemed to not change the output. By moving the `urlparams` import
> into `html`, the built output is correct.
> 
> Fixes #1082 

Does anyone know why reordering the imports in https://github.com/qunitjs/qunit/blob/master/reporter/reporter.js doesn't have the desired effect?