### PR TITLE
Core: Fix sessionStorage feature detection

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -113,6 +113,7 @@ grunt.initConfig( {
 			"test/index.html",
 			"test/autostart.html",
 			"test/startError.html",
+			"test/reorder.html",
 			"test/reorderError1.html",
 			"test/reorderError2.html",
 			"test/callbacks.html",

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -1,4 +1,4 @@
-import { window, sessionStorage } from "../globals";
+import { window, localSessionStorage } from "../globals";
 import { extend } from "./utilities";
 
 /**
@@ -54,7 +54,7 @@ const config = {
 	callbacks: {},
 
 	// The storage module to use for reordering tests
-	storage: sessionStorage
+	storage: localSessionStorage
 };
 
 // take a predefined QUnit.config and extend the defaults

--- a/src/globals.js
+++ b/src/globals.js
@@ -8,12 +8,12 @@ export const clearTimeout = global.clearTimeout;
 export const document = window && window.document;
 export const navigator = window && window.navigator;
 
-export const sessionStorage = ( function() {
+export const localSessionStorage = ( function() {
 	var x = "qunit-test-string";
 	try {
-		sessionStorage.setItem( x, x );
-		sessionStorage.removeItem( x );
-		return sessionStorage;
+		global.sessionStorage.setItem( x, x );
+		global.sessionStorage.removeItem( x );
+		return global.sessionStorage;
 	} catch ( e ) {
 		return undefined;
 	}

--- a/test/reorder.html
+++ b/test/reorder.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<title>QUnit Reordering Functionality Works in Browser</title>
+	<link rel="stylesheet" href="../dist/qunit.css">
+	<script src="../dist/qunit.js"></script>
+	<script src="reorder.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+</body>
+</html>

--- a/test/reorder.js
+++ b/test/reorder.js
@@ -1,0 +1,15 @@
+window.sessionStorage.setItem( "qunit-test-Reorder-Second", 1 );
+
+var lastTest = "";
+
+QUnit.module( "Reorder" );
+
+QUnit.test( "First", function( assert ) {
+  assert.strictEqual( lastTest, "Second" );
+  lastTest = "First";
+} );
+
+QUnit.test( "Second", function( assert ) {
+  assert.strictEqual( lastTest, "" );
+  lastTest = "Second";
+} );


### PR DESCRIPTION
Continuing https://github.com/qunitjs/qunit/pull/1112. GitHub wouldn't allow me to push to that PR since I modified the history.

> Prior to this PR `const sessionStorage` shadowed the global `sessionStorage`.
> This resulted in the feature sniffing function to always fail, as `sessionStorage` would always be `undefined`

cc @stefanpenner 