### PR TITLE
CLI: Add description to help command

### DIFF
--- a/bin/qunit
+++ b/bin/qunit
@@ -7,10 +7,18 @@ const run = require( "./run" );
 const utils = require( "./utils" );
 const pkg = require( "../package.json" );
 
+const description = `Runs tests using the QUnit framework.
+
+  Files should be a space-separated list of file/directory paths and/or glob
+  expressions. Defaults to 'test/**/*.js'.
+
+  For more info on working with QUnit, check out http://qunitjs.com.`;
+
 program._name = "qunit";
 program
 	.version( pkg.version )
 	.usage( "[options] [files]" )
+	.description( description )
 	.option( "-f, --filter <filter>", "filter which tests run" )
 	.option( "--seed [value]", "specify a seed to order your tests; " +
 		"if option is specified without a value, one will be generated" )


### PR DESCRIPTION
This provides some helpful, descriptive text when using `qunit --help`:

```bash
$ qunit --help

  Usage: qunit [options] [files]

  Runs tests using the QUnit framework.

  Files should be a space-separated list of file/directory paths and/or glob
  expressions. Defaults to 'test/**/*.js'.

  For more info on working with QUnit, checkout http://qunitjs.com.
```

Meant to have this in the original PR, but forgot.