### PR TITLE
Core: Fix start on Node when autostart is not set to true

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -129,16 +129,18 @@ extend( QUnit, {
 			} else if ( config.autostart ) {
 				throw new Error( "Called start() outside of a test context when " +
 					"QUnit.config.autostart was true" );
-			} else if ( !defined.document && !config.pageLoaded ) {
-
-				// Starts from Node even if .load was not previously called. We return
-				// early otherwise we'll wind up "beginning" twice.
-				QUnit.load();
-				return;
 			} else if ( !config.pageLoaded ) {
 
-				// The page isn't completely loaded yet, so bail out and let `QUnit.load` handle it
+				// The page isn't completely loaded yet, so we set autostart and then
+				// load if we're in Node or wait for the browser's load event.
 				config.autostart = true;
+
+				// Starts from Node even if .load was not previously called. We still return
+				// early otherwise we'll wind up "beginning" twice.
+				if ( !defined.document ) {
+					QUnit.load();
+				}
+
 				return;
 			}
 		} else {


### PR DESCRIPTION
When I submitted https://github.com/qunitjs/qunit/pull/1103, it turns out the test-on-node task never actually ran. The reason is that we don't set `autostart` to `true`. This fix will handle that case as well.