### PR TITLE
Core: Add remaining js-reporter events

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -85,7 +85,7 @@ extend( QUnit, {
 				moduleId: generateHash( moduleName ),
 				testsRun: 0,
 				childModules: [],
-				suiteReport: new SuiteReport( moduleName, parentSuite )
+				suiteReport: new SuiteReport( name, parentSuite )
 			};
 
 			var env = {};

--- a/src/reports/suite.js
+++ b/src/reports/suite.js
@@ -1,0 +1,90 @@
+export default class SuiteReport {
+	constructor( name, parentSuite ) {
+		this.name = name;
+		this.fullName = parentSuite ? parentSuite.fullName.concat( name ) : [];
+
+		this.tests = [];
+		this.childSuites = [];
+
+		if ( parentSuite ) {
+			parentSuite.pushChildSuite( this );
+		}
+	}
+
+	start( recordTime ) {
+		if ( recordTime ) {
+			this._startTime = Date.now();
+		}
+
+		return {
+			name: this.name,
+			fullName: this.fullName.slice(),
+			tests: this.tests.map( test => test.start() ),
+			childSuites: this.childSuites.map( suite => suite.start() ),
+			testCounts: {
+				total: this.getTestCounts().total
+			}
+		};
+	}
+
+	end( recordTime ) {
+		if ( recordTime ) {
+			this._endTime = Date.now();
+		}
+
+		return {
+			name: this.name,
+			fullName: this.fullName.slice(),
+			tests: this.tests.map( test => test.end() ),
+			childSuites: this.childSuites.map( suite => suite.end() ),
+			testCounts: this.getTestCounts(),
+			runtime: this.getRuntime(),
+			status: this.getStatus()
+		};
+	}
+
+	pushChildSuite( suite ) {
+		this.childSuites.push( suite );
+	}
+
+	pushTest( test ) {
+		this.tests.push( test );
+	}
+
+	getRuntime() {
+		return this._endTime - this._startTime;
+	}
+
+	getTestCounts( counts = { passed: 0, failed: 0, skipped: 0, todo: 0, total: 0 } ) {
+		counts = this.tests.reduce( ( counts, test ) => {
+			counts[ test.getStatus() ]++;
+			counts.total++;
+			return counts;
+		}, counts );
+
+		return this.childSuites.reduce( ( counts, suite ) => {
+			return suite.getTestCounts( counts );
+		}, counts );
+	}
+
+	getStatus() {
+		let {
+			total,
+			failed,
+			skipped,
+			todo
+		} = this.getTestCounts();
+
+		if ( failed ) {
+			return "failed";
+		} else {
+			if ( skipped === total ) {
+				return "skipped";
+			} else if ( todo === total ) {
+				return "todo";
+			} else {
+				return "passed";
+			}
+		}
+	}
+}

--- a/src/reports/test.js
+++ b/src/reports/test.js
@@ -1,0 +1,76 @@
+import { extend } from "../core/utilities";
+
+export default class TestReport {
+	constructor( name, suite, options ) {
+		this.name = name;
+		this.suiteName = suite.name;
+		this.fullName = suite.fullName.concat( name );
+		this.runtime = 0;
+		this.assertions = [];
+
+		this.skipped = !!options.skip;
+		this.todo = !!options.todo;
+
+		this._startTime = 0;
+		this._endTime = 0;
+
+		suite.pushTest( this );
+	}
+
+	start( recordTime ) {
+		if ( recordTime ) {
+			this._startTime = Date.now();
+		}
+
+		return {
+			name: this.name,
+			suiteName: this.suiteName,
+			fullName: this.fullName.slice()
+		};
+	}
+
+	end( recordTime ) {
+		if ( recordTime ) {
+			this._endTime = Date.now();
+		}
+
+		return extend( this.start(), {
+			runtime: this.getRuntime(),
+			status: this.getStatus(),
+			errors: this.getFailedAssertions(),
+			assertions: this.getAssertions()
+		} );
+	}
+
+	pushAssertion( assertion ) {
+		this.assertions.push( assertion );
+	}
+
+	getRuntime() {
+		return this._endTime - this._startTime;
+	}
+
+	getStatus() {
+		if ( this.skipped ) {
+			return "skipped";
+		}
+
+		let testPassed = this.getFailedAssertions().length > 0 ? this.todo : !this.todo;
+
+		if ( !testPassed ) {
+			return "failed";
+		} else if ( this.todo ) {
+			return "todo";
+		} else {
+			return "passed";
+		}
+	}
+
+	getFailedAssertions() {
+		return this.assertions.filter( assertion => !assertion.passed );
+	}
+
+	getAssertions() {
+		return this.assertions.slice();
+	}
+}

--- a/src/test.js
+++ b/src/test.js
@@ -422,7 +422,8 @@ Test.prototype = {
 			actual: details.actual,
 			expected: details.expected,
 			message: details.message,
-			stack: details.source
+			stack: details.source,
+			todo: details.todo
 		};
 		this.testReport.pushAssertion( assertion );
 		emit( "assertion", assertion );

--- a/test/events.js
+++ b/test/events.js
@@ -20,8 +20,162 @@ function callback( name ) {
 	};
 }
 
+QUnit.on( "runStart", callback( "runStart" ) );
+QUnit.on( "suiteStart", callback( "suiteStart" ) );
+QUnit.on( "testStart", callback( "testStart" ) );
 QUnit.on( "assertion", callback( "assertion1" ) );
 QUnit.on( "assertion", callback( "assertion2" ) );
+QUnit.on( "testEnd", callback( "testEnd" ) );
+QUnit.on( "suiteEnd", callback( "suiteEnd" ) );
+QUnit.on( "runEnd", callback( "runEnd" ) );
+
+var test1Start = {
+	name: "test1",
+	fullName: [ "Events", "Nested", "test1" ],
+	suiteName: "Nested"
+};
+
+var test2Start = {
+	name: "test2",
+	fullName: [ "Events", "test2" ],
+	suiteName: "Events"
+};
+
+var test3Start = {
+	name: "test3",
+	fullName: [ "Events", "test3" ],
+	suiteName: "Events"
+};
+
+var suite2Start = {
+	name: "Nested",
+	fullName: [ "Events", "Nested" ],
+	childSuites: [],
+	testCounts: {
+		total: 1
+	},
+	tests: [
+		test1Start
+	]
+};
+
+var suite1Start = {
+	name: "Events",
+	fullName: [ "Events" ],
+	childSuites: [
+		suite2Start
+	],
+	testCounts: {
+		total: 3
+	},
+	tests: [
+		test2Start,
+		test3Start
+	]
+};
+
+var assertion1 = {
+	passed: false,
+	actual: false,
+	expected: true,
+	message: "failing assertion"
+};
+
+var assertion2 = {
+	passed: true,
+	actual: true,
+	expected: true,
+	message: "passing assertion"
+};
+
+var test1End = {
+	name: "test1",
+	fullName: [ "Events", "Nested", "test1" ],
+	suiteName: "Nested",
+	status: "todo",
+	errors: [
+		assertion1
+	],
+	assertions: [
+		assertion1
+	]
+};
+
+var test2End = {
+	name: "test2",
+	fullName: [ "Events", "test2" ],
+	suiteName: "Events",
+	status: "passed",
+	errors: [],
+	assertions: [
+		assertion2
+	]
+};
+
+var test3End = {
+	name: "test3",
+	fullName: [ "Events", "test3" ],
+	suiteName: "Events",
+	status: "skipped",
+	errors: [],
+	assertions: []
+};
+
+var suite2End = {
+	name: "Nested",
+	fullName: [ "Events", "Nested" ],
+	status: "todo",
+	childSuites: [],
+	testCounts: {
+		skipped: 0,
+		passed: 0,
+		failed: 0,
+		todo: 1,
+		total: 1
+	},
+	tests: [
+		test1End
+	]
+};
+
+var suite1End = {
+	name: "Events",
+	fullName: [ "Events" ],
+	status: "passed",
+	childSuites: [
+		suite2End
+	],
+	testCounts: {
+		skipped: 1,
+		passed: 1,
+		failed: 0,
+		todo: 1,
+		total: 3
+	},
+	tests: [
+		test2End,
+		test3End
+	]
+};
+
+function removeUnstableProperties( obj ) {
+	if ( typeof obj !== "object" ) {
+		return obj;
+	}
+
+	delete obj.runtime;
+	delete obj.stack;
+
+	Object.keys( obj ).forEach( function( key ) {
+		if ( Array.isArray( obj[ key ] ) ) {
+			obj[ key ].forEach( removeUnstableProperties );
+		} else if ( typeof obj[ key ] === "object" ) {
+			removeUnstableProperties( obj[ key ] );
+		}
+	} );
+
+	return obj;
+}
 
 // After all the tests run, we verify the events were fired in the correct order
 // with the correct data
@@ -35,22 +189,102 @@ QUnit.done( function() {
 	QUnit.module( "Events" );
 	QUnit.test( "verify callback order and data", function( assert ) {
 		assert.deepEqual( invokedHooks, [
+			"runStart",
+			"suiteStart",
+			"suiteStart",
+			"testStart",
 			"assertion1",
-			"assertion2"
+			"assertion2",
+			"testEnd",
+			"suiteEnd",
+			"testStart",
+			"assertion1",
+			"assertion2",
+			"testEnd",
+			"testStart",
+			"testEnd",
+			"suiteEnd",
+			"runEnd"
 		], "event callbacks are called in correct order" );
 
-		assert.deepEqual( invokedHookDetails.assertion1[ 0 ], {
-			passed: true,
-			actual: true,
-			expected: true,
-			message: "passing assertion",
-			stack: undefined
-		}, "assertion callback data is correct" );
+		assert.deepEqual(
+			invokedHookDetails.suiteStart[ 0 ],
+			suite1Start,
+			"start of suite with tests and child suites data is correct"
+		);
+		assert.deepEqual(
+			invokedHookDetails.suiteStart[ 1 ],
+			suite2Start,
+			"start of child suite with tests data is correct"
+		);
+
+		// These are pushed in reverse order of the testStarts
+		assert.deepEqual(
+			removeUnstableProperties( invokedHookDetails.suiteEnd[ 0 ] ),
+			suite2End,
+			"end of child suite with tests data is correct"
+		);
+		assert.deepEqual(
+			removeUnstableProperties( invokedHookDetails.suiteEnd[ 1 ] ),
+			suite1End,
+			"end of suite with tests and child suites data is correct"
+		);
+
+		assert.deepEqual(
+			invokedHookDetails.testStart[ 0 ],
+			test1Start,
+			"regular testStart data is correct"
+		);
+		assert.deepEqual(
+			invokedHookDetails.testStart[ 1 ],
+			test2Start,
+			"skipped testStart data is correct"
+		);
+		assert.deepEqual(
+			invokedHookDetails.testStart[ 2 ],
+			test3Start,
+			"todo testStart data is correct"
+		);
+
+		assert.deepEqual(
+			removeUnstableProperties( invokedHookDetails.testEnd[ 0 ] ),
+			test1End,
+			"todo testEnd data is correct"
+		);
+		assert.deepEqual(
+			removeUnstableProperties( invokedHookDetails.testEnd[ 1 ] ),
+			test2End,
+			"regular testEnd data is correct"
+		);
+		assert.deepEqual(
+			removeUnstableProperties( invokedHookDetails.testEnd[ 2 ] ),
+			test3End,
+			"skipped testEnd data is correct"
+		);
+
+		assert.deepEqual(
+			invokedHookDetails.assertion1[ 0 ],
+			assertion1,
+			"failing assertion data is correct"
+		);
+		assert.deepEqual(
+			invokedHookDetails.assertion1[ 1 ],
+			assertion2,
+			"passing assertion data is correct"
+		);
 	} );
 } );
 
 QUnit.module( "Events", function() {
-	QUnit.test( "test1", function( assert ) {
+	QUnit.module( "Nested", function() {
+		QUnit.todo( "test1", function( assert ) {
+			assert.ok( false, "failing assertion" );
+		} );
+	} );
+
+	QUnit.test( "test2", function( assert ) {
 		assert.ok( true, "passing assertion" );
 	} );
+
+	QUnit.skip( "test3" );
 } );

--- a/test/events.js
+++ b/test/events.js
@@ -78,14 +78,16 @@ var assertion1 = {
 	passed: false,
 	actual: false,
 	expected: true,
-	message: "failing assertion"
+	message: "failing assertion",
+	todo: true
 };
 
 var assertion2 = {
 	passed: true,
 	actual: true,
 	expected: true,
-	message: "passing assertion"
+	message: "passing assertion",
+	todo: false
 };
 
 var test1End = {


### PR DESCRIPTION
~~**Note: Still a work-in-progress, likely will not be ready to review until after https://github.com/qunitjs/qunit/pull/1080 has landed.**~~

Since all the suite and test events are intertwined in the js-reporter spec, we have to introduce the remaining events all at once.

This also adds a `todo` field to the `assertion` event data now that `QUnit.todo()` has landed.

---

After this PR, we should update the HTML reporter to use the new event emitter interface, introduce a generic TAP reporter, and then hopefully iterate on our existing test-on-node task to become the foundation for a CLI.