### PR TITLE
Core: Add logger singleton to handle messages

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -1,7 +1,7 @@
 import dump from "./dump";
 import equiv from "./equiv";
 import { internalStop } from "./test";
-import { console } from "./globals";
+import Logger from "./logger";
 
 import config from "./core/config";
 import { objectType, objectValues } from "./core/utilities";
@@ -57,13 +57,8 @@ class Assert {
 	// Exports test.push() to the user API
 	// Alias of pushResult.
 	push( result, actual, expected, message, negative ) {
-
-		// Supports IE9, not throwing if console is not active.
-		// Ref #1092
-		if ( console ) {
-			console.warn( "assert.push is deprecated and will be removed in QUnit 3.0." +
-				" Please use assert.pushResult instead (http://api.qunitjs.com/pushResult/)." );
-		}
+		Logger.warn( "assert.push is deprecated and will be removed in QUnit 3.0." +
+			" Please use assert.pushResult instead (http://api.qunitjs.com/pushResult/)." );
 
 		let currentAssert = this instanceof Assert ? this : config.current.assert;
 		return currentAssert.pushResult( {

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,19 @@
+import { console } from "./globals";
+
+/**
+ * Returns a function that proxies to the given method name on the globals
+ * console object. The proxy will also detect if the console doesn't exist and
+ * will appropriately no-op. This allows support for IE9, which doesn't have a
+ * console if the developer tools are not open.
+ */
+function consoleProxy( method ) {
+	return function( ...args ) {
+		if ( console ) {
+			console[ method ]( ...args );
+		}
+	};
+}
+
+export default {
+	warn: consoleProxy( "warn" )
+};


### PR DESCRIPTION
As brought up in https://github.com/qunitjs/qunit/pull/1093, this adds a `Logger` singleton to handle proxying to `console` methods to abstract potential logic branches.

Unsure how useful it will be in the long run, but for now it makes for simpler code (especially as we plan to deprecate things (e.g., `assert.push`, `QUnit.load`)