### PR TITLE
Core: Test#pushFailure now calls Test#pushResult

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -385,7 +385,7 @@ Test.prototype = {
 				sourceFromStacktrace( 2 ) );
 		}
 
-		this.assert.pushResult( {
+		this.pushResult( {
 			result: false,
 			message: message || "error",
 			actual: actual || null,

--- a/test/onerror/outside-test.js
+++ b/test/onerror/outside-test.js
@@ -4,16 +4,19 @@ QUnit.module( "Should create a test and call pushFailure when outside a test", f
 	hooks.beforeEach( function() {
 
 		// Duck-punch pushResult so we can check test name and assert args.
-		originalPushResult = QUnit.assert.pushResult;
+		originalPushResult = QUnit.config.current.pushResult;
 
-		QUnit.assert.pushResult = function( resultInfo ) {
+		QUnit.config.current.pushResult = function( resultInfo ) {
 
 			// Restore pushResult for this assert object, to allow following assertions.
 			this.pushResult = originalPushResult;
 
-			this.strictEqual( this.test.testName, "global failure", "Test is appropriately named" );
+			this.assert.strictEqual(
+				this.testName,
+				"global failure", "Test is appropriately named"
+			);
 
-			this.deepEqual( resultInfo, {
+			this.assert.deepEqual( resultInfo, {
 				message: "Error message",
 				source: "filePath.js:1",
 				result: false,
@@ -25,7 +28,7 @@ QUnit.module( "Should create a test and call pushFailure when outside a test", f
 	} );
 
 	hooks.afterEach( function() {
-		QUnit.assert.pushResult = originalPushResult;
+		QUnit.config.current.pushResult = originalPushResult;
 	} );
 
 	// Actual test (outside QUnit.test context).


### PR DESCRIPTION
Fix endless recursive loop between Test#pushFailure and
Assert#pushResult.

See #1119 for details

Let me know if anything more is needed for this PR.