### PR TITLE
CLI: Add seed option

### DIFF
--- a/bin/qunit
+++ b/bin/qunit
@@ -12,11 +12,14 @@ program
 	.version( pkg.version )
 	.usage( "[options] [files]" )
 	.option( "-f, --filter <filter>", "filter which tests run" )
+	.option( "--seed [value]", "specify a seed to order your tests; " +
+		"if option is specified without a value, one will be generated" )
 	.parse( process.argv );
 
 const args = program.args;
 const files = utils.getFilesFromArgs( args );
 
 run( files, {
-	filter: program.filter
+	filter: program.filter,
+	seed: program.seed
 } );

--- a/bin/run.js
+++ b/bin/run.js
@@ -22,6 +22,17 @@ module.exports = function run( files, options ) {
 		QUnit.config.filter = options.filter;
 	}
 
+	const seed = options.seed;
+	if ( seed ) {
+		if ( seed === true ) {
+			QUnit.config.seed = Math.random().toString( 36 ).slice( 2 );
+		} else {
+			QUnit.config.seed = seed;
+		}
+
+		console.log( `Running tests with seed: ${QUnit.config.seed}` );
+	}
+
 	// TODO: Enable mode where QUnit is not auto-injected, but other setup is
 	// still done automatically.
 	global.QUnit = QUnit;

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -61,5 +61,18 @@ ok 5 Second > 1
 # pass 5
 # skip 0
 # todo 0
+# fail 0`,
+
+	"qunit --seed 's33d' test single.js 'glob/**/*-test.js'": `Running tests with seed: s33d
+TAP version 13
+ok 1 Second > 1
+ok 2 Single > has a test
+ok 3 First > 1
+ok 4 Nested-Test > herp
+ok 5 A-Test > derp
+1..5
+# pass 5
+# skip 0
+# todo 0
 # fail 0`
 };

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -100,4 +100,15 @@ QUnit.module( "CLI Main", function() {
 			assert.equal( execution.stdout, expectedOutput[ equivalentCommand ] );
 		} ) );
 	} );
+
+	QUnit.module( "seed", function() {
+		QUnit.test( "can properly seed tests", co.wrap( function* ( assert ) {
+			const command = "qunit --seed 's33d' test single.js 'glob/**/*-test.js'";
+			const execution = yield execute( command );
+
+			assert.equal( execution.code, 0 );
+			assert.equal( execution.stderr, "" );
+			assert.equal( execution.stdout, expectedOutput[ command ] );
+		} ) );
+	} );
 } );


### PR DESCRIPTION
This adds support to the CLI for `QUnit.config.seed`. Behaves similarly to the browser query param.