### PR TITLE
Assert: Add step and verifySteps functions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -139,6 +139,7 @@ grunt.initConfig( {
 			"test/logs",
 			"test/main/test",
 			"test/main/assert",
+			"test/main/assert/step",
 			"test/main/async",
 			"test/main/promise",
 			"test/main/modules",

--- a/src/assert.js
+++ b/src/assert.js
@@ -28,6 +28,11 @@ class Assert {
 		} );
 	}
 
+	// Verifies the steps in a test match a given array of string values
+	verifySteps( steps, message ) {
+		this.deepEqual( this.test.steps, steps, message );
+	}
+
 	// Specify the number of expected assertions to guarantee that failed test
 	// (no assertions are run at all) don't slip through.
 	expect( asserts ) {

--- a/src/assert.js
+++ b/src/assert.js
@@ -14,6 +14,20 @@ class Assert {
 
 	// Assert helpers
 
+	// Documents a "step", which is a string value, in a test as a passing assertion
+	step( message ) {
+		let result = !!message;
+
+		message = message || "You must provide a message to assert.step";
+
+		this.test.steps.push( message );
+
+		return this.pushResult( {
+			result,
+			message
+		} );
+	}
+
 	// Specify the number of expected assertions to guarantee that failed test
 	// (no assertions are run at all) don't slip through.
 	expect( asserts ) {

--- a/src/test.js
+++ b/src/test.js
@@ -25,6 +25,7 @@ export default function Test( settings ) {
 	this.usedAsync = false;
 	this.module = config.currentModule;
 	this.stack = sourceFromStacktrace( 3 );
+	this.steps = [];
 
 	// Register unique strings
 	for ( i = 0, l = this.module.tests; i < l.length; i++ ) {

--- a/test/index.html
+++ b/test/index.html
@@ -7,6 +7,7 @@
 	<script src="../dist/qunit.js"></script>
 	<script src="main/test.js"></script>
 	<script src="main/assert.js"></script>
+	<script src="main/assert/step.js"></script>
 	<script src="main/async.js"></script>
 	<script src="main/promise.js"></script>
 	<script src="main/dump.js"></script>

--- a/test/main/assert/step.js
+++ b/test/main/assert/step.js
@@ -34,3 +34,25 @@ QUnit.test( "pushes a passing assertion if a message is given", function( assert
 	assert.step( "One step" );
 	assert.step( "Two step" );
 } );
+
+QUnit.module( "assert.verifySteps" );
+
+QUnit.test( "verifies the order and value of steps", function( assert ) {
+	assert.expect( 6 );
+
+	assert.step( "One step" );
+	assert.step( "Two step" );
+	assert.step( "Red step" );
+	assert.step( "Blue step" );
+
+	assert.verifySteps( [ "One step", "Two step", "Red step", "Blue step" ] );
+
+	var originalPushResult = assert.pushResult;
+	assert.pushResult = function pushResultStub( resultInfo ) {
+		assert.pushResult = originalPushResult;
+
+		assert.notOk( resultInfo.result );
+	};
+
+	assert.verifySteps( [ "One step", "Red step", "Two step", "Blue step" ] );
+} );

--- a/test/main/assert/step.js
+++ b/test/main/assert/step.js
@@ -1,0 +1,36 @@
+QUnit.module( "assert.step" );
+
+QUnit.test( "pushes a failing assertion if no message is given", function( assert ) {
+	assert.expect( 2 );
+
+	var originalPushResult = assert.pushResult;
+	assert.pushResult = function pushResultStub( resultInfo ) {
+		assert.pushResult = originalPushResult;
+
+		assert.notOk( resultInfo.result );
+		assert.equal( resultInfo.message, "You must provide a message to assert.step" );
+	};
+
+	assert.step();
+} );
+
+QUnit.test( "pushes a failing assertion if empty message is given", function( assert ) {
+	assert.expect( 2 );
+
+	var originalPushResult = assert.pushResult;
+	assert.pushResult = function pushResultStub( resultInfo ) {
+		assert.pushResult = originalPushResult;
+
+		assert.notOk( resultInfo.result );
+		assert.equal( resultInfo.message, "You must provide a message to assert.step" );
+	};
+
+	assert.step( "" );
+} );
+
+QUnit.test( "pushes a passing assertion if a message is given", function( assert ) {
+	assert.expect( 2 );
+
+	assert.step( "One step" );
+	assert.step( "Two step" );
+} );


### PR DESCRIPTION
As discussed in #1075. Relevant commit messages:

> Introduces the assert.step function which logs a passing assertion
> for steps in a test. These steps are stored as string values to
> help verify order of operations.

> Introduces the assert.verifySteps function to complement assert.step.
> This acceptances an array of string values to compare to the steps
> that have executed for the current test.