### PR TITLE
Core: Implement event emitter

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -10,6 +10,7 @@ import config from "./core/config";
 import { defined, extend, objectType, is, now } from "./core/utilities";
 import { registerLoggingCallbacks, runLoggingCallbacks } from "./core/logging";
 import { sourceFromStacktrace } from "./core/stacktrace";
+import { on } from "./events";
 import "./core/onerror";
 
 const QUnit = {};
@@ -28,6 +29,7 @@ QUnit.isLocal = !( defined.document && window.location.protocol !== "file:" );
 QUnit.version = "@VERSION";
 
 extend( QUnit, {
+	on,
 
 	// Call on start of module test to prepend name to all tests
 	module: function( name, testEnvironment, executeNow ) {

--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -28,19 +28,16 @@ export function diff( a, b ) {
 	return result;
 }
 
-// From jquery.js
+/**
+ * Determines whether an element exists in a given array or not.
+ *
+ * @method inArray
+ * @param {Any} elem
+ * @param {Array} array
+ * @return {Boolean}
+ */
 export function inArray( elem, array ) {
-	if ( array.indexOf ) {
-		return array.indexOf( elem );
-	}
-
-	for ( var i = 0, length = array.length; i < length; i++ ) {
-		if ( array[ i ] === elem ) {
-			return i;
-		}
-	}
-
-	return -1;
+	return array.indexOf( elem ) !== -1;
 }
 
 /**

--- a/src/dump.js
+++ b/src/dump.js
@@ -60,7 +60,7 @@ export default ( function() {
 			parse: function( obj, objType, stack ) {
 				stack = stack || [];
 				var res, parser, parserType,
-					inStack = inArray( obj, stack );
+					inStack = stack.indexOf( obj );
 
 				if ( inStack !== -1 ) {
 					return "recursion(" + ( inStack - stack.length ) + ")";
@@ -190,7 +190,7 @@ export default ( function() {
 					nonEnumerableProperties = [ "message", "name" ];
 					for ( i in nonEnumerableProperties ) {
 						key = nonEnumerableProperties[ i ];
-						if ( key in map && inArray( key, keys ) < 0 ) {
+						if ( key in map && !inArray( key, keys ) ) {
 							keys.push( key );
 						}
 					}

--- a/src/events.js
+++ b/src/events.js
@@ -1,6 +1,15 @@
 import { objectType, inArray } from "./core/utilities";
 
 const LISTENERS = Object.create( null );
+const SUPPORTED_EVENTS = [
+	"runStart",
+	"suiteStart",
+	"testStart",
+	"assertion",
+	"testEnd",
+	"suiteEnd",
+	"runEnd"
+];
 
 /**
  * Emits an event with the specified data to all currently registered listeners.
@@ -40,6 +49,9 @@ export function emit( eventName, data ) {
 export function on( eventName, callback ) {
 	if ( objectType( eventName ) !== "string" ) {
 		throw new TypeError( "eventName must be a string when registering a listener" );
+	} else if ( !inArray( eventName, SUPPORTED_EVENTS ) ) {
+		let events = SUPPORTED_EVENTS.join( ", " );
+		throw new Error( `"${eventName}" is not a valid event; must be one of: ${events}.` );
 	} else if ( objectType( callback ) !== "function" ) {
 		throw new TypeError( "callback must be a function when registering a listener" );
 	}

--- a/src/events.js
+++ b/src/events.js
@@ -1,0 +1,55 @@
+import { objectType, inArray } from "./core/utilities";
+
+const LISTENERS = Object.create( null );
+
+/**
+ * Emits an event with the specified data to all currently registered listeners.
+ * Callbacks will fire in the order in which they are registered (FIFO). This
+ * function is not exposed publicly; it is used by QUnit internals to emit
+ * logging events.
+ *
+ * @private
+ * @method emit
+ * @param {String} eventName
+ * @param {Object} data
+ * @return {Void}
+ */
+export function emit( eventName, data ) {
+	if ( objectType( eventName ) !== "string" ) {
+		throw new TypeError( "eventName must be a string when emitting an event" );
+	}
+
+	// Clone the callbacks in case one of them registers a new callback
+	let originalCallbacks = LISTENERS[ eventName ];
+	let callbacks = originalCallbacks ? [ ...originalCallbacks ] : [];
+
+	for ( let i = 0; i < callbacks.length; i++ ) {
+		callbacks[ i ]( data );
+	}
+}
+
+/**
+ * Registers a callback as a listener to the specified event.
+ *
+ * @public
+ * @method on
+ * @param {String} eventName
+ * @param {Function} callback
+ * @return {Void}
+ */
+export function on( eventName, callback ) {
+	if ( objectType( eventName ) !== "string" ) {
+		throw new TypeError( "eventName must be a string when registering a listener" );
+	} else if ( objectType( callback ) !== "function" ) {
+		throw new TypeError( "callback must be a function when registering a listener" );
+	}
+
+	if ( !LISTENERS[ eventName ] ) {
+		LISTENERS[ eventName ] = [];
+	}
+
+	// Don't register the same callback more than once
+	if ( !inArray( callback, LISTENERS[ eventName ] ) ) {
+		LISTENERS[ eventName ].push( callback );
+	}
+}

--- a/src/test.js
+++ b/src/test.js
@@ -437,7 +437,7 @@ Test.prototype = {
 		}
 
 		function moduleChainIdMatch( testModule ) {
-			return inArray( testModule.moduleId, config.moduleId ) > -1 ||
+			return inArray( testModule.moduleId, config.moduleId ) ||
 				testModule.parentModule && moduleChainIdMatch( testModule.parentModule );
 		}
 
@@ -453,7 +453,7 @@ Test.prototype = {
 		}
 
 		if ( config.testId && config.testId.length > 0 &&
-			inArray( this.testId, config.testId ) < 0 ) {
+			!inArray( this.testId, config.testId ) ) {
 
 			return false;
 		}


### PR DESCRIPTION
**Do NOT merge until after 2.1.1 is released.**

This implements a simple event emitter interface that will eventually supersede the current logging callbacks. No tests are added here since the `emit` function is private in scope and not currently wired up internally. One goal here is to avoid a giant PR that both implement the event emitter and wires it up to all possible events.

A follow-up commit to this will use the API implemented here to emit data according to the [js-reporters standard](https://github.com/js-reporters/js-reporters#event-data).