### PR TITLE
Tests: Ensure onError tests are included in test/index.html

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -17,6 +17,8 @@
 	<script src="setTimeout.js"></script>
 	<script src="reporter-html/reporter-html.js"></script>
 	<script src="reporter-html/diff.js"></script>
+	<script src="onerror/inside-test.js"></script>
+	<script src="onerror/outside-test.js"></script>
 </head>
 <body>
 	<div id="qunit"></div>


### PR DESCRIPTION
Just adding the onError tests to the main browser page.

@gibson042 I ran the tests on Chrome and Firefox (both in isolation and via test/index.html) and I don't see any issues. This is based off current master, so #1108 is not included here. Just want to confirm you only were seeing the issue in #1108? Or is there something I need to do differently to reproduce the issue on master?