### PR TITLE
[WIP] Core: Introduce reporter control API

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,0 +1,37 @@
+import { objectType } from "./core/utilities";
+import QUnit, { internalState } from "./core";
+
+const reporters = [];
+let defaultReporter;
+
+function validateReporterChange( functionName, reporter ) {
+	let reporterType = objectType( reporter );
+	if ( reporterType !== "function" ) {
+		throw new Error(
+			`Expected ${functionName} to be called with a constructor function, ` +
+			`but was called with a ${reporterType}.`
+		);
+	} else if ( internalState.runStarted ) {
+		throw new Error(
+			`Called ${functionName} after the test run has started.`
+		);
+	}
+}
+
+export function addReporter( reporter ) {
+	validateReporterChange( "addReporter", reporter );
+	reporters.push( reporter );
+}
+
+export function setDefaultReporter( reporter ) {
+	validateReporterChange( "setDefaultReporter", reporter );
+	defaultReporter = reporter;
+}
+
+export function initializeReporters() {
+	[ defaultReporter, ...reporters ]
+		.filter( Boolean )
+		.forEach( reporter => {
+			return reporter.init ? reporter.init( QUnit ) : new reporter( QUnit );
+		} );
+}

--- a/test/reporter.html
+++ b/test/reporter.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>QUnit Reporter API Test Suite</title>
+		<link rel="stylesheet" href="../dist/qunit.css">
+		<script src="../dist/qunit.js"></script>
+		<script src="reporter.js"></script>
+	</head>
+	<body>
+		<div id="qunit"></div>
+	</body>
+</html>

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -1,0 +1,80 @@
+var defaultReporter1Called = false;
+function DefaultReporter1() {
+	defaultReporter1Called = true;
+}
+
+var defaultReporter2Called = false;
+function DefaultReporter2() {
+	defaultReporter2Called = true;
+}
+
+QUnit.setDefaultReporter( DefaultReporter1 );
+QUnit.setDefaultReporter( DefaultReporter2 );
+
+var testReporterCalledWith;
+function TestReporter( runner ) {
+	testReporterCalledWith = runner;
+}
+
+var initReporterCalledWith;
+function InitReporter() {}
+InitReporter.init = function( runner ) {
+	initReporterCalledWith = runner;
+};
+
+QUnit.addReporter( TestReporter );
+QUnit.addReporter( InitReporter );
+
+QUnit.module( "Reporter API", function() {
+	QUnit.module( "setDefaultReporter", function() {
+		QUnit.test( "only initializes last default reporter", function( assert ) {
+			assert.notOk( defaultReporter1Called, "first default reporter not initialized" );
+			assert.ok( defaultReporter2Called, "last default reporter initialized" );
+		} );
+
+		QUnit.test( "throws an error if the reporter is not a function", function( assert ) {
+			assert.throws(
+				() => QUnit.setDefaultReporter( "TAP" ),
+				// eslint-disable-next-line
+				/Expected setDefaultReporter to be called with a constructor function, but was called with a string./
+			);
+		} );
+
+		QUnit.test( "throws an error if the test run has already started", function( assert ) {
+			assert.throws(
+				() => QUnit.setDefaultReporter( function Reporter() {} ),
+				/Called setDefaultReporter after the test run has started./
+			);
+		} );
+	} );
+
+	QUnit.module( "addReporter", function() {
+		QUnit.test( "initializes added reporters", function( assert ) {
+			assert.strictEqual(
+				testReporterCalledWith,
+				QUnit,
+				"Called reporter constructor with QUnit"
+			);
+			assert.strictEqual(
+				initReporterCalledWith,
+				QUnit,
+				"Called reporter init method with QUnit"
+			);
+		} );
+
+		QUnit.test( "throws an error if the reporter is not a function", function( assert ) {
+			assert.throws(
+				() => QUnit.addReporter( "TAP" ),
+				// eslint-disable-next-line
+				/Expected addReporter to be called with a constructor function, but was called with a string./
+			);
+		} );
+
+		QUnit.test( "throws an error if the test run has already started", function( assert ) {
+			assert.throws(
+				() => QUnit.addReporter( function Reporter() {} ),
+				/Called addReporter after the test run has started./
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
This introduces an API to control what reporters are used by QUnit at run time.

This should eventually be used to register the HTML Reporter by default for Browser environments and the TAP Reporter by default for non-Browser environments.