### PR TITLE
[BUGFIX] fix sessionStorage feature detection

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -1,4 +1,4 @@
-import { window, sessionStorage } from "../globals";
+import { window, localSessionStorage } from "../globals";
 import { extend } from "./utilities";
 
 /**
@@ -54,7 +54,7 @@ const config = {
 	callbacks: {},
 
 	// The storage module to use for reordering tests
-	storage: sessionStorage
+	storage: localSessionStorage
 };
 
 // take a predefined QUnit.config and extend the defaults

--- a/src/globals.js
+++ b/src/globals.js
@@ -8,7 +8,7 @@ export const clearTimeout = global.clearTimeout;
 export const document = window && window.document;
 export const navigator = window && window.navigator;
 
-export const sessionStorage = ( function() {
+export const localSessionStorage = ( function() {
 	var x = "qunit-test-string";
 	try {
 		sessionStorage.setItem( x, x );


### PR DESCRIPTION
Prior to this PR `const sessionStorage` shadowed the global `sessionStorage`.
This resulted in the feature sniffing function to always fail, as `sessionStorage` would always be `undefined`