### PR TITLE
Assert: Use actual values for verifySteps on failed steps

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -18,13 +18,11 @@ class Assert {
 	step( message ) {
 		let result = !!message;
 
-		message = message || "You must provide a message to assert.step";
-
 		this.test.steps.push( message );
 
 		return this.pushResult( {
 			result,
-			message
+			message: message || "You must provide a message to assert.step"
 		} );
 	}
 

--- a/test/main/assert/step.js
+++ b/test/main/assert/step.js
@@ -56,3 +56,20 @@ QUnit.test( "verifies the order and value of steps", function( assert ) {
 
 	assert.verifySteps( [ "One step", "Red step", "Two step", "Blue step" ] );
 } );
+
+QUnit.test( "verifies the order and value of failed steps", function( assert ) {
+	assert.expect( 3 );
+
+	var originalPushResult = assert.pushResult;
+
+	assert.step( "One step" );
+
+	assert.pushResult = function noop() {};
+	assert.step();
+	assert.step( "" );
+	assert.pushResult = originalPushResult;
+
+	assert.step( "Two step" );
+
+	assert.verifySteps( [ "One step", undefined, "", "Two step" ] );
+} );


### PR DESCRIPTION
As brought up in https://github.com/qunitjs/qunit/pull/1094#discussion_r97558254. When calling `assert.verifySteps()` after a failed `assert.step()`, the bad values will be used in the comparison, even though `You must provide a message to assert.step` is the logged message.