### PR TITLE
All: Enable ESLint indent rule (zero-tab indent for outer IIFE bodies)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,14 @@
         "arrow-spacing": ["error", { "before": true, "after": true }],
         "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
         "constructor-super": "error",
+        "indent": ["error", "tab", {
+                "CallExpression": {
+                        "arguments": 1
+                },
+		"MemberExpression": 1,
+                "SwitchCase": 0,
+                "outerIIFEBody": 0
+        }],
         "no-const-assign": "error",
         "no-dupe-class-members": "error",
         "no-duplicate-imports": "error",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,234 +9,243 @@ var reportDir = "build/report";
 module.exports = function( grunt ) {
 
 // Load grunt tasks from NPM packages
-require( "load-grunt-tasks" )( grunt );
+	require( "load-grunt-tasks" )( grunt );
 
-function process( code ) {
-	return code
+	function process( code ) {
+		return code
 
-		// Embed version
-		.replace( /@VERSION/g, grunt.config( "pkg" ).version )
+            // Embed version
+			.replace( /@VERSION/g, grunt.config( "pkg" ).version )
 
-		// Embed date (yyyy-mm-ddThh:mmZ)
-		.replace( /@DATE/g, ( new Date() ).toISOString().replace( /:\d+\.\d+Z$/, "Z" ) );
-}
+            // Embed date (yyyy-mm-ddThh:mmZ)
+			.replace( /@DATE/g, ( new Date() ).toISOString().replace( /:\d+\.\d+Z$/, "Z" ) );
+	}
 
-grunt.initConfig( {
-	pkg: grunt.file.readJSON( "package.json" ),
-	connect: {
-		server: {
-			options: {
-				port: 8000,
-				base: "."
+	grunt.initConfig( {
+		pkg: grunt.file.readJSON( "package.json" ),
+		connect: {
+			server: {
+				options: {
+					port: 8000,
+					base: "."
+				}
 			}
-		}
-	},
-	copy: {
-		options: { process: process },
+		},
+		copy: {
+			options: { process: process },
 
-		"src-js": {
-			src: "dist/qunit.js",
-			dest: "dist/qunit.js"
-		},
-		"src-css": {
-			src: "src/qunit.css",
-			dest: "dist/qunit.css"
-		},
+			"src-js": {
+				src: "dist/qunit.js",
+				dest: "dist/qunit.js"
+			},
+			"src-css": {
+				src: "src/qunit.css",
+				dest: "dist/qunit.css"
+			},
 
 		// Moves files around during coverage runs
-		"dist-to-tmp": {
-			src: "dist/qunit.js",
-			dest: "dist/qunit.tmp.js"
+			"dist-to-tmp": {
+				src: "dist/qunit.js",
+				dest: "dist/qunit.tmp.js"
+			},
+			"instrumented-to-dist": {
+				src: "build/instrumented/dist/qunit.js",
+				dest: "dist/qunit.js"
+			},
+			"tmp-to-dist": {
+				src: "dist/qunit.tmp.js",
+				dest: "dist/qunit.js"
+			}
 		},
-		"instrumented-to-dist": {
-			src: "build/instrumented/dist/qunit.js",
-			dest: "dist/qunit.js"
+		rollup: {
+			options: require( "./rollup.config" ),
+			src: {
+				src: "src/qunit.js",
+				dest: "dist/qunit.js"
+			}
 		},
-		"tmp-to-dist": {
-			src: "dist/qunit.tmp.js",
-			dest: "dist/qunit.js"
-		}
-	},
-	rollup: {
-		options: require( "./rollup.config" ),
-		src: {
-			src: "src/qunit.js",
-			dest: "dist/qunit.js"
-		}
-	},
-	eslint: {
-		options: {
-			config: ".eslintrc.json"
-		},
-		all: [
-			"*.js",
-			"bin/**/*.js",
-			"reporter/**/*.js",
-			"runner/**/*.js",
-			"src/**/*.js",
+		eslint: {
+			options: {
+				config: ".eslintrc.json"
+			},
+			js: [
+				"*.js",
+				"bin/**/*.js",
+				"reporter/**/*.js",
+				"runner/**/*.js",
+				"src/**/*.js",
 
-			"test/**/*.js",
-			"build/*.js",
-			"build/tasks/**/*.js",
+				"test/**/*.js",
+				"build/*.js",
+				"build/tasks/**/*.js"
+			],
+			html: {
+				options: {
+					rules: {
+						indent: "off"
+					}
+				},
+				src: [
 
-			// Linting HTML files via eslint-plugin-html
-			"test/**/*.html"
-		]
-	},
-	search: {
-		options: {
+                // Linting HTML files via eslint-plugin-html
+					"test/**/*.html"
+				]
+			}
+		},
+		search: {
+			options: {
 
 			// Ensure that the only HTML entities used are those with a special status in XHTML
 			// and that any common singleton/empty HTML elements end with the XHTML-compliant
 			// "/>"rather than ">"
-			searchString: /(&(?!gt|lt|amp|quot)[A-Za-z0-9]+;|<(?:hr|HR|br|BR|input|INPUT)(?![^>]*\/>)(?:\s+[^>]*)?>)/g, // eslint-disable-line max-len
-			logFormat: "console",
-			failOnMatch: true
-		},
-		xhtml: [
-			"src/**/*.js",
-			"reporter/**/*.js"
-		]
-	},
-	qunit: {
-		options: {
-			timeout: 30000,
-			"--web-security": "no",
-			inject: [
-				path.resolve( "./build/coverage-bridge.js" ),
-				require.resolve( "grunt-contrib-qunit/phantomjs/bridge" )
-			],
-			urls: [
-				"http://localhost:8000/test/sandboxed-iframe.html"
+				searchString: /(&(?!gt|lt|amp|quot)[A-Za-z0-9]+;|<(?:hr|HR|br|BR|input|INPUT)(?![^>]*\/>)(?:\s+[^>]*)?>)/g, // eslint-disable-line max-len
+				logFormat: "console",
+				failOnMatch: true
+			},
+			xhtml: [
+				"src/**/*.js",
+				"reporter/**/*.js"
 			]
 		},
-		qunit: [
-			"test/index.html",
-			"test/autostart.html",
-			"test/startError.html",
-			"test/reorder.html",
-			"test/reorderError1.html",
-			"test/reorderError2.html",
-			"test/callbacks.html",
-			"test/events.html",
-			"test/logs.html",
-			"test/setTimeout.html",
-			"test/amd.html",
-			"test/reporter-html/index.html",
-			"test/reporter-html/legacy-markup.html",
-			"test/reporter-html/no-qunit-element.html",
-			"test/reporter-html/single-testid.html",
-			"test/reporter-html/window-onerror.html",
-			"test/reporter-html/window-onerror-preexisting-handler.html",
-			"test/reporter-urlparams.html",
-			"test/moduleId.html",
-			"test/onerror/inside-test.html",
-			"test/onerror/outside-test.html",
-			"test/only.html",
-			"test/seed.html",
-			"test/overload.html",
-			"test/preconfigured.html",
-			"test/regex-filter.html",
-			"test/regex-exclude-filter.html",
-			"test/string-filter.html"
-		]
-	},
-	"test-on-node": {
-		files: [
-			"test/logs",
-			"test/main/test",
-			"test/main/assert",
-			"test/main/assert/step",
-			"test/main/async",
-			"test/main/promise",
-			"test/main/modules",
-			"test/main/deepEqual",
-			"test/main/stack",
-			"test/events",
-			"test/onerror/inside-test",
-			"test/onerror/outside-test",
-			"test/only",
-			"test/setTimeout",
-			"test/main/dump",
-			"test/node/storage-1",
-			"test/node/storage-2"
-		]
-	},
-	watch: {
-		options: {
-			atBegin: true,
-			spawn: false,
-			interrupt: true
+		qunit: {
+			options: {
+				timeout: 30000,
+				"--web-security": "no",
+				inject: [
+					path.resolve( "./build/coverage-bridge.js" ),
+					require.resolve( "grunt-contrib-qunit/phantomjs/bridge" )
+				],
+				urls: [
+					"http://localhost:8000/test/sandboxed-iframe.html"
+				]
+			},
+			qunit: [
+				"test/index.html",
+				"test/autostart.html",
+				"test/startError.html",
+				"test/reorder.html",
+				"test/reorderError1.html",
+				"test/reorderError2.html",
+				"test/callbacks.html",
+				"test/events.html",
+				"test/logs.html",
+				"test/setTimeout.html",
+				"test/amd.html",
+				"test/reporter-html/index.html",
+				"test/reporter-html/legacy-markup.html",
+				"test/reporter-html/no-qunit-element.html",
+				"test/reporter-html/single-testid.html",
+				"test/reporter-html/window-onerror.html",
+				"test/reporter-html/window-onerror-preexisting-handler.html",
+				"test/reporter-urlparams.html",
+				"test/moduleId.html",
+				"test/onerror/inside-test.html",
+				"test/onerror/outside-test.html",
+				"test/only.html",
+				"test/seed.html",
+				"test/overload.html",
+				"test/preconfigured.html",
+				"test/regex-filter.html",
+				"test/regex-exclude-filter.html",
+				"test/string-filter.html"
+			]
 		},
-		files: [
-			".eslintrc.json",
-			"*.js",
-			"build/*.js",
-			"{src,test,reporter}/**/*.js",
-			"src/qunit.css",
-			"test/**/*.html"
-		],
-		tasks: "default"
-	},
-
-	instrument: {
-		files: "dist/qunit.js",
-		options: {
-			lazy: false,
-			basePath: instrumentedDir
-		}
-	},
-
-	storeCoverage: {
-		options: {
-			dir: reportDir
-		}
-	},
-
-	makeReport: {
-		src: reportDir + "/**/*.json",
-		options: {
-			type: [ "lcov" ],
-			dir: reportDir,
-			print: "detail"
-		}
-	},
-
-	coveralls: {
-		options: {
-			force: true
+		"test-on-node": {
+			files: [
+				"test/logs",
+				"test/main/test",
+				"test/main/assert",
+				"test/main/assert/step",
+				"test/main/async",
+				"test/main/promise",
+				"test/main/modules",
+				"test/main/deepEqual",
+				"test/main/stack",
+				"test/events",
+				"test/onerror/inside-test",
+				"test/onerror/outside-test",
+				"test/only",
+				"test/setTimeout",
+				"test/main/dump",
+				"test/node/storage-1",
+				"test/node/storage-2"
+			]
 		},
-		all: {
+		watch: {
+			options: {
+				atBegin: true,
+				spawn: false,
+				interrupt: true
+			},
+			files: [
+				".eslintrc.json",
+				"*.js",
+				"build/*.js",
+				"{src,test,reporter}/**/*.js",
+				"src/qunit.css",
+				"test/**/*.html"
+			],
+			tasks: "default"
+		},
+
+		instrument: {
+			files: "dist/qunit.js",
+			options: {
+				lazy: false,
+				basePath: instrumentedDir
+			}
+		},
+
+		storeCoverage: {
+			options: {
+				dir: reportDir
+			}
+		},
+
+		makeReport: {
+			src: reportDir + "/**/*.json",
+			options: {
+				type: [ "lcov" ],
+				dir: reportDir,
+				print: "detail"
+			}
+		},
+
+		coveralls: {
+			options: {
+				force: true
+			},
+			all: {
 
 			// LCOV coverage file relevant to every target
-			src: "build/report/lcov.info"
+				src: "build/report/lcov.info"
+			}
 		}
-	}
-} );
+	} );
 
-grunt.event.on( "qunit.coverage", function( file, coverage ) {
-	var testName = file.split( "/test/" ).pop().replace( ".html", "" );
-	var reportPath = path.join( "build/report/phantom", testName + ".json" );
+	grunt.event.on( "qunit.coverage", function( file, coverage ) {
+		var testName = file.split( "/test/" ).pop().replace( ".html", "" );
+		var reportPath = path.join( "build/report/phantom", testName + ".json" );
 
-	fs.createFileSync( reportPath );
-	fs.writeJsonSync( reportPath, coverage, { spaces: 0 } );
-} );
+		fs.createFileSync( reportPath );
+		fs.writeJsonSync( reportPath, coverage, { spaces: 0 } );
+	} );
 
-grunt.loadTasks( "build/tasks" );
-grunt.registerTask( "build", [ "rollup:src", "copy:src-js", "copy:src-css" ] );
-grunt.registerTask( "qunit-test", [ "connect", "qunit" ] );
-grunt.registerTask( "test", [ "eslint", "search", "test-on-node", "qunit-test" ] );
-grunt.registerTask( "coverage", [
-	"build",
-	"instrument",
-	"copy:dist-to-tmp",
-	"copy:instrumented-to-dist",
-	"test",
-	"copy:tmp-to-dist",
-	"storeCoverage",
-	"makeReport",
-	"coveralls"
-] );
-grunt.registerTask( "default", [ "build", "test" ] );
+	grunt.loadTasks( "build/tasks" );
+	grunt.registerTask( "build", [ "rollup:src", "copy:src-js", "copy:src-css" ] );
+	grunt.registerTask( "qunit-test", [ "connect", "qunit" ] );
+	grunt.registerTask( "test", [ "eslint", "search", "test-on-node", "qunit-test" ] );
+	grunt.registerTask( "coverage", [
+		"build",
+		"instrument",
+		"copy:dist-to-tmp",
+		"copy:instrumented-to-dist",
+		"test",
+		"copy:tmp-to-dist",
+		"storeCoverage",
+		"makeReport",
+		"coveralls"
+	] );
+	grunt.registerTask( "default", [ "build", "test" ] );
 
 };

--- a/build/coverage-bridge.js
+++ b/build/coverage-bridge.js
@@ -3,16 +3,16 @@
 ( function( QUnit ) {
 
   // Send messages to the parent PhantomJS process via alert! Good times!!
-  function sendMessage() {
-    var args = [].slice.call( arguments );
-    window.alert( JSON.stringify( args ) );
-  }
+function sendMessage() {
+	var args = [].slice.call( arguments );
+	window.alert( JSON.stringify( args ) );
+}
 
-  QUnit.done( function() {
+QUnit.done( function() {
 
     // send coverage data if available
-    if ( window.__coverage__ ) {
-      sendMessage( "qunit.coverage", window.location.pathname, window.__coverage__ );
-    }
-  } );
+	if ( window.__coverage__ ) {
+		sendMessage( "qunit.coverage", window.location.pathname, window.__coverage__ );
+	}
+} );
 }( QUnit ) );

--- a/build/release.js
+++ b/build/release.js
@@ -1,25 +1,25 @@
 /* eslint-env node */
 module.exports = function( Release ) {
 
-var shell = require( "shelljs" );
+	var shell = require( "shelljs" );
 
-Release.define( {
-	npmPublish: true,
-	issueTracker: "github",
-	changelogShell: function() {
-		return "# Changelog for QUnit v" + Release.newVersion + "\n";
-	},
+	Release.define( {
+		npmPublish: true,
+		issueTracker: "github",
+		changelogShell: function() {
+			return "# Changelog for QUnit v" + Release.newVersion + "\n";
+		},
 
-	generateArtifacts: function( done ) {
-		Release.exec( "grunt", "Grunt command failed" );
-		shell.mkdir( "-p", "qunit" );
-		shell.cp( "-r", "dist/*", "qunit/" );
-		shell.mkdir( "-p", "dist/cdn" );
-		shell.cp( "dist/qunit.js", "dist/cdn/qunit-" + Release.newVersion + ".js" );
-		shell.cp( "dist/qunit.css", "dist/cdn/qunit-" + Release.newVersion + ".css" );
-		done( [ "qunit/qunit.js", "qunit/qunit.css" ] );
-	}
-} );
+		generateArtifacts: function( done ) {
+			Release.exec( "grunt", "Grunt command failed" );
+			shell.mkdir( "-p", "qunit" );
+			shell.cp( "-r", "dist/*", "qunit/" );
+			shell.mkdir( "-p", "dist/cdn" );
+			shell.cp( "dist/qunit.js", "dist/cdn/qunit-" + Release.newVersion + ".js" );
+			shell.cp( "dist/qunit.css", "dist/cdn/qunit-" + Release.newVersion + ".css" );
+			done( [ "qunit/qunit.js", "qunit/qunit.css" ] );
+		}
+	} );
 
 };
 

--- a/reporter/diff.js
+++ b/reporter/diff.js
@@ -30,8 +30,8 @@ import { escapeText } from "./html";
  *
  */
 QUnit.diff = ( function() {
-	function DiffMatchPatch() {
-	}
+function DiffMatchPatch() {
+}
 
 	//  DIFF FUNCTIONS
 
@@ -40,9 +40,9 @@ QUnit.diff = ( function() {
 	 * [[DIFF_DELETE, 'Hello'], [DIFF_INSERT, 'Goodbye'], [DIFF_EQUAL, ' world.']]
 	 * which means: delete 'Hello', add 'Goodbye' and keep ' world.'
 	 */
-	var DIFF_DELETE = -1,
-		DIFF_INSERT = 1,
-		DIFF_EQUAL = 0;
+var DIFF_DELETE = -1,
+	DIFF_INSERT = 1,
+	DIFF_EQUAL = 0;
 
 	/**
 	 * Find the differences between two texts.  Simplifies the problem by stripping
@@ -54,114 +54,114 @@ QUnit.diff = ( function() {
 	 *     Defaults to true, which does a faster, slightly less optimal diff.
 	 * @return {!Array.<!DiffMatchPatch.Diff>} Array of diff tuples.
 	 */
-	DiffMatchPatch.prototype.DiffMain = function( text1, text2, optChecklines ) {
-		var deadline, checklines, commonlength,
-			commonprefix, commonsuffix, diffs;
+DiffMatchPatch.prototype.DiffMain = function( text1, text2, optChecklines ) {
+	var deadline, checklines, commonlength,
+		commonprefix, commonsuffix, diffs;
 
 		// The diff must be complete in up to 1 second.
-		deadline = ( new Date() ).getTime() + 1000;
+	deadline = ( new Date() ).getTime() + 1000;
 
 		// Check for null inputs.
-		if ( text1 === null || text2 === null ) {
-			throw new Error( "Null input. (DiffMain)" );
-		}
+	if ( text1 === null || text2 === null ) {
+		throw new Error( "Null input. (DiffMain)" );
+	}
 
 		// Check for equality (speedup).
-		if ( text1 === text2 ) {
-			if ( text1 ) {
-				return [
+	if ( text1 === text2 ) {
+		if ( text1 ) {
+			return [
 					[ DIFF_EQUAL, text1 ]
-				];
-			}
-			return [];
+			];
 		}
+		return [];
+	}
 
-		if ( typeof optChecklines === "undefined" ) {
-			optChecklines = true;
-		}
+	if ( typeof optChecklines === "undefined" ) {
+		optChecklines = true;
+	}
 
-		checklines = optChecklines;
+	checklines = optChecklines;
 
 		// Trim off common prefix (speedup).
-		commonlength = this.diffCommonPrefix( text1, text2 );
-		commonprefix = text1.substring( 0, commonlength );
-		text1 = text1.substring( commonlength );
-		text2 = text2.substring( commonlength );
+	commonlength = this.diffCommonPrefix( text1, text2 );
+	commonprefix = text1.substring( 0, commonlength );
+	text1 = text1.substring( commonlength );
+	text2 = text2.substring( commonlength );
 
 		// Trim off common suffix (speedup).
-		commonlength = this.diffCommonSuffix( text1, text2 );
-		commonsuffix = text1.substring( text1.length - commonlength );
-		text1 = text1.substring( 0, text1.length - commonlength );
-		text2 = text2.substring( 0, text2.length - commonlength );
+	commonlength = this.diffCommonSuffix( text1, text2 );
+	commonsuffix = text1.substring( text1.length - commonlength );
+	text1 = text1.substring( 0, text1.length - commonlength );
+	text2 = text2.substring( 0, text2.length - commonlength );
 
 		// Compute the diff on the middle block.
-		diffs = this.diffCompute( text1, text2, checklines, deadline );
+	diffs = this.diffCompute( text1, text2, checklines, deadline );
 
 		// Restore the prefix and suffix.
-		if ( commonprefix ) {
-			diffs.unshift( [ DIFF_EQUAL, commonprefix ] );
-		}
-		if ( commonsuffix ) {
-			diffs.push( [ DIFF_EQUAL, commonsuffix ] );
-		}
-		this.diffCleanupMerge( diffs );
-		return diffs;
-	};
+	if ( commonprefix ) {
+		diffs.unshift( [ DIFF_EQUAL, commonprefix ] );
+	}
+	if ( commonsuffix ) {
+		diffs.push( [ DIFF_EQUAL, commonsuffix ] );
+	}
+	this.diffCleanupMerge( diffs );
+	return diffs;
+};
 
 	/**
 	 * Reduce the number of edits by eliminating operationally trivial equalities.
 	 * @param {!Array.<!DiffMatchPatch.Diff>} diffs Array of diff tuples.
 	 */
-	DiffMatchPatch.prototype.diffCleanupEfficiency = function( diffs ) {
-		var changes, equalities, equalitiesLength, lastequality,
-			pointer, preIns, preDel, postIns, postDel;
-		changes = false;
-		equalities = []; // Stack of indices where equalities are found.
-		equalitiesLength = 0; // Keeping our own length var is faster in JS.
+DiffMatchPatch.prototype.diffCleanupEfficiency = function( diffs ) {
+	var changes, equalities, equalitiesLength, lastequality,
+		pointer, preIns, preDel, postIns, postDel;
+	changes = false;
+	equalities = []; // Stack of indices where equalities are found.
+	equalitiesLength = 0; // Keeping our own length var is faster in JS.
 		/** @type {?string} */
-		lastequality = null;
+	lastequality = null;
 
 		// Always equal to diffs[equalities[equalitiesLength - 1]][1]
-		pointer = 0; // Index of current position.
+	pointer = 0; // Index of current position.
 
 		// Is there an insertion operation before the last equality.
-		preIns = false;
+	preIns = false;
 
 		// Is there a deletion operation before the last equality.
-		preDel = false;
+	preDel = false;
 
 		// Is there an insertion operation after the last equality.
-		postIns = false;
+	postIns = false;
 
 		// Is there a deletion operation after the last equality.
-		postDel = false;
-		while ( pointer < diffs.length ) {
+	postDel = false;
+	while ( pointer < diffs.length ) {
 
 			// Equality found.
-			if ( diffs[ pointer ][ 0 ] === DIFF_EQUAL ) {
-				if ( diffs[ pointer ][ 1 ].length < 4 && ( postIns || postDel ) ) {
+		if ( diffs[ pointer ][ 0 ] === DIFF_EQUAL ) {
+			if ( diffs[ pointer ][ 1 ].length < 4 && ( postIns || postDel ) ) {
 
 					// Candidate found.
-					equalities[ equalitiesLength++ ] = pointer;
-					preIns = postIns;
-					preDel = postDel;
-					lastequality = diffs[ pointer ][ 1 ];
-				} else {
-
-					// Not a candidate, and can never become one.
-					equalitiesLength = 0;
-					lastequality = null;
-				}
-				postIns = postDel = false;
-
-			// An insertion or deletion.
+				equalities[ equalitiesLength++ ] = pointer;
+				preIns = postIns;
+				preDel = postDel;
+				lastequality = diffs[ pointer ][ 1 ];
 			} else {
 
-				if ( diffs[ pointer ][ 0 ] === DIFF_DELETE ) {
-					postDel = true;
-				} else {
-					postIns = true;
-				}
+					// Not a candidate, and can never become one.
+				equalitiesLength = 0;
+				lastequality = null;
+			}
+			postIns = postDel = false;
+
+			// An insertion or deletion.
+		} else {
+
+			if ( diffs[ pointer ][ 0 ] === DIFF_DELETE ) {
+				postDel = true;
+			} else {
+				postIns = true;
+			}
 
 				/*
 				 * Five types to be split:
@@ -171,41 +171,41 @@ QUnit.diff = ( function() {
 				 * <ins>A</del>X<ins>C</ins><del>D</del>
 				 * <ins>A</ins><del>B</del>X<del>C</del>
 				 */
-				if ( lastequality && ( ( preIns && preDel && postIns && postDel ) ||
+			if ( lastequality && ( ( preIns && preDel && postIns && postDel ) ||
 						( ( lastequality.length < 2 ) &&
 						( preIns + preDel + postIns + postDel ) === 3 ) ) ) {
 
 					// Duplicate record.
-					diffs.splice(
-						equalities[ equalitiesLength - 1 ],
-						0,
+				diffs.splice(
+					equalities[ equalitiesLength - 1 ],
+					0,
 						[ DIFF_DELETE, lastequality ]
 					);
 
 					// Change second copy to insert.
-					diffs[ equalities[ equalitiesLength - 1 ] + 1 ][ 0 ] = DIFF_INSERT;
-					equalitiesLength--; // Throw away the equality we just deleted;
-					lastequality = null;
-					if ( preIns && preDel ) {
+				diffs[ equalities[ equalitiesLength - 1 ] + 1 ][ 0 ] = DIFF_INSERT;
+				equalitiesLength--; // Throw away the equality we just deleted;
+				lastequality = null;
+				if ( preIns && preDel ) {
 
 						// No changes made which could affect previous entry, keep going.
-						postIns = postDel = true;
-						equalitiesLength = 0;
-					} else {
-						equalitiesLength--; // Throw away the previous equality.
-						pointer = equalitiesLength > 0 ? equalities[ equalitiesLength - 1 ] : -1;
-						postIns = postDel = false;
-					}
-					changes = true;
+					postIns = postDel = true;
+					equalitiesLength = 0;
+				} else {
+					equalitiesLength--; // Throw away the previous equality.
+					pointer = equalitiesLength > 0 ? equalities[ equalitiesLength - 1 ] : -1;
+					postIns = postDel = false;
 				}
+				changes = true;
 			}
-			pointer++;
 		}
+		pointer++;
+	}
 
-		if ( changes ) {
-			this.diffCleanupMerge( diffs );
-		}
-	};
+	if ( changes ) {
+		this.diffCleanupMerge( diffs );
+	}
+};
 
 	/**
 	 * Convert a diff array into a pretty HTML report.
@@ -213,26 +213,26 @@ QUnit.diff = ( function() {
 	 * @param {integer} string to be beautified.
 	 * @return {string} HTML representation.
 	 */
-	DiffMatchPatch.prototype.diffPrettyHtml = function( diffs ) {
-		var op, data, x,
-			html = [];
-		for ( x = 0; x < diffs.length; x++ ) {
-			op = diffs[ x ][ 0 ]; // Operation (insert, delete, equal)
-			data = diffs[ x ][ 1 ]; // Text of change.
-			switch ( op ) {
-			case DIFF_INSERT:
-				html[ x ] = "<ins>" + escapeText( data ) + "</ins>";
-				break;
-			case DIFF_DELETE:
-				html[ x ] = "<del>" + escapeText( data ) + "</del>";
-				break;
-			case DIFF_EQUAL:
-				html[ x ] = "<span>" + escapeText( data ) + "</span>";
-				break;
-			}
+DiffMatchPatch.prototype.diffPrettyHtml = function( diffs ) {
+	var op, data, x,
+		html = [];
+	for ( x = 0; x < diffs.length; x++ ) {
+		op = diffs[ x ][ 0 ]; // Operation (insert, delete, equal)
+		data = diffs[ x ][ 1 ]; // Text of change.
+		switch ( op ) {
+		case DIFF_INSERT:
+			html[ x ] = "<ins>" + escapeText( data ) + "</ins>";
+			break;
+		case DIFF_DELETE:
+			html[ x ] = "<del>" + escapeText( data ) + "</del>";
+			break;
+		case DIFF_EQUAL:
+			html[ x ] = "<span>" + escapeText( data ) + "</span>";
+			break;
 		}
-		return html.join( "" );
-	};
+	}
+	return html.join( "" );
+};
 
 	/**
 	 * Determine the common prefix of two strings.
@@ -241,32 +241,32 @@ QUnit.diff = ( function() {
 	 * @return {number} The number of characters common to the start of each
 	 *     string.
 	 */
-	DiffMatchPatch.prototype.diffCommonPrefix = function( text1, text2 ) {
-		var pointermid, pointermax, pointermin, pointerstart;
+DiffMatchPatch.prototype.diffCommonPrefix = function( text1, text2 ) {
+	var pointermid, pointermax, pointermin, pointerstart;
 
 		// Quick check for common null cases.
-		if ( !text1 || !text2 || text1.charAt( 0 ) !== text2.charAt( 0 ) ) {
-			return 0;
-		}
+	if ( !text1 || !text2 || text1.charAt( 0 ) !== text2.charAt( 0 ) ) {
+		return 0;
+	}
 
 		// Binary search.
 		// Performance analysis: https://neil.fraser.name/news/2007/10/09/
-		pointermin = 0;
-		pointermax = Math.min( text1.length, text2.length );
-		pointermid = pointermax;
-		pointerstart = 0;
-		while ( pointermin < pointermid ) {
-			if ( text1.substring( pointerstart, pointermid ) ===
+	pointermin = 0;
+	pointermax = Math.min( text1.length, text2.length );
+	pointermid = pointermax;
+	pointerstart = 0;
+	while ( pointermin < pointermid ) {
+		if ( text1.substring( pointerstart, pointermid ) ===
 					text2.substring( pointerstart, pointermid ) ) {
-				pointermin = pointermid;
-				pointerstart = pointermin;
-			} else {
-				pointermax = pointermid;
-			}
-			pointermid = Math.floor( ( pointermax - pointermin ) / 2 + pointermin );
+			pointermin = pointermid;
+			pointerstart = pointermin;
+		} else {
+			pointermax = pointermid;
 		}
-		return pointermid;
-	};
+		pointermid = Math.floor( ( pointermax - pointermin ) / 2 + pointermin );
+	}
+	return pointermid;
+};
 
 	/**
 	 * Determine the common suffix of two strings.
@@ -274,34 +274,34 @@ QUnit.diff = ( function() {
 	 * @param {string} text2 Second string.
 	 * @return {number} The number of characters common to the end of each string.
 	 */
-	DiffMatchPatch.prototype.diffCommonSuffix = function( text1, text2 ) {
-		var pointermid, pointermax, pointermin, pointerend;
+DiffMatchPatch.prototype.diffCommonSuffix = function( text1, text2 ) {
+	var pointermid, pointermax, pointermin, pointerend;
 
 		// Quick check for common null cases.
-		if ( !text1 ||
+	if ( !text1 ||
 				!text2 ||
 				text1.charAt( text1.length - 1 ) !== text2.charAt( text2.length - 1 ) ) {
-			return 0;
-		}
+		return 0;
+	}
 
 		// Binary search.
 		// Performance analysis: https://neil.fraser.name/news/2007/10/09/
-		pointermin = 0;
-		pointermax = Math.min( text1.length, text2.length );
-		pointermid = pointermax;
-		pointerend = 0;
-		while ( pointermin < pointermid ) {
-			if ( text1.substring( text1.length - pointermid, text1.length - pointerend ) ===
+	pointermin = 0;
+	pointermax = Math.min( text1.length, text2.length );
+	pointermid = pointermax;
+	pointerend = 0;
+	while ( pointermin < pointermid ) {
+		if ( text1.substring( text1.length - pointermid, text1.length - pointerend ) ===
 					text2.substring( text2.length - pointermid, text2.length - pointerend ) ) {
-				pointermin = pointermid;
-				pointerend = pointermin;
-			} else {
-				pointermax = pointermid;
-			}
-			pointermid = Math.floor( ( pointermax - pointermin ) / 2 + pointermin );
+			pointermin = pointermid;
+			pointerend = pointermin;
+		} else {
+			pointermax = pointermid;
 		}
-		return pointermid;
-	};
+		pointermid = Math.floor( ( pointermax - pointermin ) / 2 + pointermin );
+	}
+	return pointermid;
+};
 
 	/**
 	 * Find the differences between two texts.  Assumes that the texts do not
@@ -315,83 +315,83 @@ QUnit.diff = ( function() {
 	 * @return {!Array.<!DiffMatchPatch.Diff>} Array of diff tuples.
 	 * @private
 	 */
-	DiffMatchPatch.prototype.diffCompute = function( text1, text2, checklines, deadline ) {
-		var diffs, longtext, shorttext, i, hm,
-			text1A, text2A, text1B, text2B,
-			midCommon, diffsA, diffsB;
+DiffMatchPatch.prototype.diffCompute = function( text1, text2, checklines, deadline ) {
+	var diffs, longtext, shorttext, i, hm,
+		text1A, text2A, text1B, text2B,
+		midCommon, diffsA, diffsB;
 
-		if ( !text1 ) {
+	if ( !text1 ) {
 
 			// Just add some text (speedup).
-			return [
+		return [
 				[ DIFF_INSERT, text2 ]
-			];
-		}
+		];
+	}
 
-		if ( !text2 ) {
+	if ( !text2 ) {
 
 			// Just delete some text (speedup).
-			return [
+		return [
 				[ DIFF_DELETE, text1 ]
-			];
-		}
+		];
+	}
 
-		longtext = text1.length > text2.length ? text1 : text2;
-		shorttext = text1.length > text2.length ? text2 : text1;
-		i = longtext.indexOf( shorttext );
-		if ( i !== -1 ) {
+	longtext = text1.length > text2.length ? text1 : text2;
+	shorttext = text1.length > text2.length ? text2 : text1;
+	i = longtext.indexOf( shorttext );
+	if ( i !== -1 ) {
 
 			// Shorter text is inside the longer text (speedup).
-			diffs = [
+		diffs = [
 				[ DIFF_INSERT, longtext.substring( 0, i ) ],
 				[ DIFF_EQUAL, shorttext ],
 				[ DIFF_INSERT, longtext.substring( i + shorttext.length ) ]
-			];
+		];
 
 			// Swap insertions for deletions if diff is reversed.
-			if ( text1.length > text2.length ) {
-				diffs[ 0 ][ 0 ] = diffs[ 2 ][ 0 ] = DIFF_DELETE;
-			}
-			return diffs;
+		if ( text1.length > text2.length ) {
+			diffs[ 0 ][ 0 ] = diffs[ 2 ][ 0 ] = DIFF_DELETE;
 		}
+		return diffs;
+	}
 
-		if ( shorttext.length === 1 ) {
+	if ( shorttext.length === 1 ) {
 
 			// Single character string.
 			// After the previous speedup, the character can't be an equality.
-			return [
+		return [
 				[ DIFF_DELETE, text1 ],
 				[ DIFF_INSERT, text2 ]
-			];
-		}
+		];
+	}
 
 		// Check to see if the problem can be split in two.
-		hm = this.diffHalfMatch( text1, text2 );
-		if ( hm ) {
+	hm = this.diffHalfMatch( text1, text2 );
+	if ( hm ) {
 
 			// A half-match was found, sort out the return data.
-			text1A = hm[ 0 ];
-			text1B = hm[ 1 ];
-			text2A = hm[ 2 ];
-			text2B = hm[ 3 ];
-			midCommon = hm[ 4 ];
+		text1A = hm[ 0 ];
+		text1B = hm[ 1 ];
+		text2A = hm[ 2 ];
+		text2B = hm[ 3 ];
+		midCommon = hm[ 4 ];
 
 			// Send both pairs off for separate processing.
-			diffsA = this.DiffMain( text1A, text2A, checklines, deadline );
-			diffsB = this.DiffMain( text1B, text2B, checklines, deadline );
+		diffsA = this.DiffMain( text1A, text2A, checklines, deadline );
+		diffsB = this.DiffMain( text1B, text2B, checklines, deadline );
 
 			// Merge the results.
-			return diffsA.concat( [
+		return diffsA.concat( [
 				[ DIFF_EQUAL, midCommon ]
-			], diffsB );
-		}
+		], diffsB );
+	}
 
-		if ( checklines && text1.length > 100 && text2.length > 100 ) {
-			return this.diffLineMode( text1, text2, deadline );
-		}
+	if ( checklines && text1.length > 100 && text2.length > 100 ) {
+		return this.diffLineMode( text1, text2, deadline );
+	}
 
-		return this.diffBisect( text1, text2, deadline );
-	};
+	return this.diffBisect( text1, text2, deadline );
+};
 
 	/**
 	 * Do the two texts share a substring which is at least half the length of the
@@ -404,17 +404,17 @@ QUnit.diff = ( function() {
 	 *     text2 and the common middle.  Or null if there was no match.
 	 * @private
 	 */
-	DiffMatchPatch.prototype.diffHalfMatch = function( text1, text2 ) {
-		var longtext, shorttext, dmp,
-			text1A, text2B, text2A, text1B, midCommon,
-			hm1, hm2, hm;
+DiffMatchPatch.prototype.diffHalfMatch = function( text1, text2 ) {
+	var longtext, shorttext, dmp,
+		text1A, text2B, text2A, text1B, midCommon,
+		hm1, hm2, hm;
 
-		longtext = text1.length > text2.length ? text1 : text2;
-		shorttext = text1.length > text2.length ? text2 : text1;
-		if ( longtext.length < 4 || shorttext.length * 2 < longtext.length ) {
-			return null; // Pointless.
-		}
-		dmp = this; // 'this' becomes 'window' in a closure.
+	longtext = text1.length > text2.length ? text1 : text2;
+	shorttext = text1.length > text2.length ? text2 : text1;
+	if ( longtext.length < 4 || shorttext.length * 2 < longtext.length ) {
+		return null; // Pointless.
+	}
+	dmp = this; // 'this' becomes 'window' in a closure.
 
 		/**
 		 * Does a substring of shorttext exist within longtext such that the substring
@@ -428,71 +428,71 @@ QUnit.diff = ( function() {
 		 *     of shorttext and the common middle.  Or null if there was no match.
 		 * @private
 		 */
-		function diffHalfMatchI( longtext, shorttext, i ) {
-			var seed, j, bestCommon, prefixLength, suffixLength,
-				bestLongtextA, bestLongtextB, bestShorttextA, bestShorttextB;
+	function diffHalfMatchI( longtext, shorttext, i ) {
+		var seed, j, bestCommon, prefixLength, suffixLength,
+			bestLongtextA, bestLongtextB, bestShorttextA, bestShorttextB;
 
 			// Start with a 1/4 length substring at position i as a seed.
-			seed = longtext.substring( i, i + Math.floor( longtext.length / 4 ) );
-			j = -1;
-			bestCommon = "";
-			while ( ( j = shorttext.indexOf( seed, j + 1 ) ) !== -1 ) {
-				prefixLength = dmp.diffCommonPrefix( longtext.substring( i ),
-					shorttext.substring( j ) );
-				suffixLength = dmp.diffCommonSuffix( longtext.substring( 0, i ),
-					shorttext.substring( 0, j ) );
-				if ( bestCommon.length < suffixLength + prefixLength ) {
-					bestCommon = shorttext.substring( j - suffixLength, j ) +
+		seed = longtext.substring( i, i + Math.floor( longtext.length / 4 ) );
+		j = -1;
+		bestCommon = "";
+		while ( ( j = shorttext.indexOf( seed, j + 1 ) ) !== -1 ) {
+			prefixLength = dmp.diffCommonPrefix( longtext.substring( i ),
+				shorttext.substring( j ) );
+			suffixLength = dmp.diffCommonSuffix( longtext.substring( 0, i ),
+				shorttext.substring( 0, j ) );
+			if ( bestCommon.length < suffixLength + prefixLength ) {
+				bestCommon = shorttext.substring( j - suffixLength, j ) +
 						shorttext.substring( j, j + prefixLength );
-					bestLongtextA = longtext.substring( 0, i - suffixLength );
-					bestLongtextB = longtext.substring( i + prefixLength );
-					bestShorttextA = shorttext.substring( 0, j - suffixLength );
-					bestShorttextB = shorttext.substring( j + prefixLength );
-				}
-			}
-			if ( bestCommon.length * 2 >= longtext.length ) {
-				return [ bestLongtextA, bestLongtextB,
-					bestShorttextA, bestShorttextB, bestCommon
-				];
-			} else {
-				return null;
+				bestLongtextA = longtext.substring( 0, i - suffixLength );
+				bestLongtextB = longtext.substring( i + prefixLength );
+				bestShorttextA = shorttext.substring( 0, j - suffixLength );
+				bestShorttextB = shorttext.substring( j + prefixLength );
 			}
 		}
+		if ( bestCommon.length * 2 >= longtext.length ) {
+			return [ bestLongtextA, bestLongtextB,
+				bestShorttextA, bestShorttextB, bestCommon
+			];
+		} else {
+			return null;
+		}
+	}
 
 		// First check if the second quarter is the seed for a half-match.
-		hm1 = diffHalfMatchI( longtext, shorttext,
-			Math.ceil( longtext.length / 4 ) );
+	hm1 = diffHalfMatchI( longtext, shorttext,
+		Math.ceil( longtext.length / 4 ) );
 
 		// Check again based on the third quarter.
-		hm2 = diffHalfMatchI( longtext, shorttext,
-			Math.ceil( longtext.length / 2 ) );
-		if ( !hm1 && !hm2 ) {
-			return null;
-		} else if ( !hm2 ) {
-			hm = hm1;
-		} else if ( !hm1 ) {
-			hm = hm2;
-		} else {
+	hm2 = diffHalfMatchI( longtext, shorttext,
+		Math.ceil( longtext.length / 2 ) );
+	if ( !hm1 && !hm2 ) {
+		return null;
+	} else if ( !hm2 ) {
+		hm = hm1;
+	} else if ( !hm1 ) {
+		hm = hm2;
+	} else {
 
 			// Both matched.  Select the longest.
-			hm = hm1[ 4 ].length > hm2[ 4 ].length ? hm1 : hm2;
-		}
+		hm = hm1[ 4 ].length > hm2[ 4 ].length ? hm1 : hm2;
+	}
 
 		// A half-match was found, sort out the return data.
-		if ( text1.length > text2.length ) {
-			text1A = hm[ 0 ];
-			text1B = hm[ 1 ];
-			text2A = hm[ 2 ];
-			text2B = hm[ 3 ];
-		} else {
-			text2A = hm[ 0 ];
-			text2B = hm[ 1 ];
-			text1A = hm[ 2 ];
-			text1B = hm[ 3 ];
-		}
-		midCommon = hm[ 4 ];
-		return [ text1A, text1B, text2A, text2B, midCommon ];
-	};
+	if ( text1.length > text2.length ) {
+		text1A = hm[ 0 ];
+		text1B = hm[ 1 ];
+		text2A = hm[ 2 ];
+		text2B = hm[ 3 ];
+	} else {
+		text2A = hm[ 0 ];
+		text2B = hm[ 1 ];
+		text1A = hm[ 2 ];
+		text1B = hm[ 3 ];
+	}
+	midCommon = hm[ 4 ];
+	return [ text1A, text1B, text2A, text2B, midCommon ];
+};
 
 	/**
 	 * Do a quick line-level diff on both strings, then rediff the parts for
@@ -504,69 +504,69 @@ QUnit.diff = ( function() {
 	 * @return {!Array.<!DiffMatchPatch.Diff>} Array of diff tuples.
 	 * @private
 	 */
-	DiffMatchPatch.prototype.diffLineMode = function( text1, text2, deadline ) {
-		var a, diffs, linearray, pointer, countInsert,
-			countDelete, textInsert, textDelete, j;
+DiffMatchPatch.prototype.diffLineMode = function( text1, text2, deadline ) {
+	var a, diffs, linearray, pointer, countInsert,
+		countDelete, textInsert, textDelete, j;
 
 		// Scan the text on a line-by-line basis first.
-		a = this.diffLinesToChars( text1, text2 );
-		text1 = a.chars1;
-		text2 = a.chars2;
-		linearray = a.lineArray;
+	a = this.diffLinesToChars( text1, text2 );
+	text1 = a.chars1;
+	text2 = a.chars2;
+	linearray = a.lineArray;
 
-		diffs = this.DiffMain( text1, text2, false, deadline );
+	diffs = this.DiffMain( text1, text2, false, deadline );
 
 		// Convert the diff back to original text.
-		this.diffCharsToLines( diffs, linearray );
+	this.diffCharsToLines( diffs, linearray );
 
 		// Eliminate freak matches (e.g. blank lines)
-		this.diffCleanupSemantic( diffs );
+	this.diffCleanupSemantic( diffs );
 
 		// Rediff any replacement blocks, this time character-by-character.
 		// Add a dummy entry at the end.
-		diffs.push( [ DIFF_EQUAL, "" ] );
-		pointer = 0;
-		countDelete = 0;
-		countInsert = 0;
-		textDelete = "";
-		textInsert = "";
-		while ( pointer < diffs.length ) {
-			switch ( diffs[ pointer ][ 0 ] ) {
-			case DIFF_INSERT:
-				countInsert++;
-				textInsert += diffs[ pointer ][ 1 ];
-				break;
-			case DIFF_DELETE:
-				countDelete++;
-				textDelete += diffs[ pointer ][ 1 ];
-				break;
-			case DIFF_EQUAL:
+	diffs.push( [ DIFF_EQUAL, "" ] );
+	pointer = 0;
+	countDelete = 0;
+	countInsert = 0;
+	textDelete = "";
+	textInsert = "";
+	while ( pointer < diffs.length ) {
+		switch ( diffs[ pointer ][ 0 ] ) {
+		case DIFF_INSERT:
+			countInsert++;
+			textInsert += diffs[ pointer ][ 1 ];
+			break;
+		case DIFF_DELETE:
+			countDelete++;
+			textDelete += diffs[ pointer ][ 1 ];
+			break;
+		case DIFF_EQUAL:
 
 				// Upon reaching an equality, check for prior redundancies.
-				if ( countDelete >= 1 && countInsert >= 1 ) {
+			if ( countDelete >= 1 && countInsert >= 1 ) {
 
 					// Delete the offending records and add the merged ones.
-					diffs.splice( pointer - countDelete - countInsert,
-						countDelete + countInsert );
-					pointer = pointer - countDelete - countInsert;
-					a = this.DiffMain( textDelete, textInsert, false, deadline );
-					for ( j = a.length - 1; j >= 0; j-- ) {
-						diffs.splice( pointer, 0, a[ j ] );
-					}
-					pointer = pointer + a.length;
+				diffs.splice( pointer - countDelete - countInsert,
+					countDelete + countInsert );
+				pointer = pointer - countDelete - countInsert;
+				a = this.DiffMain( textDelete, textInsert, false, deadline );
+				for ( j = a.length - 1; j >= 0; j-- ) {
+					diffs.splice( pointer, 0, a[ j ] );
 				}
-				countInsert = 0;
-				countDelete = 0;
-				textDelete = "";
-				textInsert = "";
-				break;
+				pointer = pointer + a.length;
 			}
-			pointer++;
+			countInsert = 0;
+			countDelete = 0;
+			textDelete = "";
+			textInsert = "";
+			break;
 		}
-		diffs.pop(); // Remove the dummy entry at the end.
+		pointer++;
+	}
+	diffs.pop(); // Remove the dummy entry at the end.
 
-		return diffs;
-	};
+	return diffs;
+};
 
 	/**
 	 * Find the 'middle snake' of a diff, split the problem in two
@@ -578,134 +578,134 @@ QUnit.diff = ( function() {
 	 * @return {!Array.<!DiffMatchPatch.Diff>} Array of diff tuples.
 	 * @private
 	 */
-	DiffMatchPatch.prototype.diffBisect = function( text1, text2, deadline ) {
-		var text1Length, text2Length, maxD, vOffset, vLength,
-			v1, v2, x, delta, front, k1start, k1end, k2start,
-			k2end, k2Offset, k1Offset, x1, x2, y1, y2, d, k1, k2;
+DiffMatchPatch.prototype.diffBisect = function( text1, text2, deadline ) {
+	var text1Length, text2Length, maxD, vOffset, vLength,
+		v1, v2, x, delta, front, k1start, k1end, k2start,
+		k2end, k2Offset, k1Offset, x1, x2, y1, y2, d, k1, k2;
 
 		// Cache the text lengths to prevent multiple calls.
-		text1Length = text1.length;
-		text2Length = text2.length;
-		maxD = Math.ceil( ( text1Length + text2Length ) / 2 );
-		vOffset = maxD;
-		vLength = 2 * maxD;
-		v1 = new Array( vLength );
-		v2 = new Array( vLength );
+	text1Length = text1.length;
+	text2Length = text2.length;
+	maxD = Math.ceil( ( text1Length + text2Length ) / 2 );
+	vOffset = maxD;
+	vLength = 2 * maxD;
+	v1 = new Array( vLength );
+	v2 = new Array( vLength );
 
 		// Setting all elements to -1 is faster in Chrome & Firefox than mixing
 		// integers and undefined.
-		for ( x = 0; x < vLength; x++ ) {
-			v1[ x ] = -1;
-			v2[ x ] = -1;
-		}
-		v1[ vOffset + 1 ] = 0;
-		v2[ vOffset + 1 ] = 0;
-		delta = text1Length - text2Length;
+	for ( x = 0; x < vLength; x++ ) {
+		v1[ x ] = -1;
+		v2[ x ] = -1;
+	}
+	v1[ vOffset + 1 ] = 0;
+	v2[ vOffset + 1 ] = 0;
+	delta = text1Length - text2Length;
 
 		// If the total number of characters is odd, then the front path will collide
 		// with the reverse path.
-		front = ( delta % 2 !== 0 );
+	front = ( delta % 2 !== 0 );
 
 		// Offsets for start and end of k loop.
 		// Prevents mapping of space beyond the grid.
-		k1start = 0;
-		k1end = 0;
-		k2start = 0;
-		k2end = 0;
-		for ( d = 0; d < maxD; d++ ) {
+	k1start = 0;
+	k1end = 0;
+	k2start = 0;
+	k2end = 0;
+	for ( d = 0; d < maxD; d++ ) {
 
 			// Bail out if deadline is reached.
-			if ( ( new Date() ).getTime() > deadline ) {
-				break;
-			}
+		if ( ( new Date() ).getTime() > deadline ) {
+			break;
+		}
 
 			// Walk the front path one step.
-			for ( k1 = -d + k1start; k1 <= d - k1end; k1 += 2 ) {
-				k1Offset = vOffset + k1;
-				if ( k1 === -d || ( k1 !== d && v1[ k1Offset - 1 ] < v1[ k1Offset + 1 ] ) ) {
-					x1 = v1[ k1Offset + 1 ];
-				} else {
-					x1 = v1[ k1Offset - 1 ] + 1;
-				}
-				y1 = x1 - k1;
-				while ( x1 < text1Length && y1 < text2Length &&
+		for ( k1 = -d + k1start; k1 <= d - k1end; k1 += 2 ) {
+			k1Offset = vOffset + k1;
+			if ( k1 === -d || ( k1 !== d && v1[ k1Offset - 1 ] < v1[ k1Offset + 1 ] ) ) {
+				x1 = v1[ k1Offset + 1 ];
+			} else {
+				x1 = v1[ k1Offset - 1 ] + 1;
+			}
+			y1 = x1 - k1;
+			while ( x1 < text1Length && y1 < text2Length &&
 					text1.charAt( x1 ) === text2.charAt( y1 ) ) {
-					x1++;
-					y1++;
-				}
-				v1[ k1Offset ] = x1;
-				if ( x1 > text1Length ) {
+				x1++;
+				y1++;
+			}
+			v1[ k1Offset ] = x1;
+			if ( x1 > text1Length ) {
 
 					// Ran off the right of the graph.
-					k1end += 2;
-				} else if ( y1 > text2Length ) {
+				k1end += 2;
+			} else if ( y1 > text2Length ) {
 
 					// Ran off the bottom of the graph.
-					k1start += 2;
-				} else if ( front ) {
-					k2Offset = vOffset + delta - k1;
-					if ( k2Offset >= 0 && k2Offset < vLength && v2[ k2Offset ] !== -1 ) {
+				k1start += 2;
+			} else if ( front ) {
+				k2Offset = vOffset + delta - k1;
+				if ( k2Offset >= 0 && k2Offset < vLength && v2[ k2Offset ] !== -1 ) {
 
 						// Mirror x2 onto top-left coordinate system.
-						x2 = text1Length - v2[ k2Offset ];
-						if ( x1 >= x2 ) {
+					x2 = text1Length - v2[ k2Offset ];
+					if ( x1 >= x2 ) {
 
 							// Overlap detected.
-							return this.diffBisectSplit( text1, text2, x1, y1, deadline );
-						}
-					}
-				}
-			}
-
-			// Walk the reverse path one step.
-			for ( k2 = -d + k2start; k2 <= d - k2end; k2 += 2 ) {
-				k2Offset = vOffset + k2;
-				if ( k2 === -d || ( k2 !== d && v2[ k2Offset - 1 ] < v2[ k2Offset + 1 ] ) ) {
-					x2 = v2[ k2Offset + 1 ];
-				} else {
-					x2 = v2[ k2Offset - 1 ] + 1;
-				}
-				y2 = x2 - k2;
-				while ( x2 < text1Length && y2 < text2Length &&
-					text1.charAt( text1Length - x2 - 1 ) ===
-					text2.charAt( text2Length - y2 - 1 ) ) {
-					x2++;
-					y2++;
-				}
-				v2[ k2Offset ] = x2;
-				if ( x2 > text1Length ) {
-
-					// Ran off the left of the graph.
-					k2end += 2;
-				} else if ( y2 > text2Length ) {
-
-					// Ran off the top of the graph.
-					k2start += 2;
-				} else if ( !front ) {
-					k1Offset = vOffset + delta - k2;
-					if ( k1Offset >= 0 && k1Offset < vLength && v1[ k1Offset ] !== -1 ) {
-						x1 = v1[ k1Offset ];
-						y1 = vOffset + x1 - k1Offset;
-
-						// Mirror x2 onto top-left coordinate system.
-						x2 = text1Length - x2;
-						if ( x1 >= x2 ) {
-
-							// Overlap detected.
-							return this.diffBisectSplit( text1, text2, x1, y1, deadline );
-						}
+						return this.diffBisectSplit( text1, text2, x1, y1, deadline );
 					}
 				}
 			}
 		}
 
+			// Walk the reverse path one step.
+		for ( k2 = -d + k2start; k2 <= d - k2end; k2 += 2 ) {
+			k2Offset = vOffset + k2;
+			if ( k2 === -d || ( k2 !== d && v2[ k2Offset - 1 ] < v2[ k2Offset + 1 ] ) ) {
+				x2 = v2[ k2Offset + 1 ];
+			} else {
+				x2 = v2[ k2Offset - 1 ] + 1;
+			}
+			y2 = x2 - k2;
+			while ( x2 < text1Length && y2 < text2Length &&
+					text1.charAt( text1Length - x2 - 1 ) ===
+					text2.charAt( text2Length - y2 - 1 ) ) {
+				x2++;
+				y2++;
+			}
+			v2[ k2Offset ] = x2;
+			if ( x2 > text1Length ) {
+
+					// Ran off the left of the graph.
+				k2end += 2;
+			} else if ( y2 > text2Length ) {
+
+					// Ran off the top of the graph.
+				k2start += 2;
+			} else if ( !front ) {
+				k1Offset = vOffset + delta - k2;
+				if ( k1Offset >= 0 && k1Offset < vLength && v1[ k1Offset ] !== -1 ) {
+					x1 = v1[ k1Offset ];
+					y1 = vOffset + x1 - k1Offset;
+
+						// Mirror x2 onto top-left coordinate system.
+					x2 = text1Length - x2;
+					if ( x1 >= x2 ) {
+
+							// Overlap detected.
+						return this.diffBisectSplit( text1, text2, x1, y1, deadline );
+					}
+				}
+			}
+		}
+	}
+
 		// Diff took too long and hit the deadline or
 		// number of diffs equals number of characters, no commonality at all.
-		return [
+	return [
 			[ DIFF_DELETE, text1 ],
 			[ DIFF_INSERT, text2 ]
-		];
-	};
+	];
+};
 
 	/**
 	 * Given the location of the 'middle snake', split the diff in two parts
@@ -718,99 +718,99 @@ QUnit.diff = ( function() {
 	 * @return {!Array.<!DiffMatchPatch.Diff>} Array of diff tuples.
 	 * @private
 	 */
-	DiffMatchPatch.prototype.diffBisectSplit = function( text1, text2, x, y, deadline ) {
-		var text1a, text1b, text2a, text2b, diffs, diffsb;
-		text1a = text1.substring( 0, x );
-		text2a = text2.substring( 0, y );
-		text1b = text1.substring( x );
-		text2b = text2.substring( y );
+DiffMatchPatch.prototype.diffBisectSplit = function( text1, text2, x, y, deadline ) {
+	var text1a, text1b, text2a, text2b, diffs, diffsb;
+	text1a = text1.substring( 0, x );
+	text2a = text2.substring( 0, y );
+	text1b = text1.substring( x );
+	text2b = text2.substring( y );
 
 		// Compute both diffs serially.
-		diffs = this.DiffMain( text1a, text2a, false, deadline );
-		diffsb = this.DiffMain( text1b, text2b, false, deadline );
+	diffs = this.DiffMain( text1a, text2a, false, deadline );
+	diffsb = this.DiffMain( text1b, text2b, false, deadline );
 
-		return diffs.concat( diffsb );
-	};
+	return diffs.concat( diffsb );
+};
 
 	/**
 	 * Reduce the number of edits by eliminating semantically trivial equalities.
 	 * @param {!Array.<!DiffMatchPatch.Diff>} diffs Array of diff tuples.
 	 */
-	DiffMatchPatch.prototype.diffCleanupSemantic = function( diffs ) {
-		var changes, equalities, equalitiesLength, lastequality,
-			pointer, lengthInsertions2, lengthDeletions2, lengthInsertions1,
-			lengthDeletions1, deletion, insertion, overlapLength1, overlapLength2;
-		changes = false;
-		equalities = []; // Stack of indices where equalities are found.
-		equalitiesLength = 0; // Keeping our own length var is faster in JS.
+DiffMatchPatch.prototype.diffCleanupSemantic = function( diffs ) {
+	var changes, equalities, equalitiesLength, lastequality,
+		pointer, lengthInsertions2, lengthDeletions2, lengthInsertions1,
+		lengthDeletions1, deletion, insertion, overlapLength1, overlapLength2;
+	changes = false;
+	equalities = []; // Stack of indices where equalities are found.
+	equalitiesLength = 0; // Keeping our own length var is faster in JS.
 		/** @type {?string} */
-		lastequality = null;
+	lastequality = null;
 
 		// Always equal to diffs[equalities[equalitiesLength - 1]][1]
-		pointer = 0; // Index of current position.
+	pointer = 0; // Index of current position.
 
 		// Number of characters that changed prior to the equality.
-		lengthInsertions1 = 0;
-		lengthDeletions1 = 0;
+	lengthInsertions1 = 0;
+	lengthDeletions1 = 0;
 
 		// Number of characters that changed after the equality.
-		lengthInsertions2 = 0;
-		lengthDeletions2 = 0;
-		while ( pointer < diffs.length ) {
-			if ( diffs[ pointer ][ 0 ] === DIFF_EQUAL ) { // Equality found.
-				equalities[ equalitiesLength++ ] = pointer;
-				lengthInsertions1 = lengthInsertions2;
-				lengthDeletions1 = lengthDeletions2;
-				lengthInsertions2 = 0;
-				lengthDeletions2 = 0;
-				lastequality = diffs[ pointer ][ 1 ];
-			} else { // An insertion or deletion.
-				if ( diffs[ pointer ][ 0 ] === DIFF_INSERT ) {
-					lengthInsertions2 += diffs[ pointer ][ 1 ].length;
-				} else {
-					lengthDeletions2 += diffs[ pointer ][ 1 ].length;
-				}
+	lengthInsertions2 = 0;
+	lengthDeletions2 = 0;
+	while ( pointer < diffs.length ) {
+		if ( diffs[ pointer ][ 0 ] === DIFF_EQUAL ) { // Equality found.
+			equalities[ equalitiesLength++ ] = pointer;
+			lengthInsertions1 = lengthInsertions2;
+			lengthDeletions1 = lengthDeletions2;
+			lengthInsertions2 = 0;
+			lengthDeletions2 = 0;
+			lastequality = diffs[ pointer ][ 1 ];
+		} else { // An insertion or deletion.
+			if ( diffs[ pointer ][ 0 ] === DIFF_INSERT ) {
+				lengthInsertions2 += diffs[ pointer ][ 1 ].length;
+			} else {
+				lengthDeletions2 += diffs[ pointer ][ 1 ].length;
+			}
 
 				// Eliminate an equality that is smaller or equal to the edits on both
 				// sides of it.
-				if ( lastequality && ( lastequality.length <=
+			if ( lastequality && ( lastequality.length <=
 						Math.max( lengthInsertions1, lengthDeletions1 ) ) &&
 						( lastequality.length <= Math.max( lengthInsertions2,
 							lengthDeletions2 ) ) ) {
 
 					// Duplicate record.
-					diffs.splice(
-						equalities[ equalitiesLength - 1 ],
-						0,
+				diffs.splice(
+					equalities[ equalitiesLength - 1 ],
+					0,
 						[ DIFF_DELETE, lastequality ]
 					);
 
 					// Change second copy to insert.
-					diffs[ equalities[ equalitiesLength - 1 ] + 1 ][ 0 ] = DIFF_INSERT;
+				diffs[ equalities[ equalitiesLength - 1 ] + 1 ][ 0 ] = DIFF_INSERT;
 
 					// Throw away the equality we just deleted.
-					equalitiesLength--;
+				equalitiesLength--;
 
 					// Throw away the previous equality (it needs to be reevaluated).
-					equalitiesLength--;
-					pointer = equalitiesLength > 0 ? equalities[ equalitiesLength - 1 ] : -1;
+				equalitiesLength--;
+				pointer = equalitiesLength > 0 ? equalities[ equalitiesLength - 1 ] : -1;
 
 					// Reset the counters.
-					lengthInsertions1 = 0;
-					lengthDeletions1 = 0;
-					lengthInsertions2 = 0;
-					lengthDeletions2 = 0;
-					lastequality = null;
-					changes = true;
-				}
+				lengthInsertions1 = 0;
+				lengthDeletions1 = 0;
+				lengthInsertions2 = 0;
+				lengthDeletions2 = 0;
+				lastequality = null;
+				changes = true;
 			}
-			pointer++;
 		}
+		pointer++;
+	}
 
 		// Normalize the diff.
-		if ( changes ) {
-			this.diffCleanupMerge( diffs );
-		}
+	if ( changes ) {
+		this.diffCleanupMerge( diffs );
+	}
 
 		// Find any overlaps between deletions and insertions.
 		// e.g: <del>abcxxx</del><ins>xxxdef</ins>
@@ -818,55 +818,55 @@ QUnit.diff = ( function() {
 		// e.g: <del>xxxabc</del><ins>defxxx</ins>
 		//   -> <ins>def</ins>xxx<del>abc</del>
 		// Only extract an overlap if it is as big as the edit ahead or behind it.
-		pointer = 1;
-		while ( pointer < diffs.length ) {
-			if ( diffs[ pointer - 1 ][ 0 ] === DIFF_DELETE &&
+	pointer = 1;
+	while ( pointer < diffs.length ) {
+		if ( diffs[ pointer - 1 ][ 0 ] === DIFF_DELETE &&
 					diffs[ pointer ][ 0 ] === DIFF_INSERT ) {
-				deletion = diffs[ pointer - 1 ][ 1 ];
-				insertion = diffs[ pointer ][ 1 ];
-				overlapLength1 = this.diffCommonOverlap( deletion, insertion );
-				overlapLength2 = this.diffCommonOverlap( insertion, deletion );
-				if ( overlapLength1 >= overlapLength2 ) {
-					if ( overlapLength1 >= deletion.length / 2 ||
+			deletion = diffs[ pointer - 1 ][ 1 ];
+			insertion = diffs[ pointer ][ 1 ];
+			overlapLength1 = this.diffCommonOverlap( deletion, insertion );
+			overlapLength2 = this.diffCommonOverlap( insertion, deletion );
+			if ( overlapLength1 >= overlapLength2 ) {
+				if ( overlapLength1 >= deletion.length / 2 ||
 							overlapLength1 >= insertion.length / 2 ) {
 
 						// Overlap found.  Insert an equality and trim the surrounding edits.
-						diffs.splice(
-							pointer,
-							0,
+					diffs.splice(
+						pointer,
+						0,
 							[ DIFF_EQUAL, insertion.substring( 0, overlapLength1 ) ]
 						);
-						diffs[ pointer - 1 ][ 1 ] =
+					diffs[ pointer - 1 ][ 1 ] =
 							deletion.substring( 0, deletion.length - overlapLength1 );
-						diffs[ pointer + 1 ][ 1 ] = insertion.substring( overlapLength1 );
-						pointer++;
-					}
-				} else {
-					if ( overlapLength2 >= deletion.length / 2 ||
+					diffs[ pointer + 1 ][ 1 ] = insertion.substring( overlapLength1 );
+					pointer++;
+				}
+			} else {
+				if ( overlapLength2 >= deletion.length / 2 ||
 							overlapLength2 >= insertion.length / 2 ) {
 
 						// Reverse overlap found.
 						// Insert an equality and swap and trim the surrounding edits.
-						diffs.splice(
-							pointer,
-							0,
+					diffs.splice(
+						pointer,
+						0,
 							[ DIFF_EQUAL, deletion.substring( 0, overlapLength2 ) ]
 						);
 
-						diffs[ pointer - 1 ][ 0 ] = DIFF_INSERT;
-						diffs[ pointer - 1 ][ 1 ] =
+					diffs[ pointer - 1 ][ 0 ] = DIFF_INSERT;
+					diffs[ pointer - 1 ][ 1 ] =
 							insertion.substring( 0, insertion.length - overlapLength2 );
-						diffs[ pointer + 1 ][ 0 ] = DIFF_DELETE;
-						diffs[ pointer + 1 ][ 1 ] =
+					diffs[ pointer + 1 ][ 0 ] = DIFF_DELETE;
+					diffs[ pointer + 1 ][ 1 ] =
 							deletion.substring( overlapLength2 );
-						pointer++;
-					}
+					pointer++;
 				}
-				pointer++;
 			}
 			pointer++;
 		}
-	};
+		pointer++;
+	}
+};
 
 	/**
 	 * Determine if the suffix of one string is the prefix of another.
@@ -876,51 +876,51 @@ QUnit.diff = ( function() {
 	 *     string and the start of the second string.
 	 * @private
 	 */
-	DiffMatchPatch.prototype.diffCommonOverlap = function( text1, text2 ) {
-		var text1Length, text2Length, textLength,
-			best, length, pattern, found;
+DiffMatchPatch.prototype.diffCommonOverlap = function( text1, text2 ) {
+	var text1Length, text2Length, textLength,
+		best, length, pattern, found;
 
 		// Cache the text lengths to prevent multiple calls.
-		text1Length = text1.length;
-		text2Length = text2.length;
+	text1Length = text1.length;
+	text2Length = text2.length;
 
 		// Eliminate the null case.
-		if ( text1Length === 0 || text2Length === 0 ) {
-			return 0;
-		}
+	if ( text1Length === 0 || text2Length === 0 ) {
+		return 0;
+	}
 
 		// Truncate the longer string.
-		if ( text1Length > text2Length ) {
-			text1 = text1.substring( text1Length - text2Length );
-		} else if ( text1Length < text2Length ) {
-			text2 = text2.substring( 0, text1Length );
-		}
-		textLength = Math.min( text1Length, text2Length );
+	if ( text1Length > text2Length ) {
+		text1 = text1.substring( text1Length - text2Length );
+	} else if ( text1Length < text2Length ) {
+		text2 = text2.substring( 0, text1Length );
+	}
+	textLength = Math.min( text1Length, text2Length );
 
 		// Quick check for the worst case.
-		if ( text1 === text2 ) {
-			return textLength;
-		}
+	if ( text1 === text2 ) {
+		return textLength;
+	}
 
 		// Start by looking for a single character match
 		// and increase length until no match is found.
 		// Performance analysis: https://neil.fraser.name/news/2010/11/04/
-		best = 0;
-		length = 1;
-		while ( true ) {
-			pattern = text1.substring( textLength - length );
-			found = text2.indexOf( pattern );
-			if ( found === -1 ) {
-				return best;
-			}
-			length += found;
-			if ( found === 0 || text1.substring( textLength - length ) ===
-					text2.substring( 0, length ) ) {
-				best = length;
-				length++;
-			}
+	best = 0;
+	length = 1;
+	while ( true ) {
+		pattern = text1.substring( textLength - length );
+		found = text2.indexOf( pattern );
+		if ( found === -1 ) {
+			return best;
 		}
-	};
+		length += found;
+		if ( found === 0 || text1.substring( textLength - length ) ===
+					text2.substring( 0, length ) ) {
+			best = length;
+			length++;
+		}
+	}
+};
 
 	/**
 	 * Split two texts into an array of strings.  Reduce the texts to a string of
@@ -933,14 +933,14 @@ QUnit.diff = ( function() {
 	 *     The zeroth element of the array of unique strings is intentionally blank.
 	 * @private
 	 */
-	DiffMatchPatch.prototype.diffLinesToChars = function( text1, text2 ) {
-		var lineArray, lineHash, chars1, chars2;
-		lineArray = []; // E.g. lineArray[4] === 'Hello\n'
-		lineHash = {};  // E.g. lineHash['Hello\n'] === 4
+DiffMatchPatch.prototype.diffLinesToChars = function( text1, text2 ) {
+	var lineArray, lineHash, chars1, chars2;
+	lineArray = []; // E.g. lineArray[4] === 'Hello\n'
+	lineHash = {};  // E.g. lineHash['Hello\n'] === 4
 
 		// '\x00' is a valid character, but various debuggers don't like it.
 		// So we'll insert a junk entry to avoid generating a null character.
-		lineArray[ 0 ] = "";
+	lineArray[ 0 ] = "";
 
 		/**
 		 * Split a text into an array of strings.  Reduce the texts to a string of
@@ -950,46 +950,46 @@ QUnit.diff = ( function() {
 		 * @return {string} Encoded string.
 		 * @private
 		 */
-		function diffLinesToCharsMunge( text ) {
-			var chars, lineStart, lineEnd, lineArrayLength, line;
-			chars = "";
+	function diffLinesToCharsMunge( text ) {
+		var chars, lineStart, lineEnd, lineArrayLength, line;
+		chars = "";
 
 			// Walk the text, pulling out a substring for each line.
 			// text.split('\n') would would temporarily double our memory footprint.
 			// Modifying text would create many large strings to garbage collect.
-			lineStart = 0;
-			lineEnd = -1;
+		lineStart = 0;
+		lineEnd = -1;
 
 			// Keeping our own length variable is faster than looking it up.
-			lineArrayLength = lineArray.length;
-			while ( lineEnd < text.length - 1 ) {
-				lineEnd = text.indexOf( "\n", lineStart );
-				if ( lineEnd === -1 ) {
-					lineEnd = text.length - 1;
-				}
-				line = text.substring( lineStart, lineEnd + 1 );
-				lineStart = lineEnd + 1;
-
-				if ( lineHash.hasOwnProperty ? lineHash.hasOwnProperty( line ) :
-							( lineHash[ line ] !== undefined ) ) {
-					chars += String.fromCharCode( lineHash[ line ] );
-				} else {
-					chars += String.fromCharCode( lineArrayLength );
-					lineHash[ line ] = lineArrayLength;
-					lineArray[ lineArrayLength++ ] = line;
-				}
+		lineArrayLength = lineArray.length;
+		while ( lineEnd < text.length - 1 ) {
+			lineEnd = text.indexOf( "\n", lineStart );
+			if ( lineEnd === -1 ) {
+				lineEnd = text.length - 1;
 			}
-			return chars;
-		}
+			line = text.substring( lineStart, lineEnd + 1 );
+			lineStart = lineEnd + 1;
 
-		chars1 = diffLinesToCharsMunge( text1 );
-		chars2 = diffLinesToCharsMunge( text2 );
-		return {
-			chars1: chars1,
-			chars2: chars2,
-			lineArray: lineArray
-		};
+			if ( lineHash.hasOwnProperty ? lineHash.hasOwnProperty( line ) :
+							( lineHash[ line ] !== undefined ) ) {
+				chars += String.fromCharCode( lineHash[ line ] );
+			} else {
+				chars += String.fromCharCode( lineArrayLength );
+				lineHash[ line ] = lineArrayLength;
+				lineArray[ lineArrayLength++ ] = line;
+			}
+		}
+		return chars;
+	}
+
+	chars1 = diffLinesToCharsMunge( text1 );
+	chars2 = diffLinesToCharsMunge( text2 );
+	return {
+		chars1: chars1,
+		chars2: chars2,
+		lineArray: lineArray
 	};
+};
 
 	/**
 	 * Rehydrate the text in a diff from a string of line hashes to real lines of
@@ -998,171 +998,171 @@ QUnit.diff = ( function() {
 	 * @param {!Array.<string>} lineArray Array of unique strings.
 	 * @private
 	 */
-	DiffMatchPatch.prototype.diffCharsToLines = function( diffs, lineArray ) {
-		var x, chars, text, y;
-		for ( x = 0; x < diffs.length; x++ ) {
-			chars = diffs[ x ][ 1 ];
-			text = [];
-			for ( y = 0; y < chars.length; y++ ) {
-				text[ y ] = lineArray[ chars.charCodeAt( y ) ];
-			}
-			diffs[ x ][ 1 ] = text.join( "" );
+DiffMatchPatch.prototype.diffCharsToLines = function( diffs, lineArray ) {
+	var x, chars, text, y;
+	for ( x = 0; x < diffs.length; x++ ) {
+		chars = diffs[ x ][ 1 ];
+		text = [];
+		for ( y = 0; y < chars.length; y++ ) {
+			text[ y ] = lineArray[ chars.charCodeAt( y ) ];
 		}
-	};
+		diffs[ x ][ 1 ] = text.join( "" );
+	}
+};
 
 	/**
 	 * Reorder and merge like edit sections.  Merge equalities.
 	 * Any edit section can move as long as it doesn't cross an equality.
 	 * @param {!Array.<!DiffMatchPatch.Diff>} diffs Array of diff tuples.
 	 */
-	DiffMatchPatch.prototype.diffCleanupMerge = function( diffs ) {
-		var pointer, countDelete, countInsert, textInsert, textDelete,
-			commonlength, changes, diffPointer, position;
-		diffs.push( [ DIFF_EQUAL, "" ] ); // Add a dummy entry at the end.
-		pointer = 0;
-		countDelete = 0;
-		countInsert = 0;
-		textDelete = "";
-		textInsert = "";
+DiffMatchPatch.prototype.diffCleanupMerge = function( diffs ) {
+	var pointer, countDelete, countInsert, textInsert, textDelete,
+		commonlength, changes, diffPointer, position;
+	diffs.push( [ DIFF_EQUAL, "" ] ); // Add a dummy entry at the end.
+	pointer = 0;
+	countDelete = 0;
+	countInsert = 0;
+	textDelete = "";
+	textInsert = "";
 
-		while ( pointer < diffs.length ) {
-			switch ( diffs[ pointer ][ 0 ] ) {
-			case DIFF_INSERT:
-				countInsert++;
-				textInsert += diffs[ pointer ][ 1 ];
-				pointer++;
-				break;
-			case DIFF_DELETE:
-				countDelete++;
-				textDelete += diffs[ pointer ][ 1 ];
-				pointer++;
-				break;
-			case DIFF_EQUAL:
+	while ( pointer < diffs.length ) {
+		switch ( diffs[ pointer ][ 0 ] ) {
+		case DIFF_INSERT:
+			countInsert++;
+			textInsert += diffs[ pointer ][ 1 ];
+			pointer++;
+			break;
+		case DIFF_DELETE:
+			countDelete++;
+			textDelete += diffs[ pointer ][ 1 ];
+			pointer++;
+			break;
+		case DIFF_EQUAL:
 
 				// Upon reaching an equality, check for prior redundancies.
-				if ( countDelete + countInsert > 1 ) {
-					if ( countDelete !== 0 && countInsert !== 0 ) {
+			if ( countDelete + countInsert > 1 ) {
+				if ( countDelete !== 0 && countInsert !== 0 ) {
 
 						// Factor out any common prefixes.
-						commonlength = this.diffCommonPrefix( textInsert, textDelete );
-						if ( commonlength !== 0 ) {
-							if ( ( pointer - countDelete - countInsert ) > 0 &&
+					commonlength = this.diffCommonPrefix( textInsert, textDelete );
+					if ( commonlength !== 0 ) {
+						if ( ( pointer - countDelete - countInsert ) > 0 &&
 									diffs[ pointer - countDelete - countInsert - 1 ][ 0 ] ===
 									DIFF_EQUAL ) {
-								diffs[ pointer - countDelete - countInsert - 1 ][ 1 ] +=
+							diffs[ pointer - countDelete - countInsert - 1 ][ 1 ] +=
 									textInsert.substring( 0, commonlength );
-							} else {
-								diffs.splice( 0, 0, [ DIFF_EQUAL,
-									textInsert.substring( 0, commonlength )
-								] );
-								pointer++;
-							}
-							textInsert = textInsert.substring( commonlength );
-							textDelete = textDelete.substring( commonlength );
+						} else {
+							diffs.splice( 0, 0, [ DIFF_EQUAL,
+								textInsert.substring( 0, commonlength )
+							] );
+							pointer++;
 						}
+						textInsert = textInsert.substring( commonlength );
+						textDelete = textDelete.substring( commonlength );
+					}
 
 						// Factor out any common suffixies.
-						commonlength = this.diffCommonSuffix( textInsert, textDelete );
-						if ( commonlength !== 0 ) {
-							diffs[ pointer ][ 1 ] = textInsert.substring( textInsert.length -
+					commonlength = this.diffCommonSuffix( textInsert, textDelete );
+					if ( commonlength !== 0 ) {
+						diffs[ pointer ][ 1 ] = textInsert.substring( textInsert.length -
 									commonlength ) + diffs[ pointer ][ 1 ];
-							textInsert = textInsert.substring( 0, textInsert.length -
+						textInsert = textInsert.substring( 0, textInsert.length -
 								commonlength );
-							textDelete = textDelete.substring( 0, textDelete.length -
+						textDelete = textDelete.substring( 0, textDelete.length -
 								commonlength );
-						}
 					}
+				}
 
 					// Delete the offending records and add the merged ones.
-					if ( countDelete === 0 ) {
-						diffs.splice( pointer - countInsert,
-							countDelete + countInsert, [ DIFF_INSERT, textInsert ] );
-					} else if ( countInsert === 0 ) {
-						diffs.splice( pointer - countDelete,
-							countDelete + countInsert, [ DIFF_DELETE, textDelete ] );
-					} else {
-						diffs.splice(
-							pointer - countDelete - countInsert,
-							countDelete + countInsert,
+				if ( countDelete === 0 ) {
+					diffs.splice( pointer - countInsert,
+						countDelete + countInsert, [ DIFF_INSERT, textInsert ] );
+				} else if ( countInsert === 0 ) {
+					diffs.splice( pointer - countDelete,
+						countDelete + countInsert, [ DIFF_DELETE, textDelete ] );
+				} else {
+					diffs.splice(
+						pointer - countDelete - countInsert,
+						countDelete + countInsert,
 							[ DIFF_DELETE, textDelete ], [ DIFF_INSERT, textInsert ]
 						);
-					}
-					pointer = pointer - countDelete - countInsert +
+				}
+				pointer = pointer - countDelete - countInsert +
 						( countDelete ? 1 : 0 ) + ( countInsert ? 1 : 0 ) + 1;
-				} else if ( pointer !== 0 && diffs[ pointer - 1 ][ 0 ] === DIFF_EQUAL ) {
+			} else if ( pointer !== 0 && diffs[ pointer - 1 ][ 0 ] === DIFF_EQUAL ) {
 
 					// Merge this equality with the previous one.
-					diffs[ pointer - 1 ][ 1 ] += diffs[ pointer ][ 1 ];
-					diffs.splice( pointer, 1 );
-				} else {
-					pointer++;
-				}
-				countInsert = 0;
-				countDelete = 0;
-				textDelete = "";
-				textInsert = "";
-				break;
+				diffs[ pointer - 1 ][ 1 ] += diffs[ pointer ][ 1 ];
+				diffs.splice( pointer, 1 );
+			} else {
+				pointer++;
 			}
+			countInsert = 0;
+			countDelete = 0;
+			textDelete = "";
+			textInsert = "";
+			break;
 		}
-		if ( diffs[ diffs.length - 1 ][ 1 ] === "" ) {
-			diffs.pop(); // Remove the dummy entry at the end.
-		}
+	}
+	if ( diffs[ diffs.length - 1 ][ 1 ] === "" ) {
+		diffs.pop(); // Remove the dummy entry at the end.
+	}
 
 		// Second pass: look for single edits surrounded on both sides by equalities
 		// which can be shifted sideways to eliminate an equality.
 		// e.g: A<ins>BA</ins>C -> <ins>AB</ins>AC
-		changes = false;
-		pointer = 1;
+	changes = false;
+	pointer = 1;
 
 		// Intentionally ignore the first and last element (don't need checking).
-		while ( pointer < diffs.length - 1 ) {
-			if ( diffs[ pointer - 1 ][ 0 ] === DIFF_EQUAL &&
+	while ( pointer < diffs.length - 1 ) {
+		if ( diffs[ pointer - 1 ][ 0 ] === DIFF_EQUAL &&
 					diffs[ pointer + 1 ][ 0 ] === DIFF_EQUAL ) {
 
-				diffPointer = diffs[ pointer ][ 1 ];
-				position = diffPointer.substring(
-					diffPointer.length - diffs[ pointer - 1 ][ 1 ].length
+			diffPointer = diffs[ pointer ][ 1 ];
+			position = diffPointer.substring(
+				diffPointer.length - diffs[ pointer - 1 ][ 1 ].length
 				);
 
 				// This is a single edit surrounded by equalities.
-				if ( position === diffs[ pointer - 1 ][ 1 ] ) {
+			if ( position === diffs[ pointer - 1 ][ 1 ] ) {
 
 					// Shift the edit over the previous equality.
-					diffs[ pointer ][ 1 ] = diffs[ pointer - 1 ][ 1 ] +
+				diffs[ pointer ][ 1 ] = diffs[ pointer - 1 ][ 1 ] +
 						diffs[ pointer ][ 1 ].substring( 0, diffs[ pointer ][ 1 ].length -
 							diffs[ pointer - 1 ][ 1 ].length );
-					diffs[ pointer + 1 ][ 1 ] =
+				diffs[ pointer + 1 ][ 1 ] =
 						diffs[ pointer - 1 ][ 1 ] + diffs[ pointer + 1 ][ 1 ];
-					diffs.splice( pointer - 1, 1 );
-					changes = true;
-				} else if ( diffPointer.substring( 0, diffs[ pointer + 1 ][ 1 ].length ) ===
+				diffs.splice( pointer - 1, 1 );
+				changes = true;
+			} else if ( diffPointer.substring( 0, diffs[ pointer + 1 ][ 1 ].length ) ===
 						diffs[ pointer + 1 ][ 1 ] ) {
 
 					// Shift the edit over the next equality.
-					diffs[ pointer - 1 ][ 1 ] += diffs[ pointer + 1 ][ 1 ];
-					diffs[ pointer ][ 1 ] =
+				diffs[ pointer - 1 ][ 1 ] += diffs[ pointer + 1 ][ 1 ];
+				diffs[ pointer ][ 1 ] =
 						diffs[ pointer ][ 1 ].substring( diffs[ pointer + 1 ][ 1 ].length ) +
 						diffs[ pointer + 1 ][ 1 ];
-					diffs.splice( pointer + 1, 1 );
-					changes = true;
-				}
+				diffs.splice( pointer + 1, 1 );
+				changes = true;
 			}
-			pointer++;
 		}
+		pointer++;
+	}
 
 		// If shifts were made, the diff needs reordering and another shift sweep.
-		if ( changes ) {
-			this.diffCleanupMerge( diffs );
-		}
-	};
+	if ( changes ) {
+		this.diffCleanupMerge( diffs );
+	}
+};
 
-	return function( o, n ) {
-		var diff, output, text;
-		diff = new DiffMatchPatch();
-		output = diff.DiffMain( o, n );
-		diff.diffCleanupEfficiency( output );
-		text = diff.diffPrettyHtml( output );
+return function( o, n ) {
+	var diff, output, text;
+	diff = new DiffMatchPatch();
+	output = diff.DiffMain( o, n );
+	diff.diffCleanupEfficiency( output );
+	text = diff.diffPrettyHtml( output );
 
-		return text;
-	};
+	return text;
+};
 }() );

--- a/src/export.js
+++ b/src/export.js
@@ -4,34 +4,34 @@ import { window } from "./globals";
 
 export default function exportQUnit( QUnit ) {
 
-if ( defined.document ) {
+	if ( defined.document ) {
 
 	// QUnit may be defined when it is preconfigured but then only QUnit and QUnit.config may be defined.
-	if ( window.QUnit && window.QUnit.version ) {
-		throw new Error( "QUnit has already been defined." );
+		if ( window.QUnit && window.QUnit.version ) {
+			throw new Error( "QUnit has already been defined." );
+		}
+
+		window.QUnit = QUnit;
 	}
 
-	window.QUnit = QUnit;
-}
-
 // For nodejs
-if ( typeof module !== "undefined" && module && module.exports ) {
-	module.exports = QUnit;
+	if ( typeof module !== "undefined" && module && module.exports ) {
+		module.exports = QUnit;
 
 	// For consistency with CommonJS environments' exports
-	module.exports.QUnit = QUnit;
-}
+		module.exports.QUnit = QUnit;
+	}
 
 // For CommonJS with exports, but without module.exports, like Rhino
-if ( typeof exports !== "undefined" && exports ) {
-	exports.QUnit = QUnit;
-}
+	if ( typeof exports !== "undefined" && exports ) {
+		exports.QUnit = QUnit;
+	}
 
-if ( typeof define === "function" && define.amd ) {
-	define( function() {
-		return QUnit;
-	} );
-	QUnit.config.autostart = false;
-}
+	if ( typeof define === "function" && define.amd ) {
+		define( function() {
+			return QUnit;
+		} );
+		QUnit.config.autostart = false;
+	}
 
 }

--- a/test/amd.js
+++ b/test/amd.js
@@ -1,23 +1,23 @@
 /* eslint-env amd */
 define( [ "qunit" ], function( QUnit ) {
 
-return function() {
-	QUnit.module( "AMD autostart", {
-		after: function( assert ) {
-			assert.ok( true, "after hook ran" );
-		}
-	} );
-
-	QUnit.test( "Prove the test run started as expected", function( assert ) {
-		assert.expect( 2 );
-		assert.strictEqual( window.beginData.totalTests, 1, "Should have expected 1 test" );
-	} );
-
-	setTimeout( function() {
-		QUnit.test( "Async-loaded tests should not run after hook again", function( assert ) {
-			assert.expect( 0 );
+	return function() {
+		QUnit.module( "AMD autostart", {
+			after: function( assert ) {
+				assert.ok( true, "after hook ran" );
+			}
 		} );
-	}, 5000 );
-};
+
+		QUnit.test( "Prove the test run started as expected", function( assert ) {
+			assert.expect( 2 );
+			assert.strictEqual( window.beginData.totalTests, 1, "Should have expected 1 test" );
+		} );
+
+		setTimeout( function() {
+			QUnit.test( "Async-loaded tests should not run after hook again", function( assert ) {
+				assert.expect( 0 );
+			} );
+		}, 5000 );
+	};
 
 } );

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -488,29 +488,29 @@ QUnit.test( "multiple `done` calls, final `done` is called BEFORE assertion", fu
 } );
 
 QUnit.test( "cannot allow assertions between first `done` call and second `assert.async` call",
-		function( assert ) {
-	var done2,
-		testContext = this,
-		done1 = assert.async();
+	function( assert ) {
+		var done2,
+			testContext = this,
+			done1 = assert.async();
 
-	assert.expect( 1 );
-	setTimeout( function() {
-		done1();
+		assert.expect( 1 );
+		setTimeout( function() {
+			done1();
 
-		testContext._assertCatch( function() {
+			testContext._assertCatch( function() {
 
 			// FAIL!!! (with duck-punch to force an Error to be thrown instead of `pushFailure`)
-			assert.ok( true, "should fail with a special `done`-related error message if called " +
-				"after final `done` even if result is passing" );
+				assert.ok( true, "should fail with a special `done`-related error message if " +
+				"called after final `done` even if result is passing" );
 
-			done2 = assert.async();
-			setTimeout( function() {
-				assert.ok( false, "Should never reach this point anyway" );
-				done2();
+				done2 = assert.async();
+				setTimeout( function() {
+					assert.ok( false, "Should never reach this point anyway" );
+					done2();
+				} );
 			} );
 		} );
 	} );
-} );
 
 QUnit.module( "assert after last done in before fail, but allow other phases to run", {
 	before: function( assert ) {

--- a/test/main/deepEqual.js
+++ b/test/main/deepEqual.js
@@ -159,38 +159,38 @@ QUnit.test( "Objects basics", function( assert ) {
 QUnit[ typeof Object.create === "function" ? "test" : "skip" ](
 	"Objects with null prototypes", function( assert ) {
 
-	var nonEmptyWithNoProto;
+		var nonEmptyWithNoProto;
 
 	// Objects with no prototype, created via Object.create(null), are used
 	// e.g. as dictionaries.
 	// Being able to test equivalence against object literals is quite useful.
-	assert.equal(
-		QUnit.equiv( Object.create( null ), {} ),
-		true,
-		"empty object without prototype VS empty object"
+		assert.equal(
+			QUnit.equiv( Object.create( null ), {} ),
+			true,
+			"empty object without prototype VS empty object"
 	);
 
-	assert.equal(
-		QUnit.equiv( {}, Object.create( null ) ),
-		true,
-		"empty object VS empty object without prototype"
+		assert.equal(
+			QUnit.equiv( {}, Object.create( null ) ),
+			true,
+			"empty object VS empty object without prototype"
 	);
 
-	nonEmptyWithNoProto = Object.create( null );
-	nonEmptyWithNoProto.foo = "bar";
+		nonEmptyWithNoProto = Object.create( null );
+		nonEmptyWithNoProto.foo = "bar";
 
-	assert.equal(
-		QUnit.equiv( nonEmptyWithNoProto, { foo: "bar" } ),
-		true,
-		"object without prototype VS object"
+		assert.equal(
+			QUnit.equiv( nonEmptyWithNoProto, { foo: "bar" } ),
+			true,
+			"object without prototype VS object"
 	);
 
-	assert.equal(
-		QUnit.equiv( { foo: "bar" }, nonEmptyWithNoProto ),
-		true,
-		"object VS object without prototype"
+		assert.equal(
+			QUnit.equiv( { foo: "bar" }, nonEmptyWithNoProto ),
+			true,
+			"object VS object without prototype"
 	);
-} );
+	} );
 
 // Ref #851
 QUnit[ typeof Object.create === "function" ? "test" : "skip" ](
@@ -201,20 +201,20 @@ QUnit[ typeof Object.create === "function" ? "test" : "skip" ](
 	// To mitigate this cost a specialized NullObject can be used. This
 	// Object has similar safe characteristics, but with dramatically
 	// reduced allocation costs.
-	function NullObject() {}
-	NullObject.prototype = Object.create( null, {
-		constructor: {
-			value: null
-		}
+		function NullObject() {}
+		NullObject.prototype = Object.create( null, {
+			constructor: {
+				value: null
+			}
+		} );
+
+		var a = new NullObject();
+		a.foo = 1;
+		var b = { foo: 1 };
+
+		assert.ok( QUnit.equiv( a, b ) );
+		assert.ok( QUnit.equiv( b, a ) );
 	} );
-
-	var a = new NullObject();
-	a.foo = 1;
-	var b = { foo: 1 };
-
-	assert.ok( QUnit.equiv( a, b ) );
-	assert.ok( QUnit.equiv( b, a ) );
-} );
 
 QUnit.test( "Arrays basics", function( assert ) {
 
@@ -244,153 +244,153 @@ QUnit.test( "Arrays basics", function( assert ) {
 	assert.equal( QUnit.equiv(
 					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
 					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]] ),
-					true );
+		true );
 	assert.equal( QUnit.equiv(
 					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
 					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]] ), // shorter
-					false );
+		false );
 	assert.equal( QUnit.equiv(
 					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[ {} ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
 					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]] ), // deepest element not an array
-					false );
+		false );
 
 	// same multidimensional
 	assert.equal( QUnit.equiv(
-							[ 1,2,3,4,5,6,7,8,9, [
-								1,2,3,4,5,6,7,8,9, [
-									1,2,3,4,5,[
-										[ 6,7,8,9, [
-											[
-												1,2,3,4,[
-													2,3,4,[
-														1,2,[
-															1,2,3,4,[
-																1,2,3,4,5,6,7,8,9,[
-																	0
-																],1,2,3,4,5,6,7,8,9
-															],5,6,7,8,9
-														],4,5,6,7,8,9
-													],5,6,7,8,9
-												],5,6,7
-											]
-										]
-									]
-								]
-							]]],
-							[ 1,2,3,4,5,6,7,8,9, [
-								1,2,3,4,5,6,7,8,9, [
-									1,2,3,4,5,[
-										[ 6,7,8,9, [
-											[
-												1,2,3,4,[
-													2,3,4,[
-														1,2,[
-															1,2,3,4,[
-																1,2,3,4,5,6,7,8,9,[
-																	0
-																],1,2,3,4,5,6,7,8,9
-															],5,6,7,8,9
-														],4,5,6,7,8,9
-													],5,6,7,8,9
-												],5,6,7
-											]
-										]
-									]
-								]
-							]]] ),
-							true, "Multidimensional" );
+		[ 1,2,3,4,5,6,7,8,9, [
+			1,2,3,4,5,6,7,8,9, [
+				1,2,3,4,5,[
+					[ 6,7,8,9, [
+						[
+							1,2,3,4,[
+								2,3,4,[
+									1,2,[
+										1,2,3,4,[
+											1,2,3,4,5,6,7,8,9,[
+												0
+											],1,2,3,4,5,6,7,8,9
+										],5,6,7,8,9
+									],4,5,6,7,8,9
+								],5,6,7,8,9
+							],5,6,7
+						]
+					]
+					]
+				]
+			]]],
+		[ 1,2,3,4,5,6,7,8,9, [
+			1,2,3,4,5,6,7,8,9, [
+				1,2,3,4,5,[
+					[ 6,7,8,9, [
+						[
+							1,2,3,4,[
+								2,3,4,[
+									1,2,[
+										1,2,3,4,[
+											1,2,3,4,5,6,7,8,9,[
+												0
+											],1,2,3,4,5,6,7,8,9
+										],5,6,7,8,9
+									],4,5,6,7,8,9
+								],5,6,7,8,9
+							],5,6,7
+						]
+					]
+					]
+				]
+			]]] ),
+		true, "Multidimensional" );
 
 	// different multidimensional
 	assert.equal( QUnit.equiv(
-							[ 1,2,3,4,5,6,7,8,9, [
-								1,2,3,4,5,6,7,8,9, [
-									1,2,3,4,5,[
-										[ 6,7,8,9, [
-											[
-												1,2,3,4,[
-													2,3,4,[
-														1,2,[
-															1,2,3,4,[
-																1,2,3,4,5,6,7,8,9,[
-																	0
-																],1,2,3,4,5,6,7,8,9
-															],5,6,7,8,9
-														],4,5,6,7,8,9
-													],5,6,7,8,9
-												],5,6,7
-											]
-										]
-									]
-								]
-							]]],
-							[ 1,2,3,4,5,6,7,8,9, [
-								1,2,3,4,5,6,7,8,9, [
-									1,2,3,4,5,[
-										[ 6,7,8,9, [
-											[
-												1,2,3,4,[
-													2,3,4,[
-														1,2,[
-															"1",2,3,4,[                 // string instead of number
-																1,2,3,4,5,6,7,8,9,[
-																	0
-																],1,2,3,4,5,6,7,8,9
-															],5,6,7,8,9
-														],4,5,6,7,8,9
-													],5,6,7,8,9
-												],5,6,7
-											]
-										]
-									]
-								]
-							]]] ),
-							false, "Multidimensional" );
+		[ 1,2,3,4,5,6,7,8,9, [
+			1,2,3,4,5,6,7,8,9, [
+				1,2,3,4,5,[
+					[ 6,7,8,9, [
+						[
+							1,2,3,4,[
+								2,3,4,[
+									1,2,[
+										1,2,3,4,[
+											1,2,3,4,5,6,7,8,9,[
+												0
+											],1,2,3,4,5,6,7,8,9
+										],5,6,7,8,9
+									],4,5,6,7,8,9
+								],5,6,7,8,9
+							],5,6,7
+						]
+					]
+					]
+				]
+			]]],
+		[ 1,2,3,4,5,6,7,8,9, [
+			1,2,3,4,5,6,7,8,9, [
+				1,2,3,4,5,[
+					[ 6,7,8,9, [
+						[
+							1,2,3,4,[
+								2,3,4,[
+									1,2,[
+										"1",2,3,4,[                 // string instead of number
+											1,2,3,4,5,6,7,8,9,[
+												0
+											],1,2,3,4,5,6,7,8,9
+										],5,6,7,8,9
+									],4,5,6,7,8,9
+								],5,6,7,8,9
+							],5,6,7
+						]
+					]
+					]
+				]
+			]]] ),
+		false, "Multidimensional" );
 
 	// different multidimensional
 	assert.equal( QUnit.equiv(
-							[ 1,2,3,4,5,6,7,8,9, [
-								1,2,3,4,5,6,7,8,9, [
-									1,2,3,4,5,[
-										[ 6,7,8,9, [
-											[
-												1,2,3,4,[
-													2,3,4,[
-														1,2,[
-															1,2,3,4,[
-																1,2,3,4,5,6,7,8,9,[
-																	0
-																],1,2,3,4,5,6,7,8,9
-															],5,6,7,8,9
-														],4,5,6,7,8,9
-													],5,6,7,8,9
-												],5,6,7
-											]
-										]
-									]
-								]
-							]]],
-							[ 1,2,3,4,5,6,7,8,9, [
-								1,2,3,4,5,6,7,8,9, [
-									1,2,3,4,5,[
-										[ 6,7,8,9, [
-											[
-												1,2,3,4,[
-													2,3,[                   // missing an element (4)
-														1,2,[
-															1,2,3,4,[
-																1,2,3,4,5,6,7,8,9,[
-																	0
-																],1,2,3,4,5,6,7,8,9
-															],5,6,7,8,9
-														],4,5,6,7,8,9
-													],5,6,7,8,9
-												],5,6,7
-											]
-										]
-									]
-								]
-							]]] ),
-							false, "Multidimensional" );
+		[ 1,2,3,4,5,6,7,8,9, [
+			1,2,3,4,5,6,7,8,9, [
+				1,2,3,4,5,[
+					[ 6,7,8,9, [
+						[
+							1,2,3,4,[
+								2,3,4,[
+									1,2,[
+										1,2,3,4,[
+											1,2,3,4,5,6,7,8,9,[
+												0
+											],1,2,3,4,5,6,7,8,9
+										],5,6,7,8,9
+									],4,5,6,7,8,9
+								],5,6,7,8,9
+							],5,6,7
+						]
+					]
+					]
+				]
+			]]],
+		[ 1,2,3,4,5,6,7,8,9, [
+			1,2,3,4,5,6,7,8,9, [
+				1,2,3,4,5,[
+					[ 6,7,8,9, [
+						[
+							1,2,3,4,[
+								2,3,[                   // missing an element (4)
+									1,2,[
+										1,2,3,4,[
+											1,2,3,4,5,6,7,8,9,[
+												0
+											],1,2,3,4,5,6,7,8,9
+										],5,6,7,8,9
+									],4,5,6,7,8,9
+								],5,6,7,8,9
+							],5,6,7
+						]
+					]
+					]
+				]
+			]]] ),
+		false, "Multidimensional" );
 } );
 
 QUnit.test( "Functions", function( assert ) {
@@ -1060,34 +1060,34 @@ QUnit.test( "Complex Arrays", function( assert ) {
 	function fn() {}
 
 	assert.equal( QUnit.equiv(
-				[ 1, 2, 3, true, {}, null, [
-					{
-						a: [ "", "1", 0 ]
-					},
-					5, 6, 7
-				], "foo" ],
-				[ 1, 2, 3, true, {}, null, [
-					{
-						a: [ "", "1", 0 ]
-					},
-					5, 6, 7
-				], "foo" ] ),
-			true );
+		[ 1, 2, 3, true, {}, null, [
+			{
+				a: [ "", "1", 0 ]
+			},
+			5, 6, 7
+		], "foo" ],
+		[ 1, 2, 3, true, {}, null, [
+			{
+				a: [ "", "1", 0 ]
+			},
+			5, 6, 7
+		], "foo" ] ),
+		true );
 
 	assert.equal( QUnit.equiv(
-				[ 1, 2, 3, true, {}, null, [
-					{
-						a: [ "", "1", 0 ]
-					},
-					5, 6, 7
-				], "foo" ],
-				[ 1, 2, 3, true, {}, null, [
-					{
-						b: [ "", "1", 0 ]         // not same property name
-					},
-					5, 6, 7
-				], "foo" ] ),
-			false );
+		[ 1, 2, 3, true, {}, null, [
+			{
+				a: [ "", "1", 0 ]
+			},
+			5, 6, 7
+		], "foo" ],
+		[ 1, 2, 3, true, {}, null, [
+			{
+				b: [ "", "1", 0 ]         // not same property name
+			},
+			5, 6, 7
+		], "foo" ] ),
+		false );
 
 	var a = [ {
 		b: fn,
@@ -1114,130 +1114,130 @@ QUnit.test( "Complex Arrays", function( assert ) {
 	}, {} ] ] ];
 
 	assert.equal( QUnit.equiv( a,
-			[ {
-				b: fn,
-				c: false,
-				"do": "reserved word",
-				"for": {
-					ar: [ 3, 5, 9, "hey!", [], {
-						ar: [ 1, [
-							3,4,6,9, null, [], []
-						]],
-						e: fn,
-						f: undefined
-					} ]
-				},
-				e: 0.43445
-			}, 5, "string", 0, fn, false, null, undefined, 0, [
-				4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
-			], [], [[[], "foo", null, {
-				n: 1 / 0,
-				z: {
-					a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
-					b: {}
-				}
-			}, {}]]] ), true );
+		[ {
+			b: fn,
+			c: false,
+			"do": "reserved word",
+			"for": {
+				ar: [ 3, 5, 9, "hey!", [], {
+					ar: [ 1, [
+						3,4,6,9, null, [], []
+					]],
+					e: fn,
+					f: undefined
+				} ]
+			},
+			e: 0.43445
+		}, 5, "string", 0, fn, false, null, undefined, 0, [
+			4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
+		], [], [[[], "foo", null, {
+			n: 1 / 0,
+			z: {
+				a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
+				b: {}
+			}
+		}, {}]]] ), true );
 
 	assert.equal( QUnit.equiv( a,
-			[ {
-				b: fn,
-				c: false,
-				"do": "reserved word",
-				"for": {
-					ar: [ 3, 5, 9, "hey!", [], {
-						ar: [ 1, [
-							3,4,6,9, null, [], []
-						]],
-						e: fn,
-						f: undefined
-					} ]
-				},
-				e: 0.43445
-			}, 5, "string", 0, fn, false, null, undefined, 0, [
-				4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 2 ]]]], "3"], {}, 1 / 0    // different: [[[[[2]]]]] instead of [[[[[3]]]]]
-			], [], [[[], "foo", null, {
-				n: 1 / 0,
-				z: {
-					a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
-					b: {}
-				}
-			}, {}]]] ), false );
+		[ {
+			b: fn,
+			c: false,
+			"do": "reserved word",
+			"for": {
+				ar: [ 3, 5, 9, "hey!", [], {
+					ar: [ 1, [
+						3,4,6,9, null, [], []
+					]],
+					e: fn,
+					f: undefined
+				} ]
+			},
+			e: 0.43445
+		}, 5, "string", 0, fn, false, null, undefined, 0, [
+			4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 2 ]]]], "3"], {}, 1 / 0    // different: [[[[[2]]]]] instead of [[[[[3]]]]]
+		], [], [[[], "foo", null, {
+			n: 1 / 0,
+			z: {
+				a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
+				b: {}
+			}
+		}, {}]]] ), false );
 
 	assert.equal( QUnit.equiv( a,
-			[ {
-				b: fn,
-				c: false,
-				"do": "reserved word",
-				"for": {
-					ar: [ 3, 5, 9, "hey!", [], {
-						ar: [ 1, [
-							3,4,6,9, null, [], []
-						]],
-						e: fn,
-						f: undefined
-					} ]
-				},
-				e: 0.43445
-			}, 5, "string", 0, fn, false, null, undefined, 0, [
-				4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
-			], [], [[[], "foo", null, {
-				n: -1 / 0,                                                                // different, -Infinity instead of Infinity
-				z: {
-					a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
-					b: {}
-				}
-			}, {}]]] ), false );
+		[ {
+			b: fn,
+			c: false,
+			"do": "reserved word",
+			"for": {
+				ar: [ 3, 5, 9, "hey!", [], {
+					ar: [ 1, [
+						3,4,6,9, null, [], []
+					]],
+					e: fn,
+					f: undefined
+				} ]
+			},
+			e: 0.43445
+		}, 5, "string", 0, fn, false, null, undefined, 0, [
+			4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
+		], [], [[[], "foo", null, {
+			n: -1 / 0,                                                                // different, -Infinity instead of Infinity
+			z: {
+				a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
+				b: {}
+			}
+		}, {}]]] ), false );
 
 	assert.equal( QUnit.equiv( a,
-			[ {
-				b: fn,
-				c: false,
-				"do": "reserved word",
-				"for": {
-					ar: [ 3, 5, 9, "hey!", [], {
-						ar: [ 1, [
-							3,4,6,9, null, [], []
-						]],
-						e: fn,
-						f: undefined
-					} ]
-				},
-				e: 0.43445
-			}, 5, "string", 0, fn, false, null, undefined, 0, [
-				4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
-			], [], [[[], "foo", {                                                       // different: null is missing
-				n: 1 / 0,
-				z: {
-					a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
-					b: {}
-				}
-			}, {}]]] ), false );
+		[ {
+			b: fn,
+			c: false,
+			"do": "reserved word",
+			"for": {
+				ar: [ 3, 5, 9, "hey!", [], {
+					ar: [ 1, [
+						3,4,6,9, null, [], []
+					]],
+					e: fn,
+					f: undefined
+				} ]
+			},
+			e: 0.43445
+		}, 5, "string", 0, fn, false, null, undefined, 0, [
+			4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
+		], [], [[[], "foo", {                                                       // different: null is missing
+			n: 1 / 0,
+			z: {
+				a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
+				b: {}
+			}
+		}, {}]]] ), false );
 
 	assert.equal( QUnit.equiv( a,
-			[ {
-				b: fn,
-				c: false,
-				"do": "reserved word",
-				"for": {
-					ar: [ 3, 5, 9, "hey!", [], {
-						ar: [ 1, [
-							3,4,6,9, null, [], []
-						]],
-						e: fn
+		[ {
+			b: fn,
+			c: false,
+			"do": "reserved word",
+			"for": {
+				ar: [ 3, 5, 9, "hey!", [], {
+					ar: [ 1, [
+						3,4,6,9, null, [], []
+					]],
+					e: fn
 
 																				// different: missing property f: undefined
-					} ]
-				},
-				e: 0.43445
-			}, 5, "string", 0, fn, false, null, undefined, 0, [
-				4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
-			], [], [[[], "foo", null, {
-				n: 1 / 0,
-				z: {
-					a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
-					b: {}
-				}
-			}, {}]]] ), false );
+				} ]
+			},
+			e: 0.43445
+		}, 5, "string", 0, fn, false, null, undefined, 0, [
+			4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
+		], [], [[[], "foo", null, {
+			n: 1 / 0,
+			z: {
+				a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
+				b: {}
+			}
+		}, {}]]] ), false );
 } );
 
 QUnit.test( "Prototypal inheritance", function( assert ) {
@@ -1723,43 +1723,43 @@ QUnit.test( "Boolean", function( assert ) {
 QUnit.module( "equiv Maps and Sets" );
 
 var hasES6Set = ( function() {
-	if ( typeof Set !== "function" ) {
-		return false;
-	}
+if ( typeof Set !== "function" ) {
+	return false;
+}
 
-	try {
+try {
 
 		// some platforms don't support iterables in Set constructors
-		var s = new Set( [ 1, 2, 3 ] );
-		if ( s.size !== 3 || !s.has( 2 ) ) {
-			return false;
-		}
-
-		// in IE 11, QUnit.objectType( new Set() ) === "object"
-		return ( QUnit.objectType( s ) === "set" );
-	} catch ( e ) {
+	var s = new Set( [ 1, 2, 3 ] );
+	if ( s.size !== 3 || !s.has( 2 ) ) {
 		return false;
 	}
+
+		// in IE 11, QUnit.objectType( new Set() ) === "object"
+	return ( QUnit.objectType( s ) === "set" );
+} catch ( e ) {
+	return false;
+}
 }() );
 
 var hasES6Map = ( function() {
-	if ( typeof Map !== "function" ) {
-		return false;
-	}
+if ( typeof Map !== "function" ) {
+	return false;
+}
 
-	try {
+try {
 
 		// some platforms don't support array-like iterables in Map constructors
-		var m = new Map( [ [ 1, 2 ] ] );
-		if ( m.size !== 1 || !m.has( 1 ) ) {
-			return false;
-		}
-
-		// in IE 11, QUnit.objectType( new Map() ) === "object"
-		return ( QUnit.objectType( m ) === "map" );
-	} catch ( e ) {
+	var m = new Map( [ [ 1, 2 ] ] );
+	if ( m.size !== 1 || !m.has( 1 ) ) {
 		return false;
 	}
+
+		// in IE 11, QUnit.objectType( new Map() ) === "object"
+	return ( QUnit.objectType( m ) === "map" );
+} catch ( e ) {
+	return false;
+}
 }() );
 
 QUnit[ hasES6Set ? "test" : "skip" ]( "Sets", function( assert ) {
@@ -1941,7 +1941,7 @@ QUnit[ hasES6Map ? "test" : "skip" ]( "Maps", function( assert ) {
 QUnit.module( "equiv Symbols" );
 
 var hasES6Symbol = ( function() {
-	return typeof Symbol === "function";
+return typeof Symbol === "function";
 }() );
 
 QUnit[ hasES6Symbol ? "test" : "skip" ]( "regular checks", function( assert ) {

--- a/test/main/modules.js
+++ b/test/main/modules.js
@@ -152,22 +152,22 @@ QUnit.module( "pre-nested modules" );
 
 QUnit.module( "nested modules", function() {
 	QUnit.module( "first outer", {
-			afterEach: function( assert ) {
-				assert.ok( true, "first outer module afterEach called" );
-			},
-			beforeEach: function( assert ) {
-				assert.ok( true, "first outer beforeEach called" );
-			}
+		afterEach: function( assert ) {
+			assert.ok( true, "first outer module afterEach called" );
 		},
+		beforeEach: function( assert ) {
+			assert.ok( true, "first outer beforeEach called" );
+		}
+	},
 		function() {
 			QUnit.module( "first inner", {
-					afterEach: function( assert ) {
-						assert.ok( true, "first inner module afterEach called" );
-					},
-					beforeEach: function( assert ) {
-						assert.ok( true, "first inner module beforeEach called" );
-					}
+				afterEach: function( assert ) {
+					assert.ok( true, "first inner module afterEach called" );
 				},
+				beforeEach: function( assert ) {
+					assert.ok( true, "first inner module beforeEach called" );
+				}
+			},
 				function() {
 					QUnit.test( "in module, before- and afterEach called in out-in-out " +
 						"order",

--- a/test/main/stack.js
+++ b/test/main/stack.js
@@ -1,14 +1,14 @@
 ( function() {
-	var stack = QUnit.stack();
+var stack = QUnit.stack();
 
-	QUnit.module( "QUnit.stack" );
+QUnit.module( "QUnit.stack" );
 
 	// Flag this test as skipped on browsers that doesn't support stack trace
-	QUnit[ stack ? "test" : "skip" ]( "returns the proper stack line", function( assert ) {
-		assert.ok( /(\/|\\)test(\/|\\)main(\/|\\)stack\.js/.test( stack ) );
+QUnit[ stack ? "test" : "skip" ]( "returns the proper stack line", function( assert ) {
+	assert.ok( /(\/|\\)test(\/|\\)main(\/|\\)stack\.js/.test( stack ) );
 
-		stack = QUnit.stack( 2 );
-		assert.ok( stack, "can use offset argument to return a different stacktrace line" );
-		assert.notOk( /\/test\/main\/stack\.js/.test( stack ), "stack with offset argument" );
-	} );
+	stack = QUnit.stack( 2 );
+	assert.ok( stack, "can use offset argument to return a different stacktrace line" );
+	assert.notOk( /\/test\/main\/stack\.js/.test( stack ), "stack with offset argument" );
+} );
 }() );

--- a/test/node/storage.js
+++ b/test/node/storage.js
@@ -1,20 +1,20 @@
 module.exports = {
-  _store: Object.create( null ),
-  setItem: function( key, value ) {
-    this._store[ key ] = value;
-  },
-  getItem: function( key ) {
-    return key in this._store ? this._store[ key ] : null;
-  },
-  removeItem: function( key ) {
-    if ( key in this._store ) {
-      delete this._store[ key ];
-    }
-  },
-  key: function( i ) {
-    return Object.keys( this._store )[ i ];
-  },
-  get length() {
-    return Object.keys( this._store ).length;
-  }
+	_store: Object.create( null ),
+	setItem: function( key, value ) {
+		this._store[ key ] = value;
+	},
+	getItem: function( key ) {
+		return key in this._store ? this._store[ key ] : null;
+	},
+	removeItem: function( key ) {
+		if ( key in this._store ) {
+			delete this._store[ key ];
+		}
+	},
+	key: function( i ) {
+		return Object.keys( this._store )[ i ];
+	},
+	get length() {
+		return Object.keys( this._store ).length;
+	}
 };

--- a/test/reorder.js
+++ b/test/reorder.js
@@ -5,11 +5,11 @@ var lastTest = "";
 QUnit.module( "Reorder" );
 
 QUnit.test( "First", function( assert ) {
-  assert.strictEqual( lastTest, "Second" );
-  lastTest = "First";
+	assert.strictEqual( lastTest, "Second" );
+	lastTest = "First";
 } );
 
 QUnit.test( "Second", function( assert ) {
-  assert.strictEqual( lastTest, "" );
-  lastTest = "Second";
+	assert.strictEqual( lastTest, "" );
+	lastTest = "Second";
 } );

--- a/test/reporter-html/window-onerror.js
+++ b/test/reporter-html/window-onerror.js
@@ -5,9 +5,9 @@ QUnit.module( "window.onerror (no preexisting handler)", function( hooks ) {
 		originalQUnitOnError = QUnit.onError;
 	} );
 
-    hooks.afterEach( function() {
-        QUnit.onError = originalQUnitOnError;
-    } );
+	hooks.afterEach( function() {
+		QUnit.onError = originalQUnitOnError;
+	} );
 
 	QUnit.test( "Should call QUnit.onError", function( assert ) {
 		assert.expect( 1 );

--- a/test/startError.js
+++ b/test/startError.js
@@ -7,8 +7,8 @@ QUnit.test( "start() throws when QUnit.config.autostart === true", function( ass
 } );
 
 QUnit.test( "Throws after calling start() too many times outside of a test context",
-		function( assert ) {
-	assert.expect( 1 );
-	assert.equal( window.tooManyStartsError.message,
-		"Called start() outside of a test context too many times" );
-} );
+	function( assert ) {
+		assert.expect( 1 );
+		assert.equal( window.tooManyStartsError.message,
+			"Called start() outside of a test context too many times" );
+	} );


### PR DESCRIPTION
This enables the ESLint "indent" rule.

There are some limitations of this rule which would force us to deviate from the jQuery style guide, especially around full file closures (whether IIFEs or factory functions). This PR chooses to have pure IIFEs be indented 0 tabs, which is closer to the style guide but results in inconsistencies between pure IIFEs and factory functions.

PR #1143 is the one-tab IIFE version.