### PR TITLE
All: Enable some ES2015-specific ESLint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,16 @@
         "sourceType": "module"
     },
     "rules": {
+        "arrow-spacing": ["error", { "before": true, "after": true }],
         "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
+        "constructor-super": "error",
+        "no-const-assign": "error",
+        "no-dupe-class-members": "error",
+        "no-duplicate-imports": "error",
+        "no-this-before-super": "error",
+        "no-useless-constructor": "error",
+        "no-useless-rename": "error",
+        "rest-spread-spacing": ["error", "never"],
         "wrap-iife": ["error", "any"]
     }
 }


### PR DESCRIPTION
Enabling nine fairly simple ES2015 ESLint rules for the repo, none of which required any code changes.

* [arrow-spacing](http://eslint.org/docs/rules/arrow-spacing): Assuming arrow operators should always have spaces around them
* [constructor-super](http://eslint.org/docs/rules/constructor-super): In a derived class with a constructor, ensure `super()` is called right away
* [no-const-assign](http://eslint.org/docs/rules/no-const-assign): Forbid reassigning a const variable (would throw runtime error)
* [no-dupe-class-members](http://eslint.org/docs/rules/no-dupe-class-members): Class members must be unique (otherwise latter definition would override former)
* [no-duplicate-imports](http://eslint.org/docs/rules/no-duplicate-imports): Multiple imports from same module are not allowed, must combine specifiers
* [no-this-before-super](http://eslint.org/docs/rules/no-this-before-super): In a derived class with a constructor, ensure `super()` is called before any use of `this` or `super`
* [no-useless-constructor](http://eslint.org/docs/rules/no-useless-constructor): Warn on empty constructors (for classes with no superclass) or `super()`-only constructors that just forward arguments (for classes with a superclass).
* [no-useless-rename](http://eslint.org/docs/rules/no-useless-rename): Forbid silly renames during import, export, and destructuring assignment.
* [rest-spread-spacing](http://eslint.org/docs/rules/rest-spread-spacing): Ensure no spaces are used between rest or spread operator and its operand.

Happy to remove anything that seems not terribly important, just let me know.