### PR TITLE
Core: Revamp processing order to enable proper aborting of test runs

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -241,7 +241,7 @@ export function begin() {
 	}
 
 	config.blocking = false;
-	ProcessingQueue.advance( true );
+	ProcessingQueue.advance();
 }
 
 function setHook( module, hookName ) {

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -40,9 +40,6 @@ const config = {
 	// Set of all modules.
 	modules: [],
 
-	// Stack of nested modules
-	moduleStack: [],
-
 	// The first unnamed module
 	currentModule: {
 		name: "",

--- a/src/core/processing-queue.js
+++ b/src/core/processing-queue.js
@@ -27,11 +27,7 @@ let unitSampler;
  * Advances the ProcessingQueue to the next item if it is ready.
  * @param {Boolean} last
  */
-function advance( last ) {
-	function next() {
-		advance( last );
-	}
-
+function advance() {
 	const start = now();
 	config.depth = ( config.depth || 0 ) + 1;
 
@@ -47,14 +43,14 @@ function advance( last ) {
 
 			config.queue.shift()();
 		} else {
-			setTimeout( next, 13 );
+			setTimeout( advance, 13 );
 			break;
 		}
 	}
 
 	config.depth--;
 
-	if ( last && !config.blocking && !config.queue.length && config.depth === 0 ) {
+	if ( !config.blocking && !config.queue.length && config.depth === 0 ) {
 		done();
 	}
 }
@@ -66,8 +62,6 @@ function advance( last ) {
  * @param {String} seed
  */
 function addToQueue( callback, priority, seed ) {
-	const last = !priority;
-
 	if ( objectType( callback ) === "array" ) {
 		while ( callback.length ) {
 			addToQueue( callback.shift() );
@@ -91,7 +85,7 @@ function addToQueue( callback, priority, seed ) {
 	}
 
 	if ( internalState.autorun && !config.blocking ) {
-		advance( last );
+		advance();
 	}
 }
 


### PR DESCRIPTION
_Note: This is a follow up to https://github.com/qunitjs/qunit/pull/1121_.

## The Problem

Bear with me a moment, while I explain what this PR is doing. In the **current** system, when you add a test, it is [queued up as a single function](https://github.com/qunitjs/qunit/blob/41cb62569786de4b0d64c48cd0bf099839e28ae4/src/test.js#L314-L345), named `run`. Thus, when a test suite begins running, the queue generally looks something like this (not real code, just for illustration purposes):

```bash
QUnit.config.queue = [
  function run(),
  function run(),
  # and so on, for however many tests you have
];
```

When we begin processing the queue, each of those individual `run` functions is replaced by [a series of sub-functions](https://github.com/qunitjs/qunit/blob/41cb62569786de4b0d64c48cd0bf099839e28ae4/src/test.js#L317-L344). These functions, however, wind up at the **back of the queue**. Thus, after processing the first item you get:

```bash
QUnit.config.queue = [
  function run(),
  # ...
  function() { test.before() },
  function runHook(), # before
  function() { test.preserveTestEnvironment(); },
  function runHook(), #beforeEach
  function() { test.run(); },
  function runHook(), #afterEach
  function runHook(), # after
  function() { test.after(); },
  function() { test.finish(); }
];
```

This is not intuitive. It also means that by the time we actually begin processing tests we have a massive queue of anonymous and `runHook` functions. This makes it very difficult to determine where one test ends and another begins by looking at the queue.

Previously, this knowledge was not very important, _but_ with the coming CLI and specifically the `--watch` option, we need to be able to tell where tests start/end in the queue so that we can properly abort the test run while still allowing the test to cleanup after itself.

## The Solution

So, what this PR does is change the processing order such that as each test is processed, it is added to the **front of the queue** so that it is processed immediately. In other words, the original queue above would become the following after processing the first test:

```bash
QUnit.config.queue = [
  function() { test.before() },
  function runHook(), # before
  function() { test.preserveTestEnvironment(); },
  function runHook(), #beforeEach
  function() { test.run(); },
  function runHook(), #afterEach
  function runHook(), # after
  function() { test.after(); },
  function() { test.finish(); },
  function run(),
  # ...
];
```

This means that further tests will remain as a self-contained `run` function until the current test is finished executing.

This makes it easy to tell where the current test ends and the next one begins. It also means that the queue will remain relatively compact, instead of expanding every single test ahead of time.

This PR also revamps some of the behavior in the system that was previously, implicitly relying on the fact that all tests were expanded before processing any of them (specifically, how we handled hooks for tests). Overall, I think this makes the processing behavior much more understandable and less dynamic, while also enabling a better CLI experience.

Thanks for taking the time to read and review this!