### PR TITLE
CLI: Support filtering tests

### DIFF
--- a/bin/qunit
+++ b/bin/qunit
@@ -11,9 +11,12 @@ program._name = "qunit";
 program
 	.version( pkg.version )
 	.usage( "[options] [files]" )
+	.option( "-f, --filter <filter>", "filter which tests run" )
 	.parse( process.argv );
 
 const args = program.args;
 const files = utils.getFilesFromArgs( args );
 
-run( files );
+run( files, {
+	filter: program.filter
+} );

--- a/bin/run.js
+++ b/bin/run.js
@@ -17,7 +17,10 @@ const QUnit = ( function requireQUnit() {
 	}
 }() );
 
-module.exports = function run( files ) {
+module.exports = function run( files, options ) {
+	if ( options.filter ) {
+		QUnit.config.filter = options.filter;
+	}
 
 	// TODO: Enable mode where QUnit is not auto-injected, but other setup is
 	// still done automatically.

--- a/src/reports/suite.js
+++ b/src/reports/suite.js
@@ -57,8 +57,11 @@ export default class SuiteReport {
 
 	getTestCounts( counts = { passed: 0, failed: 0, skipped: 0, todo: 0, total: 0 } ) {
 		counts = this.tests.reduce( ( counts, test ) => {
-			counts[ test.getStatus() ]++;
-			counts.total++;
+			if ( test.isValid() ) {
+				counts[ test.getStatus() ]++;
+				counts.total++;
+			}
+
 			return counts;
 		}, counts );
 

--- a/src/reports/test.js
+++ b/src/reports/test.js
@@ -11,10 +11,16 @@ export default class TestReport {
 		this.skipped = !!options.skip;
 		this.todo = !!options.todo;
 
+		this.testInstance = options.testInstance;
+
 		this._startTime = 0;
 		this._endTime = 0;
 
 		suite.pushTest( this );
+	}
+
+	isValid() {
+		return this.testInstance.valid();
 	}
 
 	start( recordTime ) {

--- a/src/test.js
+++ b/src/test.js
@@ -32,7 +32,8 @@ export default function Test( settings ) {
 
 	this.testReport = new TestReport( settings.testName, this.module.suiteReport, {
 		todo: settings.todo,
-		skip: settings.skip
+		skip: settings.skip,
+		testInstance: this
 	} );
 
 	// Register unique strings

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -88,4 +88,16 @@ QUnit.module( "CLI Main", function() {
 			assert.equal( e.code, 1 );
 		}
 	} ) );
+
+	QUnit.module( "filter", function() {
+		QUnit.test( "can properly filter tests", co.wrap( function* ( assert ) {
+			const command = "qunit --filter 'single' test single.js 'glob/**/*-test.js'";
+			const equivalentCommand = "qunit single.js";
+			const execution = yield execute( command );
+
+			assert.equal( execution.code, 0 );
+			assert.equal( execution.stderr, "" );
+			assert.equal( execution.stdout, expectedOutput[ equivalentCommand ] );
+		} ) );
+	} );
 } );


### PR DESCRIPTION
This PR does two things:
1. Introduces a `--filter` option to the CLI for setting `QUnit.config.filter`
2. Fixes a bug in the new event emitter interface, where filtered tests were still being counted even when not run