### PR TITLE
All: Enable ESLint prefer-const rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
         "no-this-before-super": "error",
         "no-useless-constructor": "error",
         "no-useless-rename": "error",
+        "prefer-const": "error",
         "rest-spread-spacing": ["error", "never"],
         "wrap-iife": ["error", "any"]
     }

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -840,7 +840,7 @@ QUnit.testDone( function( details ) {
 	bad = details.failed;
 
 	// This test passed if it has no unexpected failed assertions
-	let testPassed = details.failed > 0 ? details.todo : !details.todo;
+	const testPassed = details.failed > 0 ? details.todo : !details.todo;
 
 	if ( testPassed ) {
 
@@ -884,7 +884,7 @@ QUnit.testDone( function( details ) {
 		testItem.className = testPassed ? "pass" : "fail";
 
 		if ( details.todo ) {
-			let todoLabel = document.createElement( "em" );
+			const todoLabel = document.createElement( "em" );
 			todoLabel.className = "qunit-todo-label";
 			todoLabel.innerHTML = "todo";
 			testItem.insertBefore( todoLabel, testTitle );
@@ -948,7 +948,7 @@ window.onerror = function( message, fileName, lineNumber, ...args ) {
 	// Treat return value as window.onerror itself does,
 	// Only do our handling if not suppressed.
 	if ( ret !== true ) {
-		let error = {
+		const error = {
 			message,
 			fileName,
 			lineNumber

--- a/src/assert.js
+++ b/src/assert.js
@@ -16,7 +16,7 @@ class Assert {
 
 	// Documents a "step", which is a string value, in a test as a passing assertion
 	step( message ) {
-		let result = !!message;
+		const result = !!message;
 
 		this.test.steps.push( message );
 
@@ -43,8 +43,9 @@ class Assert {
 
 	// Put a hold on processing and return a function that will release it a maximum of once.
 	async( count ) {
-		let test = this.test,
-			popped = false,
+		const test = this.test;
+
+		let popped = false,
 			acceptCallCount = count;
 
 		if ( typeof acceptCallCount === "undefined" ) {
@@ -52,7 +53,7 @@ class Assert {
 		}
 
 		test.usedAsync = true;
-		let resume = internalStop( test );
+		const resume = internalStop( test );
 
 		return function done() {
 			if ( popped ) {
@@ -77,7 +78,7 @@ class Assert {
 		Logger.warn( "assert.push is deprecated and will be removed in QUnit 3.0." +
 			" Please use assert.pushResult instead (http://api.qunitjs.com/pushResult/)." );
 
-		let currentAssert = this instanceof Assert ? this : config.current.assert;
+		const currentAssert = this instanceof Assert ? this : config.current.assert;
 		return currentAssert.pushResult( {
 			result,
 			actual,
@@ -90,8 +91,8 @@ class Assert {
 	pushResult( resultInfo ) {
 
 		// Destructure of resultInfo = { result, actual, expected, message, negative }
-		let assert = this,
-			currentTest = ( assert instanceof Assert && assert.test ) || config.current;
+		let assert = this;
+		const currentTest = ( assert instanceof Assert && assert.test ) || config.current;
 
 		// Backwards compatibility fix.
 		// Allows the direct use of global exported assertions and QUnit.assert.*
@@ -149,7 +150,7 @@ class Assert {
 	equal( actual, expected, message ) {
 
 		// eslint-disable-next-line eqeqeq
-		let result = expected == actual;
+		const result = expected == actual;
 
 		this.pushResult( {
 			result,
@@ -162,7 +163,7 @@ class Assert {
 	notEqual( actual, expected, message ) {
 
 		// eslint-disable-next-line eqeqeq
-		let result = expected != actual;
+		const result = expected != actual;
 
 		this.pushResult( {
 			result,
@@ -238,8 +239,9 @@ class Assert {
 
 	[ "throws" ]( block, expected, message ) {
 		let actual,
-			result = false,
-			currentTest = ( this instanceof Assert && this.test ) || config.current;
+			result = false;
+
+		const currentTest = ( this instanceof Assert && this.test ) || config.current;
 
 		// 'expected' is optional unless doing string comparison
 		if ( objectType( expected ) === "string" ) {
@@ -263,7 +265,7 @@ class Assert {
 		currentTest.ignoreGlobalErrors = false;
 
 		if ( actual ) {
-			let expectedType = objectType( expected );
+			const expectedType = objectType( expected );
 
 			// We don't want to validate thrown error
 			if ( !expected ) {
@@ -312,11 +314,11 @@ Assert.prototype.raises = Assert.prototype[ "throws" ];
  * @return {String}
  */
 function errorString( error ) {
-	let resultErrorString = error.toString();
+	const resultErrorString = error.toString();
 
 	if ( resultErrorString.substring( 0, 7 ) === "[object" ) {
-		let name = error.name ? error.name.toString() : "Error";
-		let message = error.message ? error.message.toString() : "";
+		const name = error.name ? error.name.toString() : "Error";
+		const message = error.message ? error.message.toString() : "";
 
 		if ( name && message ) {
 			return `${name}: ${message}`;

--- a/src/events.js
+++ b/src/events.js
@@ -29,8 +29,8 @@ export function emit( eventName, data ) {
 	}
 
 	// Clone the callbacks in case one of them registers a new callback
-	let originalCallbacks = LISTENERS[ eventName ];
-	let callbacks = originalCallbacks ? [ ...originalCallbacks ] : [];
+	const originalCallbacks = LISTENERS[ eventName ];
+	const callbacks = originalCallbacks ? [ ...originalCallbacks ] : [];
 
 	for ( let i = 0; i < callbacks.length; i++ ) {
 		callbacks[ i ]( data );
@@ -50,7 +50,7 @@ export function on( eventName, callback ) {
 	if ( objectType( eventName ) !== "string" ) {
 		throw new TypeError( "eventName must be a string when registering a listener" );
 	} else if ( !inArray( eventName, SUPPORTED_EVENTS ) ) {
-		let events = SUPPORTED_EVENTS.join( ", " );
+		const events = SUPPORTED_EVENTS.join( ", " );
 		throw new Error( `"${eventName}" is not a valid event; must be one of: ${events}.` );
 	} else if ( objectType( callback ) !== "function" ) {
 		throw new TypeError( "callback must be a function when registering a listener" );

--- a/src/reports/suite.js
+++ b/src/reports/suite.js
@@ -68,7 +68,7 @@ export default class SuiteReport {
 	}
 
 	getStatus() {
-		let {
+		const {
 			total,
 			failed,
 			skipped,

--- a/src/reports/test.js
+++ b/src/reports/test.js
@@ -55,7 +55,7 @@ export default class TestReport {
 			return "skipped";
 		}
 
-		let testPassed = this.getFailedAssertions().length > 0 ? this.todo : !this.todo;
+		const testPassed = this.getFailedAssertions().length > 0 ? this.todo : !this.todo;
 
 		if ( !testPassed ) {
 			return "failed";

--- a/src/test.js
+++ b/src/test.js
@@ -403,7 +403,7 @@ Test.prototype = {
 	logAssertion( details ) {
 		runLoggingCallbacks( "log", details );
 
-		let assertion = {
+		const assertion = {
 			passed: details.result,
 			actual: details.actual,
 			expected: details.expected,
@@ -647,7 +647,7 @@ export function test( testName, callback ) {
 		return;
 	}
 
-	let newTest = new Test( {
+	const newTest = new Test( {
 		testName: testName,
 		callback: callback
 	} );
@@ -660,7 +660,7 @@ export function todo( testName, callback ) {
 		return;
 	}
 
-	let newTest = new Test( {
+	const newTest = new Test( {
 		testName,
 		callback,
 		todo: true
@@ -675,7 +675,7 @@ export function skip( testName ) {
 		return;
 	}
 
-	let test = new Test( {
+	const test = new Test( {
 		testName: testName,
 		skip: true
 	} );
@@ -692,7 +692,7 @@ export function only( testName, callback ) {
 	config.queue.length = 0;
 	focused = true;
 
-	let newTest = new Test( {
+	const newTest = new Test( {
 		testName: testName,
 		callback: callback
 	} );
@@ -785,12 +785,12 @@ function internalStart( test ) {
 }
 
 function numberOfTests( module ) {
-	let count = module.tests.length,
-		modules = [ ...module.childModules ];
+	let count = module.tests.length;
+	const modules = [ ...module.childModules ];
 
 	// Do a breadth-first traversal of the child modules
 	while ( modules.length ) {
-		let nextModule =  modules.shift();
+		const nextModule =  modules.shift();
 		count += nextModule.tests.length;
 		modules.push( ...nextModule.childModules );
 	}


### PR DESCRIPTION
Flags `let` variables that don't ever get reassigned and could be turned into `const` variables. Does not flag `var` variables.

See [here](http://eslint.org/docs/rules/prefer-const) for more information.