### PR TITLE
Core: QUnit.onError resumes the test runner

### DIFF
--- a/src/core/onerror.js
+++ b/src/core/onerror.js
@@ -1,4 +1,4 @@
-import { pushFailure, test } from "../test";
+import { internalRecover, pushFailure, test } from "../test";
 
 import config from "./config";
 import { extend } from "./utilities";
@@ -12,7 +12,10 @@ export default function onError( error, ...args ) {
 		if ( config.current.ignoreGlobalErrors ) {
 			return true;
 		}
+
 		pushFailure( error.message, error.fileName + ":" + error.lineNumber, ...args );
+
+		internalRecover( config.current );
 	} else {
 		test( "global failure", extend( function() {
 			pushFailure( error.message, error.fileName + ":" + error.lineNumber, ...args );

--- a/src/test.js
+++ b/src/test.js
@@ -663,7 +663,7 @@ export function internalStop( test ) {
 }
 
 // Forcefully release all processing holds.
-function internalRecover( test ) {
+export function internalRecover( test ) {
 	test.semaphore = 0;
 	internalStart( test );
 }

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -173,6 +173,19 @@ QUnit.test( "fails if callback is called more than callback call count", functio
 	done();
 } );
 
+QUnit.test( "Current test should not advance while waiting for async", function( assert ) {
+	var done = assert.async();
+
+	assert.expect( 2 );
+
+	assert.strictEqual( QUnit.config.current, assert.test, "Current test is this test" );
+
+	setTimeout( function() {
+		assert.strictEqual( QUnit.config.current, assert.test, "Current test is still this test" );
+		done();
+	}, 100 );
+} );
+
 QUnit.module( "assert.async in module hooks", {
 	before: asyncCallback,
 	beforeEach: asyncCallback,

--- a/test/onerror/inside-test.js
+++ b/test/onerror/inside-test.js
@@ -33,4 +33,26 @@ QUnit.module( "QUnit.onError", function() {
 
 		assert.strictEqual( result, true, "onError should not allow other error handlers to run" );
 	} );
+
+	QUnit.test( "Should resume test runner if test was stopped", function( assert ) {
+		assert.expect( 2 );
+
+		// This would hold up the test runner, but onError should resume it
+		assert.async();
+
+		// Avoid assertion error
+		QUnit.config.current.pushFailure = function() {
+			assert.ok( true, "pushFailure was called" );
+		};
+
+		setTimeout( function() {
+			assert.ok( true, "Waited for async successfully" );
+
+			QUnit.onError( {
+				message: "Error message",
+				fileName: "filePath.js",
+				lineNumber: 1
+			} );
+		}, 50 );
+	} );
 } );


### PR DESCRIPTION
Fixes gh-990.

At first I was thinking we needed a configuration option to control this behavior, but... who wouldn't want a fatal error to at least try to resume the test runner? (We could add a configuration option later, if necessary.)

If someone needs to account for multiple errors possibly being thrown asynchronously, I think that could be handled by implementing a custom `window.onerror` handler (or equivalent) which would handle collecting the individual errors and only call `QUnit.onError()` with an aggregate error object when it is for sure abandoning the test. (Of course, better practice is to implement error handling in the test itself, or write more reliable code...)