### PR TITLE
All: Enable ESLint indent rule (one-tab indent for outer IIFE bodies)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,14 @@
         "arrow-spacing": ["error", { "before": true, "after": true }],
         "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
         "constructor-super": "error",
+        "indent": ["error", "tab", {
+                "CallExpression": {
+                        "arguments": 1
+                },
+		"MemberExpression": 1,
+		"SwitchCase": 0,
+		"outerIIFEBody": 1
+        }],
         "no-const-assign": "error",
         "no-dupe-class-members": "error",
         "no-duplicate-imports": "error",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,236 +9,245 @@ var reportDir = "build/report";
 module.exports = function( grunt ) {
 
 // Load grunt tasks from NPM packages
-require( "load-grunt-tasks" )( grunt );
+	require( "load-grunt-tasks" )( grunt );
 
-function process( code ) {
-	return code
+	function process( code ) {
+		return code
 
 		// Embed version
-		.replace( /@VERSION/g, grunt.config( "pkg" ).version )
+			.replace( /@VERSION/g, grunt.config( "pkg" ).version )
 
 		// Embed date (yyyy-mm-ddThh:mmZ)
-		.replace( /@DATE/g, ( new Date() ).toISOString().replace( /:\d+\.\d+Z$/, "Z" ) );
-}
+			.replace( /@DATE/g, ( new Date() ).toISOString().replace( /:\d+\.\d+Z$/, "Z" ) );
+	}
 
-grunt.initConfig( {
-	pkg: grunt.file.readJSON( "package.json" ),
-	connect: {
-		server: {
-			options: {
-				port: 8000,
-				base: "."
+	grunt.initConfig( {
+		pkg: grunt.file.readJSON( "package.json" ),
+		connect: {
+			server: {
+				options: {
+					port: 8000,
+					base: "."
+				}
 			}
-		}
-	},
-	copy: {
-		options: { process: process },
+		},
+		copy: {
+			options: { process: process },
 
-		"src-js": {
-			src: "dist/qunit.js",
-			dest: "dist/qunit.js"
-		},
-		"src-css": {
-			src: "src/qunit.css",
-			dest: "dist/qunit.css"
-		},
+			"src-js": {
+				src: "dist/qunit.js",
+				dest: "dist/qunit.js"
+			},
+			"src-css": {
+				src: "src/qunit.css",
+				dest: "dist/qunit.css"
+			},
 
-		// Moves files around during coverage runs
-		"dist-to-tmp": {
-			src: "dist/qunit.js",
-			dest: "dist/qunit.tmp.js"
+			// Moves files around during coverage runs
+			"dist-to-tmp": {
+				src: "dist/qunit.js",
+				dest: "dist/qunit.tmp.js"
+			},
+			"instrumented-to-dist": {
+				src: "build/instrumented/dist/qunit.js",
+				dest: "dist/qunit.js"
+			},
+			"tmp-to-dist": {
+				src: "dist/qunit.tmp.js",
+				dest: "dist/qunit.js"
+			}
 		},
-		"instrumented-to-dist": {
-			src: "build/instrumented/dist/qunit.js",
-			dest: "dist/qunit.js"
+		rollup: {
+			options: require( "./rollup.config" ),
+			src: {
+				src: "src/qunit.js",
+				dest: "dist/qunit.js"
+			}
 		},
-		"tmp-to-dist": {
-			src: "dist/qunit.tmp.js",
-			dest: "dist/qunit.js"
-		}
-	},
-	rollup: {
-		options: require( "./rollup.config" ),
-		src: {
-			src: "src/qunit.js",
-			dest: "dist/qunit.js"
-		}
-	},
-	eslint: {
-		options: {
-			config: ".eslintrc.json"
-		},
-		all: [
-			"*.js",
-			"bin/**/*.js",
-			"reporter/**/*.js",
-			"runner/**/*.js",
-			"src/**/*.js",
+		eslint: {
+			options: {
+				config: ".eslintrc.json"
+			},
+			js: [
+				"*.js",
+				"bin/**/*.js",
+				"reporter/**/*.js",
+				"runner/**/*.js",
+				"src/**/*.js",
 
-			"test/**/*.js",
-			"build/*.js",
-			"build/tasks/**/*.js",
-
-			// Linting HTML files via eslint-plugin-html
-			"test/**/*.html"
-		]
-	},
-	search: {
-		options: {
-
-			// Ensure that the only HTML entities used are those with a special status in XHTML
-			// and that any common singleton/empty HTML elements end with the XHTML-compliant
-			// "/>"rather than ">"
-			searchString: /(&(?!gt|lt|amp|quot)[A-Za-z0-9]+;|<(?:hr|HR|br|BR|input|INPUT)(?![^>]*\/>)(?:\s+[^>]*)?>)/g, // eslint-disable-line max-len
-			logFormat: "console",
-			failOnMatch: true
-		},
-		xhtml: [
-			"src/**/*.js",
-			"reporter/**/*.js"
-		]
-	},
-	qunit: {
-		options: {
-			timeout: 30000,
-			"--web-security": "no",
-			inject: [
-				path.resolve( "./build/coverage-bridge.js" ),
-				require.resolve( "grunt-contrib-qunit/phantomjs/bridge" )
+				"test/**/*.js",
+				"build/*.js",
+				"build/tasks/**/*.js"
 			],
-			urls: [
-				"http://localhost:8000/test/sandboxed-iframe.html"
+			html: {
+				options: {
+					rules: {
+						indent: "off"
+					}
+				},
+				src: [
+
+					// Linting HTML files via eslint-plugin-html
+					"test/**/*.html"
+				]
+			}
+		},
+		search: {
+			options: {
+
+				// Ensure that the only HTML entities used are those with a special status in XHTML
+				// and that any common singleton/empty HTML elements end with the XHTML-compliant
+				// "/>"rather than ">"
+				searchString: /(&(?!gt|lt|amp|quot)[A-Za-z0-9]+;|<(?:hr|HR|br|BR|input|INPUT)(?![^>]*\/>)(?:\s+[^>]*)?>)/g, // eslint-disable-line max-len
+				logFormat: "console",
+				failOnMatch: true
+			},
+			xhtml: [
+				"src/**/*.js",
+				"reporter/**/*.js"
 			]
 		},
-		qunit: [
-			"test/index.html",
-			"test/autostart.html",
-			"test/startError.html",
-			"test/reorder.html",
-			"test/reorderError1.html",
-			"test/reorderError2.html",
-			"test/callbacks.html",
-			"test/events.html",
-			"test/events-in-test.html",
-			"test/logs.html",
-			"test/setTimeout.html",
-			"test/amd.html",
-			"test/reporter-html/index.html",
-			"test/reporter-html/legacy-markup.html",
-			"test/reporter-html/no-qunit-element.html",
-			"test/reporter-html/single-testid.html",
-			"test/reporter-html/window-onerror.html",
-			"test/reporter-html/window-onerror-preexisting-handler.html",
-			"test/reporter-urlparams.html",
-			"test/moduleId.html",
-			"test/onerror/inside-test.html",
-			"test/onerror/outside-test.html",
-			"test/only.html",
-			"test/seed.html",
-			"test/overload.html",
-			"test/preconfigured.html",
-			"test/regex-filter.html",
-			"test/regex-exclude-filter.html",
-			"test/string-filter.html"
-		]
-	},
-	"test-on-node": {
-		files: [
-			"test/logs",
-			"test/main/test",
-			"test/main/assert",
-			"test/main/assert/step",
-			"test/main/async",
-			"test/main/promise",
-			"test/main/modules",
-			"test/main/deepEqual",
-			"test/main/stack",
-			"test/events",
-			"test/events-in-test",
-			"test/onerror/inside-test",
-			"test/onerror/outside-test",
-			"test/only",
-			"test/setTimeout",
-			"test/main/dump",
-			"test/node/storage-1",
-			"test/node/storage-2"
-		]
-	},
-	watch: {
-		options: {
-			atBegin: true,
-			spawn: false,
-			interrupt: true
+		qunit: {
+			options: {
+				timeout: 30000,
+				"--web-security": "no",
+				inject: [
+					path.resolve( "./build/coverage-bridge.js" ),
+					require.resolve( "grunt-contrib-qunit/phantomjs/bridge" )
+				],
+				urls: [
+					"http://localhost:8000/test/sandboxed-iframe.html"
+				]
+			},
+			qunit: [
+				"test/index.html",
+				"test/autostart.html",
+				"test/startError.html",
+				"test/reorder.html",
+				"test/reorderError1.html",
+				"test/reorderError2.html",
+				"test/callbacks.html",
+				"test/events.html",
+				"test/events-in-test.html",
+				"test/logs.html",
+				"test/setTimeout.html",
+				"test/amd.html",
+				"test/reporter-html/index.html",
+				"test/reporter-html/legacy-markup.html",
+				"test/reporter-html/no-qunit-element.html",
+				"test/reporter-html/single-testid.html",
+				"test/reporter-html/window-onerror.html",
+				"test/reporter-html/window-onerror-preexisting-handler.html",
+				"test/reporter-urlparams.html",
+				"test/moduleId.html",
+				"test/onerror/inside-test.html",
+				"test/onerror/outside-test.html",
+				"test/only.html",
+				"test/seed.html",
+				"test/overload.html",
+				"test/preconfigured.html",
+				"test/regex-filter.html",
+				"test/regex-exclude-filter.html",
+				"test/string-filter.html"
+			]
 		},
-		files: [
-			".eslintrc.json",
-			"*.js",
-			"build/*.js",
-			"{src,test,reporter}/**/*.js",
-			"src/qunit.css",
-			"test/**/*.html"
-		],
-		tasks: "default"
-	},
-
-	instrument: {
-		files: "dist/qunit.js",
-		options: {
-			lazy: false,
-			basePath: instrumentedDir
-		}
-	},
-
-	storeCoverage: {
-		options: {
-			dir: reportDir
-		}
-	},
-
-	makeReport: {
-		src: reportDir + "/**/*.json",
-		options: {
-			type: [ "lcov" ],
-			dir: reportDir,
-			print: "detail"
-		}
-	},
-
-	coveralls: {
-		options: {
-			force: true
+		"test-on-node": {
+			files: [
+				"test/logs",
+				"test/main/test",
+				"test/main/assert",
+				"test/main/assert/step",
+				"test/main/async",
+				"test/main/promise",
+				"test/main/modules",
+				"test/main/deepEqual",
+				"test/main/stack",
+				"test/events",
+				"test/events-in-test",
+				"test/onerror/inside-test",
+				"test/onerror/outside-test",
+				"test/only",
+				"test/setTimeout",
+				"test/main/dump",
+				"test/node/storage-1",
+				"test/node/storage-2"
+			]
 		},
-		all: {
+		watch: {
+			options: {
+				atBegin: true,
+				spawn: false,
+				interrupt: true
+			},
+			files: [
+				".eslintrc.json",
+				"*.js",
+				"build/*.js",
+				"{src,test,reporter}/**/*.js",
+				"src/qunit.css",
+				"test/**/*.html"
+			],
+			tasks: "default"
+		},
 
-			// LCOV coverage file relevant to every target
-			src: "build/report/lcov.info"
+		instrument: {
+			files: "dist/qunit.js",
+			options: {
+				lazy: false,
+				basePath: instrumentedDir
+			}
+		},
+
+		storeCoverage: {
+			options: {
+				dir: reportDir
+			}
+		},
+
+		makeReport: {
+			src: reportDir + "/**/*.json",
+			options: {
+				type: [ "lcov" ],
+				dir: reportDir,
+				print: "detail"
+			}
+		},
+
+		coveralls: {
+			options: {
+				force: true
+			},
+			all: {
+
+				// LCOV coverage file relevant to every target
+				src: "build/report/lcov.info"
+			}
 		}
-	}
-} );
+	} );
 
-grunt.event.on( "qunit.coverage", function( file, coverage ) {
-	var testName = file.split( "/test/" ).pop().replace( ".html", "" );
-	var reportPath = path.join( "build/report/phantom", testName + ".json" );
+	grunt.event.on( "qunit.coverage", function( file, coverage ) {
+		var testName = file.split( "/test/" ).pop().replace( ".html", "" );
+		var reportPath = path.join( "build/report/phantom", testName + ".json" );
 
-	fs.createFileSync( reportPath );
-	fs.writeJsonSync( reportPath, coverage, { spaces: 0 } );
-} );
+		fs.createFileSync( reportPath );
+		fs.writeJsonSync( reportPath, coverage, { spaces: 0 } );
+	} );
 
-grunt.loadTasks( "build/tasks" );
-grunt.registerTask( "build", [ "rollup:src", "copy:src-js", "copy:src-css" ] );
-grunt.registerTask( "qunit-test", [ "connect", "qunit" ] );
-grunt.registerTask( "test", [ "eslint", "search", "test-on-node", "qunit-test" ] );
-grunt.registerTask( "coverage", [
-	"build",
-	"instrument",
-	"copy:dist-to-tmp",
-	"copy:instrumented-to-dist",
-	"test",
-	"copy:tmp-to-dist",
-	"storeCoverage",
-	"makeReport",
-	"coveralls"
-] );
-grunt.registerTask( "default", [ "build", "test" ] );
+	grunt.loadTasks( "build/tasks" );
+	grunt.registerTask( "build", [ "rollup:src", "copy:src-js", "copy:src-css" ] );
+	grunt.registerTask( "qunit-test", [ "connect", "qunit" ] );
+	grunt.registerTask( "test", [ "eslint", "search", "test-on-node", "qunit-test" ] );
+	grunt.registerTask( "coverage", [
+		"build",
+		"instrument",
+		"copy:dist-to-tmp",
+		"copy:instrumented-to-dist",
+		"test",
+		"copy:tmp-to-dist",
+		"storeCoverage",
+		"makeReport",
+		"coveralls"
+	] );
+	grunt.registerTask( "default", [ "build", "test" ] );
 
 };

--- a/build/coverage-bridge.js
+++ b/build/coverage-bridge.js
@@ -3,16 +3,16 @@
 ( function( QUnit ) {
 
   // Send messages to the parent PhantomJS process via alert! Good times!!
-  function sendMessage() {
-    var args = [].slice.call( arguments );
-    window.alert( JSON.stringify( args ) );
-  }
+	function sendMessage() {
+		var args = [].slice.call( arguments );
+		window.alert( JSON.stringify( args ) );
+	}
 
-  QUnit.done( function() {
+	QUnit.done( function() {
 
     // send coverage data if available
-    if ( window.__coverage__ ) {
-      sendMessage( "qunit.coverage", window.location.pathname, window.__coverage__ );
-    }
-  } );
+		if ( window.__coverage__ ) {
+			sendMessage( "qunit.coverage", window.location.pathname, window.__coverage__ );
+		}
+	} );
 }( QUnit ) );

--- a/build/release.js
+++ b/build/release.js
@@ -1,25 +1,25 @@
 /* eslint-env node */
 module.exports = function( Release ) {
 
-var shell = require( "shelljs" );
+	var shell = require( "shelljs" );
 
-Release.define( {
-	npmPublish: true,
-	issueTracker: "github",
-	changelogShell: function() {
-		return "# Changelog for QUnit v" + Release.newVersion + "\n";
-	},
+	Release.define( {
+		npmPublish: true,
+		issueTracker: "github",
+		changelogShell: function() {
+			return "# Changelog for QUnit v" + Release.newVersion + "\n";
+		},
 
-	generateArtifacts: function( done ) {
-		Release.exec( "grunt", "Grunt command failed" );
-		shell.mkdir( "-p", "qunit" );
-		shell.cp( "-r", "dist/*", "qunit/" );
-		shell.mkdir( "-p", "dist/cdn" );
-		shell.cp( "dist/qunit.js", "dist/cdn/qunit-" + Release.newVersion + ".js" );
-		shell.cp( "dist/qunit.css", "dist/cdn/qunit-" + Release.newVersion + ".css" );
-		done( [ "qunit/qunit.js", "qunit/qunit.css" ] );
-	}
-} );
+		generateArtifacts: function( done ) {
+			Release.exec( "grunt", "Grunt command failed" );
+			shell.mkdir( "-p", "qunit" );
+			shell.cp( "-r", "dist/*", "qunit/" );
+			shell.mkdir( "-p", "dist/cdn" );
+			shell.cp( "dist/qunit.js", "dist/cdn/qunit-" + Release.newVersion + ".js" );
+			shell.cp( "dist/qunit.css", "dist/cdn/qunit-" + Release.newVersion + ".css" );
+			done( [ "qunit/qunit.js", "qunit/qunit.css" ] );
+		}
+	} );
 
 };
 

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -36,929 +36,938 @@ export function escapeText( s ) {
 ( function() {
 
 // Don't load the HTML Reporter on non-browser environments
-if ( typeof window === "undefined" || !window.document ) {
-	return;
-}
-
-var config = QUnit.config,
-	document = window.document,
-	collapseNext = false,
-	hasOwn = Object.prototype.hasOwnProperty,
-	unfilteredUrl = setUrl( { filter: undefined, module: undefined,
-		moduleId: undefined, testId: undefined } ),
-	modulesList = [];
-
-function addEvent( elem, type, fn ) {
-	elem.addEventListener( type, fn, false );
-}
-
-function removeEvent( elem, type, fn ) {
-	elem.removeEventListener( type, fn, false );
-}
-
-function addEvents( elems, type, fn ) {
-	var i = elems.length;
-	while ( i-- ) {
-		addEvent( elems[ i ], type, fn );
+	if ( typeof window === "undefined" || !window.document ) {
+		return;
 	}
-}
 
-function hasClass( elem, name ) {
-	return ( " " + elem.className + " " ).indexOf( " " + name + " " ) >= 0;
-}
+	var config = QUnit.config,
+		document = window.document,
+		collapseNext = false,
+		hasOwn = Object.prototype.hasOwnProperty,
+		unfilteredUrl = setUrl( { filter: undefined, module: undefined,
+			moduleId: undefined, testId: undefined } ),
+		modulesList = [];
 
-function addClass( elem, name ) {
-	if ( !hasClass( elem, name ) ) {
-		elem.className += ( elem.className ? " " : "" ) + name;
+	function addEvent( elem, type, fn ) {
+		elem.addEventListener( type, fn, false );
 	}
-}
 
-function toggleClass( elem, name, force ) {
-	if ( force || typeof force === "undefined" && !hasClass( elem, name ) ) {
-		addClass( elem, name );
-	} else {
-		removeClass( elem, name );
+	function removeEvent( elem, type, fn ) {
+		elem.removeEventListener( type, fn, false );
 	}
-}
 
-function removeClass( elem, name ) {
-	var set = " " + elem.className + " ";
+	function addEvents( elems, type, fn ) {
+		var i = elems.length;
+		while ( i-- ) {
+			addEvent( elems[ i ], type, fn );
+		}
+	}
+
+	function hasClass( elem, name ) {
+		return ( " " + elem.className + " " ).indexOf( " " + name + " " ) >= 0;
+	}
+
+	function addClass( elem, name ) {
+		if ( !hasClass( elem, name ) ) {
+			elem.className += ( elem.className ? " " : "" ) + name;
+		}
+	}
+
+	function toggleClass( elem, name, force ) {
+		if ( force || typeof force === "undefined" && !hasClass( elem, name ) ) {
+			addClass( elem, name );
+		} else {
+			removeClass( elem, name );
+		}
+	}
+
+	function removeClass( elem, name ) {
+		var set = " " + elem.className + " ";
 
 	// Class name may appear multiple times
-	while ( set.indexOf( " " + name + " " ) >= 0 ) {
-		set = set.replace( " " + name + " ", " " );
-	}
-
-	// Trim for prettiness
-	elem.className = typeof set.trim === "function" ? set.trim() : set.replace( /^\s+|\s+$/g, "" );
-}
-
-function id( name ) {
-	return document.getElementById && document.getElementById( name );
-}
-
-function abortTests() {
-	var abortButton = id( "qunit-abort-tests-button" );
-	if ( abortButton ) {
-		abortButton.disabled = true;
-		abortButton.innerHTML = "Aborting...";
-	}
-	QUnit.config.queue.length = 0;
-	return false;
-}
-
-function interceptNavigation( ev ) {
-	applyUrlParams();
-
-	if ( ev && ev.preventDefault ) {
-		ev.preventDefault();
-	}
-
-	return false;
-}
-
-function getUrlConfigHtml() {
-	var i, j, val,
-		escaped, escapedTooltip,
-		selection = false,
-		urlConfig = config.urlConfig,
-		urlConfigHtml = "";
-
-	for ( i = 0; i < urlConfig.length; i++ ) {
-
-		// Options can be either strings or objects with nonempty "id" properties
-		val = config.urlConfig[ i ];
-		if ( typeof val === "string" ) {
-			val = {
-				id: val,
-				label: val
-			};
+		while ( set.indexOf( " " + name + " " ) >= 0 ) {
+			set = set.replace( " " + name + " ", " " );
 		}
 
-		escaped = escapeText( val.id );
-		escapedTooltip = escapeText( val.tooltip );
+	// Trim for prettiness
+		elem.className = typeof set.trim === "function" ?
+			set.trim() :
+			set.replace( /^\s+|\s+$/g, "" );
+	}
 
-		if ( !val.value || typeof val.value === "string" ) {
-			urlConfigHtml += "<label for='qunit-urlconfig-" + escaped +
+	function id( name ) {
+		return document.getElementById && document.getElementById( name );
+	}
+
+	function abortTests() {
+		var abortButton = id( "qunit-abort-tests-button" );
+		if ( abortButton ) {
+			abortButton.disabled = true;
+			abortButton.innerHTML = "Aborting...";
+		}
+		QUnit.config.queue.length = 0;
+		return false;
+	}
+
+	function interceptNavigation( ev ) {
+		applyUrlParams();
+
+		if ( ev && ev.preventDefault ) {
+			ev.preventDefault();
+		}
+
+		return false;
+	}
+
+	function getUrlConfigHtml() {
+		var i, j, val,
+			escaped, escapedTooltip,
+			selection = false,
+			urlConfig = config.urlConfig,
+			urlConfigHtml = "";
+
+		for ( i = 0; i < urlConfig.length; i++ ) {
+
+		// Options can be either strings or objects with nonempty "id" properties
+			val = config.urlConfig[ i ];
+			if ( typeof val === "string" ) {
+				val = {
+					id: val,
+					label: val
+				};
+			}
+
+			escaped = escapeText( val.id );
+			escapedTooltip = escapeText( val.tooltip );
+
+			if ( !val.value || typeof val.value === "string" ) {
+				urlConfigHtml += "<label for='qunit-urlconfig-" + escaped +
 				"' title='" + escapedTooltip + "'><input id='qunit-urlconfig-" + escaped +
 				"' name='" + escaped + "' type='checkbox'" +
 				( val.value ? " value='" + escapeText( val.value ) + "'" : "" ) +
 				( config[ val.id ] ? " checked='checked'" : "" ) +
 				" title='" + escapedTooltip + "' />" + escapeText( val.label ) + "</label>";
-		} else {
-			urlConfigHtml += "<label for='qunit-urlconfig-" + escaped +
+			} else {
+				urlConfigHtml += "<label for='qunit-urlconfig-" + escaped +
 				"' title='" + escapedTooltip + "'>" + val.label +
 				": </label><select id='qunit-urlconfig-" + escaped +
 				"' name='" + escaped + "' title='" + escapedTooltip + "'><option></option>";
 
-			if ( QUnit.is( "array", val.value ) ) {
-				for ( j = 0; j < val.value.length; j++ ) {
-					escaped = escapeText( val.value[ j ] );
-					urlConfigHtml += "<option value='" + escaped + "'" +
+				if ( QUnit.is( "array", val.value ) ) {
+					for ( j = 0; j < val.value.length; j++ ) {
+						escaped = escapeText( val.value[ j ] );
+						urlConfigHtml += "<option value='" + escaped + "'" +
 						( config[ val.id ] === val.value[ j ] ?
 							( selection = true ) && " selected='selected'" : "" ) +
 						">" + escaped + "</option>";
-				}
-			} else {
-				for ( j in val.value ) {
-					if ( hasOwn.call( val.value, j ) ) {
-						urlConfigHtml += "<option value='" + escapeText( j ) + "'" +
+					}
+				} else {
+					for ( j in val.value ) {
+						if ( hasOwn.call( val.value, j ) ) {
+							urlConfigHtml += "<option value='" + escapeText( j ) + "'" +
 							( config[ val.id ] === j ?
 								( selection = true ) && " selected='selected'" : "" ) +
 							">" + escapeText( val.value[ j ] ) + "</option>";
+						}
 					}
 				}
-			}
-			if ( config[ val.id ] && !selection ) {
-				escaped = escapeText( config[ val.id ] );
-				urlConfigHtml += "<option value='" + escaped +
+				if ( config[ val.id ] && !selection ) {
+					escaped = escapeText( config[ val.id ] );
+					urlConfigHtml += "<option value='" + escaped +
 					"' selected='selected' disabled='disabled'>" + escaped + "</option>";
+				}
+				urlConfigHtml += "</select>";
 			}
-			urlConfigHtml += "</select>";
 		}
-	}
 
-	return urlConfigHtml;
-}
+		return urlConfigHtml;
+	}
 
 // Handle "click" events on toolbar checkboxes and "change" for select menus.
 // Updates the URL with the new state of `config.urlConfig` values.
-function toolbarChanged() {
-	var updatedUrl, value, tests,
-		field = this,
-		params = {};
+	function toolbarChanged() {
+		var updatedUrl, value, tests,
+			field = this,
+			params = {};
 
 	// Detect if field is a select menu or a checkbox
-	if ( "selectedIndex" in field ) {
-		value = field.options[ field.selectedIndex ].value || undefined;
-	} else {
-		value = field.checked ? ( field.defaultValue || true ) : undefined;
-	}
+		if ( "selectedIndex" in field ) {
+			value = field.options[ field.selectedIndex ].value || undefined;
+		} else {
+			value = field.checked ? ( field.defaultValue || true ) : undefined;
+		}
 
-	params[ field.name ] = value;
-	updatedUrl = setUrl( params );
+		params[ field.name ] = value;
+		updatedUrl = setUrl( params );
 
 	// Check if we can apply the change without a page refresh
-	if ( "hidepassed" === field.name && "replaceState" in window.history ) {
-		QUnit.urlParams[ field.name ] = value;
-		config[ field.name ] = value || false;
-		tests = id( "qunit-tests" );
-		if ( tests ) {
-			toggleClass( tests, "hidepass", value || false );
+		if ( "hidepassed" === field.name && "replaceState" in window.history ) {
+			QUnit.urlParams[ field.name ] = value;
+			config[ field.name ] = value || false;
+			tests = id( "qunit-tests" );
+			if ( tests ) {
+				toggleClass( tests, "hidepass", value || false );
+			}
+			window.history.replaceState( null, "", updatedUrl );
+		} else {
+			window.location = updatedUrl;
 		}
-		window.history.replaceState( null, "", updatedUrl );
-	} else {
-		window.location = updatedUrl;
 	}
-}
 
-function setUrl( params ) {
-	var key, arrValue, i,
-		querystring = "?",
-		location = window.location;
+	function setUrl( params ) {
+		var key, arrValue, i,
+			querystring = "?",
+			location = window.location;
 
-	params = QUnit.extend( QUnit.extend( {}, QUnit.urlParams ), params );
+		params = QUnit.extend( QUnit.extend( {}, QUnit.urlParams ), params );
 
-	for ( key in params ) {
+		for ( key in params ) {
 
 		// Skip inherited or undefined properties
-		if ( hasOwn.call( params, key ) && params[ key ] !== undefined ) {
+			if ( hasOwn.call( params, key ) && params[ key ] !== undefined ) {
 
 			// Output a parameter for each value of this key (but usually just one)
-			arrValue = [].concat( params[ key ] );
-			for ( i = 0; i < arrValue.length; i++ ) {
-				querystring += encodeURIComponent( key );
-				if ( arrValue[ i ] !== true ) {
-					querystring += "=" + encodeURIComponent( arrValue[ i ] );
+				arrValue = [].concat( params[ key ] );
+				for ( i = 0; i < arrValue.length; i++ ) {
+					querystring += encodeURIComponent( key );
+					if ( arrValue[ i ] !== true ) {
+						querystring += "=" + encodeURIComponent( arrValue[ i ] );
+					}
+					querystring += "&";
 				}
-				querystring += "&";
 			}
 		}
-	}
-	return location.protocol + "//" + location.host +
+		return location.protocol + "//" + location.host +
 		location.pathname + querystring.slice( 0, -1 );
-}
-
-function applyUrlParams() {
-	var i,
-		selectedModules = [],
-		modulesList = id( "qunit-modulefilter-dropdown-list" ).getElementsByTagName( "input" ),
-		filter = id( "qunit-filter-input" ).value;
-
-	for ( i = 0; i < modulesList.length; i++ ) {
-		if ( modulesList[ i ].checked ) {
-			selectedModules.push( modulesList[ i ].value );
-		}
 	}
 
-	window.location = setUrl( {
-		filter: ( filter === "" ) ? undefined : filter,
-		moduleId: ( selectedModules.length === 0 ) ? undefined : selectedModules,
+	function applyUrlParams() {
+		var i,
+			selectedModules = [],
+			modulesList = id( "qunit-modulefilter-dropdown-list" ).getElementsByTagName( "input" ),
+			filter = id( "qunit-filter-input" ).value;
+
+		for ( i = 0; i < modulesList.length; i++ ) {
+			if ( modulesList[ i ].checked ) {
+				selectedModules.push( modulesList[ i ].value );
+			}
+		}
+
+		window.location = setUrl( {
+			filter: ( filter === "" ) ? undefined : filter,
+			moduleId: ( selectedModules.length === 0 ) ? undefined : selectedModules,
 
 		// Remove module and testId filter
-		module: undefined,
-		testId: undefined
-	} );
-}
+			module: undefined,
+			testId: undefined
+		} );
+	}
 
-function toolbarUrlConfigContainer() {
-	var urlConfigContainer = document.createElement( "span" );
+	function toolbarUrlConfigContainer() {
+		var urlConfigContainer = document.createElement( "span" );
 
-	urlConfigContainer.innerHTML = getUrlConfigHtml();
-	addClass( urlConfigContainer, "qunit-url-config" );
+		urlConfigContainer.innerHTML = getUrlConfigHtml();
+		addClass( urlConfigContainer, "qunit-url-config" );
 
-	addEvents( urlConfigContainer.getElementsByTagName( "input" ), "change", toolbarChanged );
-	addEvents( urlConfigContainer.getElementsByTagName( "select" ), "change", toolbarChanged );
+		addEvents( urlConfigContainer.getElementsByTagName( "input" ), "change", toolbarChanged );
+		addEvents( urlConfigContainer.getElementsByTagName( "select" ), "change", toolbarChanged );
 
-	return urlConfigContainer;
-}
+		return urlConfigContainer;
+	}
 
-function abortTestsButton() {
-	var button = document.createElement( "button" );
-	button.id = "qunit-abort-tests-button";
-	button.innerHTML = "Abort";
-	addEvent( button, "click", abortTests );
-	return button;
-}
+	function abortTestsButton() {
+		var button = document.createElement( "button" );
+		button.id = "qunit-abort-tests-button";
+		button.innerHTML = "Abort";
+		addEvent( button, "click", abortTests );
+		return button;
+	}
 
-function toolbarLooseFilter() {
-	var filter = document.createElement( "form" ),
-		label = document.createElement( "label" ),
-		input = document.createElement( "input" ),
-		button = document.createElement( "button" );
+	function toolbarLooseFilter() {
+		var filter = document.createElement( "form" ),
+			label = document.createElement( "label" ),
+			input = document.createElement( "input" ),
+			button = document.createElement( "button" );
 
-	addClass( filter, "qunit-filter" );
+		addClass( filter, "qunit-filter" );
 
-	label.innerHTML = "Filter: ";
+		label.innerHTML = "Filter: ";
 
-	input.type = "text";
-	input.value = config.filter || "";
-	input.name = "filter";
-	input.id = "qunit-filter-input";
+		input.type = "text";
+		input.value = config.filter || "";
+		input.name = "filter";
+		input.id = "qunit-filter-input";
 
-	button.innerHTML = "Go";
+		button.innerHTML = "Go";
 
-	label.appendChild( input );
+		label.appendChild( input );
 
-	filter.appendChild( label );
-	filter.appendChild( document.createTextNode( " " ) );
-	filter.appendChild( button );
-	addEvent( filter, "submit", interceptNavigation );
+		filter.appendChild( label );
+		filter.appendChild( document.createTextNode( " " ) );
+		filter.appendChild( button );
+		addEvent( filter, "submit", interceptNavigation );
 
-	return filter;
-}
+		return filter;
+	}
 
-function moduleListHtml() {
-	var i, checked,
-		html = "";
+	function moduleListHtml() {
+		var i, checked,
+			html = "";
 
-	for ( i = 0; i < config.modules.length; i++ ) {
-		if ( config.modules[ i ].name !== "" ) {
-			checked = config.moduleId.indexOf( config.modules[ i ].moduleId ) > -1;
-			html += "<li><label class='clickable" + ( checked ? " checked" : "" ) +
+		for ( i = 0; i < config.modules.length; i++ ) {
+			if ( config.modules[ i ].name !== "" ) {
+				checked = config.moduleId.indexOf( config.modules[ i ].moduleId ) > -1;
+				html += "<li><label class='clickable" + ( checked ? " checked" : "" ) +
 				"'><input type='checkbox' " + "value='" + config.modules[ i ].moduleId + "'" +
 				( checked ? " checked='checked'" : "" ) + " />" +
 				escapeText( config.modules[ i ].name ) + "</label></li>";
+			}
 		}
+
+		return html;
 	}
 
-	return html;
-}
+	function toolbarModuleFilter() {
+		var allCheckbox, commit, reset,
+			moduleFilter = document.createElement( "form" ),
+			label = document.createElement( "label" ),
+			moduleSearch = document.createElement( "input" ),
+			dropDown = document.createElement( "div" ),
+			actions = document.createElement( "span" ),
+			dropDownList = document.createElement( "ul" ),
+			dirty = false;
 
-function toolbarModuleFilter() {
-	var allCheckbox, commit, reset,
-		moduleFilter = document.createElement( "form" ),
-		label = document.createElement( "label" ),
-		moduleSearch = document.createElement( "input" ),
-		dropDown = document.createElement( "div" ),
-		actions = document.createElement( "span" ),
-		dropDownList = document.createElement( "ul" ),
-		dirty = false;
+		moduleSearch.id = "qunit-modulefilter-search";
+		addEvent( moduleSearch, "input", searchInput );
+		addEvent( moduleSearch, "input", searchFocus );
+		addEvent( moduleSearch, "focus", searchFocus );
+		addEvent( moduleSearch, "click", searchFocus );
 
-	moduleSearch.id = "qunit-modulefilter-search";
-	addEvent( moduleSearch, "input", searchInput );
-	addEvent( moduleSearch, "input", searchFocus );
-	addEvent( moduleSearch, "focus", searchFocus );
-	addEvent( moduleSearch, "click", searchFocus );
+		label.id = "qunit-modulefilter-search-container";
+		label.innerHTML = "Module: ";
+		label.appendChild( moduleSearch );
 
-	label.id = "qunit-modulefilter-search-container";
-	label.innerHTML = "Module: ";
-	label.appendChild( moduleSearch );
-
-	actions.id = "qunit-modulefilter-actions";
-	actions.innerHTML =
+		actions.id = "qunit-modulefilter-actions";
+		actions.innerHTML =
 		"<button style='display:none'>Apply</button>" +
 		"<button type='reset' style='display:none'>Reset</button>" +
 		"<label class='clickable" +
 		( config.moduleId.length ? "" : " checked" ) +
 		"'><input type='checkbox'" + ( config.moduleId.length ? "" : " checked='checked'" ) +
 		">All modules</label>";
-	allCheckbox = actions.lastChild.firstChild;
-	commit = actions.firstChild;
-	reset = commit.nextSibling;
-	addEvent( commit, "click", applyUrlParams );
+		allCheckbox = actions.lastChild.firstChild;
+		commit = actions.firstChild;
+		reset = commit.nextSibling;
+		addEvent( commit, "click", applyUrlParams );
 
-	dropDownList.id = "qunit-modulefilter-dropdown-list";
-	dropDownList.innerHTML = moduleListHtml();
+		dropDownList.id = "qunit-modulefilter-dropdown-list";
+		dropDownList.innerHTML = moduleListHtml();
 
-	dropDown.id = "qunit-modulefilter-dropdown";
-	dropDown.style.display = "none";
-	dropDown.appendChild( actions );
-	dropDown.appendChild( dropDownList );
-	addEvent( dropDown, "change", selectionChange );
-	selectionChange();
+		dropDown.id = "qunit-modulefilter-dropdown";
+		dropDown.style.display = "none";
+		dropDown.appendChild( actions );
+		dropDown.appendChild( dropDownList );
+		addEvent( dropDown, "change", selectionChange );
+		selectionChange();
 
-	moduleFilter.id = "qunit-modulefilter";
-	moduleFilter.appendChild( label );
-	moduleFilter.appendChild( dropDown );
-	addEvent( moduleFilter, "submit", interceptNavigation );
-	addEvent( moduleFilter, "reset", function() {
+		moduleFilter.id = "qunit-modulefilter";
+		moduleFilter.appendChild( label );
+		moduleFilter.appendChild( dropDown );
+		addEvent( moduleFilter, "submit", interceptNavigation );
+		addEvent( moduleFilter, "reset", function() {
 
 		// Let the reset happen, then update styles
-		window.setTimeout( selectionChange );
-	} );
+			window.setTimeout( selectionChange );
+		} );
 
 	// Enables show/hide for the dropdown
-	function searchFocus() {
-		if ( dropDown.style.display !== "none" ) {
-			return;
-		}
+		function searchFocus() {
+			if ( dropDown.style.display !== "none" ) {
+				return;
+			}
 
-		dropDown.style.display = "block";
-		addEvent( document, "click", hideHandler );
-		addEvent( document, "keydown", hideHandler );
+			dropDown.style.display = "block";
+			addEvent( document, "click", hideHandler );
+			addEvent( document, "keydown", hideHandler );
 
 		// Hide on Escape keydown or outside-container click
-		function hideHandler( e )  {
-			var inContainer = moduleFilter.contains( e.target );
+			function hideHandler( e )  {
+				var inContainer = moduleFilter.contains( e.target );
 
-			if ( e.keyCode === 27 || !inContainer ) {
-				if ( e.keyCode === 27 && inContainer ) {
-					moduleSearch.focus();
+				if ( e.keyCode === 27 || !inContainer ) {
+					if ( e.keyCode === 27 && inContainer ) {
+						moduleSearch.focus();
+					}
+					dropDown.style.display = "none";
+					removeEvent( document, "click", hideHandler );
+					removeEvent( document, "keydown", hideHandler );
+					moduleSearch.value = "";
+					searchInput();
 				}
-				dropDown.style.display = "none";
-				removeEvent( document, "click", hideHandler );
-				removeEvent( document, "keydown", hideHandler );
-				moduleSearch.value = "";
-				searchInput();
 			}
 		}
-	}
 
 	// Processes module search box input
-	function searchInput() {
-		var i, item,
-			searchText = moduleSearch.value.toLowerCase(),
-			listItems = dropDownList.children;
+		function searchInput() {
+			var i, item,
+				searchText = moduleSearch.value.toLowerCase(),
+				listItems = dropDownList.children;
 
-		for ( i = 0; i < listItems.length; i++ ) {
-			item = listItems[ i ];
-			if ( !searchText || item.textContent.toLowerCase().indexOf( searchText ) > -1 ) {
-				item.style.display = "";
-			} else {
-				item.style.display = "none";
+			for ( i = 0; i < listItems.length; i++ ) {
+				item = listItems[ i ];
+				if ( !searchText || item.textContent.toLowerCase().indexOf( searchText ) > -1 ) {
+					item.style.display = "";
+				} else {
+					item.style.display = "none";
+				}
 			}
 		}
-	}
 
 	// Processes selection changes
-	function selectionChange( evt ) {
-		var i, item,
-			checkbox = evt && evt.target || allCheckbox,
-			modulesList = dropDownList.getElementsByTagName( "input" ),
-			selectedNames = [];
+		function selectionChange( evt ) {
+			var i, item,
+				checkbox = evt && evt.target || allCheckbox,
+				modulesList = dropDownList.getElementsByTagName( "input" ),
+				selectedNames = [];
 
-		toggleClass( checkbox.parentNode, "checked", checkbox.checked );
+			toggleClass( checkbox.parentNode, "checked", checkbox.checked );
 
-		dirty = false;
-		if ( checkbox.checked && checkbox !== allCheckbox ) {
-			allCheckbox.checked = false;
-			removeClass( allCheckbox.parentNode, "checked" );
-		}
-		for ( i = 0; i < modulesList.length; i++ ) {
-			item = modulesList[ i ];
-			if ( !evt ) {
-				toggleClass( item.parentNode, "checked", item.checked );
-			} else if ( checkbox === allCheckbox && checkbox.checked ) {
-				item.checked = false;
-				removeClass( item.parentNode, "checked" );
+			dirty = false;
+			if ( checkbox.checked && checkbox !== allCheckbox ) {
+				allCheckbox.checked = false;
+				removeClass( allCheckbox.parentNode, "checked" );
 			}
-			dirty = dirty || ( item.checked !== item.defaultChecked );
-			if ( item.checked ) {
-				selectedNames.push( item.parentNode.textContent );
+			for ( i = 0; i < modulesList.length; i++ ) {
+				item = modulesList[ i ];
+				if ( !evt ) {
+					toggleClass( item.parentNode, "checked", item.checked );
+				} else if ( checkbox === allCheckbox && checkbox.checked ) {
+					item.checked = false;
+					removeClass( item.parentNode, "checked" );
+				}
+				dirty = dirty || ( item.checked !== item.defaultChecked );
+				if ( item.checked ) {
+					selectedNames.push( item.parentNode.textContent );
+				}
 			}
-		}
 
-		commit.style.display = reset.style.display = dirty ? "" : "none";
-		moduleSearch.placeholder = selectedNames.join( ", " ) || allCheckbox.parentNode.textContent;
-		moduleSearch.title = "Type to filter list. Current selection:\n" +
+			commit.style.display = reset.style.display = dirty ? "" : "none";
+			moduleSearch.placeholder = selectedNames.join( ", " ) ||
+				allCheckbox.parentNode.textContent;
+			moduleSearch.title = "Type to filter list. Current selection:\n" +
 			( selectedNames.join( "\n" ) || allCheckbox.parentNode.textContent );
+		}
+
+		return moduleFilter;
 	}
 
-	return moduleFilter;
-}
+	function appendToolbar() {
+		var toolbar = id( "qunit-testrunner-toolbar" );
 
-function appendToolbar() {
-	var toolbar = id( "qunit-testrunner-toolbar" );
-
-	if ( toolbar ) {
-		toolbar.appendChild( toolbarUrlConfigContainer() );
-		toolbar.appendChild( toolbarModuleFilter() );
-		toolbar.appendChild( toolbarLooseFilter() );
-		toolbar.appendChild( document.createElement( "div" ) ).className = "clearfix";
+		if ( toolbar ) {
+			toolbar.appendChild( toolbarUrlConfigContainer() );
+			toolbar.appendChild( toolbarModuleFilter() );
+			toolbar.appendChild( toolbarLooseFilter() );
+			toolbar.appendChild( document.createElement( "div" ) ).className = "clearfix";
+		}
 	}
-}
 
-function appendHeader() {
-	var header = id( "qunit-header" );
+	function appendHeader() {
+		var header = id( "qunit-header" );
 
-	if ( header ) {
-		header.innerHTML = "<a href='" + escapeText( unfilteredUrl ) + "'>" + header.innerHTML +
+		if ( header ) {
+			header.innerHTML = "<a href='" + escapeText( unfilteredUrl ) + "'>" + header.innerHTML +
 			"</a> ";
-	}
-}
-
-function appendBanner() {
-	var banner = id( "qunit-banner" );
-
-	if ( banner ) {
-		banner.className = "";
-	}
-}
-
-function appendTestResults() {
-	var tests = id( "qunit-tests" ),
-		result = id( "qunit-testresult" ),
-		controls;
-
-	if ( result ) {
-		result.parentNode.removeChild( result );
+		}
 	}
 
-	if ( tests ) {
-		tests.innerHTML = "";
-		result = document.createElement( "p" );
-		result.id = "qunit-testresult";
-		result.className = "result";
-		tests.parentNode.insertBefore( result, tests );
-		result.innerHTML = "<div id=\"qunit-testresult-display\">Running...<br />&#160;</div>" +
+	function appendBanner() {
+		var banner = id( "qunit-banner" );
+
+		if ( banner ) {
+			banner.className = "";
+		}
+	}
+
+	function appendTestResults() {
+		var tests = id( "qunit-tests" ),
+			result = id( "qunit-testresult" ),
+			controls;
+
+		if ( result ) {
+			result.parentNode.removeChild( result );
+		}
+
+		if ( tests ) {
+			tests.innerHTML = "";
+			result = document.createElement( "p" );
+			result.id = "qunit-testresult";
+			result.className = "result";
+			tests.parentNode.insertBefore( result, tests );
+			result.innerHTML = "<div id=\"qunit-testresult-display\">Running...<br />&#160;</div>" +
 			"<div id=\"qunit-testresult-controls\"></div>" +
 			"<div class=\"clearfix\"></div>";
-		controls = id( "qunit-testresult-controls" );
+			controls = id( "qunit-testresult-controls" );
+		}
+
+		if ( controls ) {
+			controls.appendChild( abortTestsButton() );
+		}
 	}
 
-	if ( controls ) {
-		controls.appendChild( abortTestsButton() );
-	}
-}
-
-function appendFilteredTest() {
-	var testId = QUnit.config.testId;
-	if ( !testId || testId.length <= 0 ) {
-		return "";
-	}
-	return "<div id='qunit-filteredTest'>Rerunning selected tests: " +
+	function appendFilteredTest() {
+		var testId = QUnit.config.testId;
+		if ( !testId || testId.length <= 0 ) {
+			return "";
+		}
+		return "<div id='qunit-filteredTest'>Rerunning selected tests: " +
 		escapeText( testId.join( ", " ) ) +
 		" <a id='qunit-clearFilter' href='" +
 		escapeText( unfilteredUrl ) +
 		"'>Run all tests</a></div>";
-}
+	}
 
-function appendUserAgent() {
-	var userAgent = id( "qunit-userAgent" );
+	function appendUserAgent() {
+		var userAgent = id( "qunit-userAgent" );
 
-	if ( userAgent ) {
-		userAgent.innerHTML = "";
-		userAgent.appendChild(
-			document.createTextNode(
-				"QUnit " + QUnit.version + "; " + navigator.userAgent
+		if ( userAgent ) {
+			userAgent.innerHTML = "";
+			userAgent.appendChild(
+				document.createTextNode(
+					"QUnit " + QUnit.version + "; " + navigator.userAgent
 			)
 		);
+		}
 	}
-}
 
-function appendInterface() {
-	var qunit = id( "qunit" );
+	function appendInterface() {
+		var qunit = id( "qunit" );
 
-	if ( qunit ) {
-		qunit.innerHTML =
+		if ( qunit ) {
+			qunit.innerHTML =
 			"<h1 id='qunit-header'>" + escapeText( document.title ) + "</h1>" +
 			"<h2 id='qunit-banner'></h2>" +
 			"<div id='qunit-testrunner-toolbar'></div>" +
 			appendFilteredTest() +
 			"<h2 id='qunit-userAgent'></h2>" +
 			"<ol id='qunit-tests'></ol>";
-	}
-
-	appendHeader();
-	appendBanner();
-	appendTestResults();
-	appendUserAgent();
-	appendToolbar();
-}
-
-function appendTestsList( modules ) {
-	var i, l, x, z, test, moduleObj;
-
-	for ( i = 0, l = modules.length; i < l; i++ ) {
-		moduleObj = modules[ i ];
-
-		for ( x = 0, z = moduleObj.tests.length; x < z; x++ ) {
-			test = moduleObj.tests[ x ];
-
-			appendTest( test.name, test.testId, moduleObj.name );
 		}
-	}
-}
 
-function appendTest( name, testId, moduleName ) {
-	var title, rerunTrigger, testBlock, assertList,
-		tests = id( "qunit-tests" );
-
-	if ( !tests ) {
-		return;
+		appendHeader();
+		appendBanner();
+		appendTestResults();
+		appendUserAgent();
+		appendToolbar();
 	}
 
-	title = document.createElement( "strong" );
-	title.innerHTML = getNameHtml( name, moduleName );
+	function appendTestsList( modules ) {
+		var i, l, x, z, test, moduleObj;
 
-	rerunTrigger = document.createElement( "a" );
-	rerunTrigger.innerHTML = "Rerun";
-	rerunTrigger.href = setUrl( { testId: testId } );
+		for ( i = 0, l = modules.length; i < l; i++ ) {
+			moduleObj = modules[ i ];
 
-	testBlock = document.createElement( "li" );
-	testBlock.appendChild( title );
-	testBlock.appendChild( rerunTrigger );
-	testBlock.id = "qunit-test-output-" + testId;
+			for ( x = 0, z = moduleObj.tests.length; x < z; x++ ) {
+				test = moduleObj.tests[ x ];
 
-	assertList = document.createElement( "ol" );
-	assertList.className = "qunit-assert-list";
-
-	testBlock.appendChild( assertList );
-
-	tests.appendChild( testBlock );
-}
-
-// HTML Reporter initialization and load
-QUnit.begin( function( details ) {
-	var i, moduleObj, tests;
-
-	// Sort modules by name for the picker
-	for ( i = 0; i < details.modules.length; i++ ) {
-		moduleObj = details.modules[ i ];
-		if ( moduleObj.name ) {
-			modulesList.push( moduleObj.name );
-		}
-	}
-	modulesList.sort( function( a, b ) {
-		return a.localeCompare( b );
-	} );
-
-	// Initialize QUnit elements
-	appendInterface();
-	appendTestsList( details.modules );
-	tests = id( "qunit-tests" );
-	if ( tests && config.hidepassed ) {
-		addClass( tests, "hidepass" );
-	}
-} );
-
-QUnit.done( function( details ) {
-	var banner = id( "qunit-banner" ),
-		tests = id( "qunit-tests" ),
-		abortButton = id( "qunit-abort-tests-button" ),
-		totalTests = stats.passedTests + stats.skippedTests + stats.todoTests + stats.failedTests,
-		html = [
-			totalTests,
-			" tests completed in ",
-			details.runtime,
-			" milliseconds, with ",
-			stats.failedTests,
-			" failed, ",
-			stats.skippedTests,
-			" skipped, and ",
-			stats.todoTests,
-			" todo.<br />",
-			"<span class='passed'>",
-			details.passed,
-			"</span> assertions of <span class='total'>",
-			details.total,
-			"</span> passed, <span class='failed'>",
-			details.failed,
-			"</span> failed."
-		].join( "" ),
-		test,
-		assertLi,
-		assertList;
-
-	// Update remaing tests to aborted
-	if ( abortButton && abortButton.disabled ) {
-		html = "Tests aborted after " + details.runtime + " milliseconds.";
-
-		for ( var i = 0; i < tests.children.length; i++ ) {
-			test = tests.children[ i ];
-			if ( test.className === "" || test.className === "running" ) {
-				test.className = "aborted";
-				assertList = test.getElementsByTagName( "ol" )[ 0 ];
-				assertLi = document.createElement( "li" );
-				assertLi.className = "fail";
-				assertLi.innerHTML = "Test aborted.";
-				assertList.appendChild( assertLi );
+				appendTest( test.name, test.testId, moduleObj.name );
 			}
 		}
 	}
 
-	if ( banner && ( !abortButton || abortButton.disabled === false ) ) {
-		banner.className = stats.failedTests ? "qunit-fail" : "qunit-pass";
+	function appendTest( name, testId, moduleName ) {
+		var title, rerunTrigger, testBlock, assertList,
+			tests = id( "qunit-tests" );
+
+		if ( !tests ) {
+			return;
+		}
+
+		title = document.createElement( "strong" );
+		title.innerHTML = getNameHtml( name, moduleName );
+
+		rerunTrigger = document.createElement( "a" );
+		rerunTrigger.innerHTML = "Rerun";
+		rerunTrigger.href = setUrl( { testId: testId } );
+
+		testBlock = document.createElement( "li" );
+		testBlock.appendChild( title );
+		testBlock.appendChild( rerunTrigger );
+		testBlock.id = "qunit-test-output-" + testId;
+
+		assertList = document.createElement( "ol" );
+		assertList.className = "qunit-assert-list";
+
+		testBlock.appendChild( assertList );
+
+		tests.appendChild( testBlock );
 	}
 
-	if ( abortButton ) {
-		abortButton.parentNode.removeChild( abortButton );
-	}
+// HTML Reporter initialization and load
+	QUnit.begin( function( details ) {
+		var i, moduleObj, tests;
 
-	if ( tests ) {
-		id( "qunit-testresult-display" ).innerHTML = html;
-	}
+	// Sort modules by name for the picker
+		for ( i = 0; i < details.modules.length; i++ ) {
+			moduleObj = details.modules[ i ];
+			if ( moduleObj.name ) {
+				modulesList.push( moduleObj.name );
+			}
+		}
+		modulesList.sort( function( a, b ) {
+			return a.localeCompare( b );
+		} );
 
-	if ( config.altertitle && document.title ) {
+	// Initialize QUnit elements
+		appendInterface();
+		appendTestsList( details.modules );
+		tests = id( "qunit-tests" );
+		if ( tests && config.hidepassed ) {
+			addClass( tests, "hidepass" );
+		}
+	} );
+
+	QUnit.done( function( details ) {
+		var banner = id( "qunit-banner" ),
+			tests = id( "qunit-tests" ),
+			abortButton = id( "qunit-abort-tests-button" ),
+			totalTests = stats.passedTests +
+				stats.skippedTests +
+				stats.todoTests +
+				stats.failedTests,
+			html = [
+				totalTests,
+				" tests completed in ",
+				details.runtime,
+				" milliseconds, with ",
+				stats.failedTests,
+				" failed, ",
+				stats.skippedTests,
+				" skipped, and ",
+				stats.todoTests,
+				" todo.<br />",
+				"<span class='passed'>",
+				details.passed,
+				"</span> assertions of <span class='total'>",
+				details.total,
+				"</span> passed, <span class='failed'>",
+				details.failed,
+				"</span> failed."
+			].join( "" ),
+			test,
+			assertLi,
+			assertList;
+
+	// Update remaing tests to aborted
+		if ( abortButton && abortButton.disabled ) {
+			html = "Tests aborted after " + details.runtime + " milliseconds.";
+
+			for ( var i = 0; i < tests.children.length; i++ ) {
+				test = tests.children[ i ];
+				if ( test.className === "" || test.className === "running" ) {
+					test.className = "aborted";
+					assertList = test.getElementsByTagName( "ol" )[ 0 ];
+					assertLi = document.createElement( "li" );
+					assertLi.className = "fail";
+					assertLi.innerHTML = "Test aborted.";
+					assertList.appendChild( assertLi );
+				}
+			}
+		}
+
+		if ( banner && ( !abortButton || abortButton.disabled === false ) ) {
+			banner.className = stats.failedTests ? "qunit-fail" : "qunit-pass";
+		}
+
+		if ( abortButton ) {
+			abortButton.parentNode.removeChild( abortButton );
+		}
+
+		if ( tests ) {
+			id( "qunit-testresult-display" ).innerHTML = html;
+		}
+
+		if ( config.altertitle && document.title ) {
 
 		// Show ✖ for good, ✔ for bad suite result in title
 		// use escape sequences in case file gets loaded with non-utf-8-charset
-		document.title = [
+			document.title = [
 			( stats.failedTests ? "\u2716" : "\u2714" ),
-			document.title.replace( /^[\u2714\u2716] /i, "" )
-		].join( " " );
-	}
+				document.title.replace( /^[\u2714\u2716] /i, "" )
+			].join( " " );
+		}
 
 	// Scroll back to top to show results
-	if ( config.scrolltop && window.scrollTo ) {
-		window.scrollTo( 0, 0 );
+		if ( config.scrolltop && window.scrollTo ) {
+			window.scrollTo( 0, 0 );
+		}
+	} );
+
+	function getNameHtml( name, module ) {
+		var nameHtml = "";
+
+		if ( module ) {
+			nameHtml = "<span class='module-name'>" + escapeText( module ) + "</span>: ";
+		}
+
+		nameHtml += "<span class='test-name'>" + escapeText( name ) + "</span>";
+
+		return nameHtml;
 	}
-} );
 
-function getNameHtml( name, module ) {
-	var nameHtml = "";
+	QUnit.testStart( function( details ) {
+		var running, testBlock, bad;
 
-	if ( module ) {
-		nameHtml = "<span class='module-name'>" + escapeText( module ) + "</span>: ";
-	}
-
-	nameHtml += "<span class='test-name'>" + escapeText( name ) + "</span>";
-
-	return nameHtml;
-}
-
-QUnit.testStart( function( details ) {
-	var running, testBlock, bad;
-
-	testBlock = id( "qunit-test-output-" + details.testId );
-	if ( testBlock ) {
-		testBlock.className = "running";
-	} else {
+		testBlock = id( "qunit-test-output-" + details.testId );
+		if ( testBlock ) {
+			testBlock.className = "running";
+		} else {
 
 		// Report later registered tests
-		appendTest( details.name, details.testId, details.module );
-	}
+			appendTest( details.name, details.testId, details.module );
+		}
 
-	running = id( "qunit-testresult-display" );
-	if ( running ) {
-		bad = QUnit.config.reorder && details.previousFailure;
+		running = id( "qunit-testresult-display" );
+		if ( running ) {
+			bad = QUnit.config.reorder && details.previousFailure;
 
-		running.innerHTML = ( bad ?
+			running.innerHTML = ( bad ?
 			"Rerunning previously failed test: <br />" :
 			"Running: <br />" ) +
 			getNameHtml( details.name, details.module );
+		}
+
+	} );
+
+	function stripHtml( string ) {
+
+		// Strip tags, html entity and whitespaces
+		return string
+			.replace( /<\/?[^>]+(>|$)/g, "" )
+			.replace( /\&quot;/g, "" )
+			.replace( /\s+/g, "" );
 	}
 
-} );
+	QUnit.log( function( details ) {
+		var assertList, assertLi,
+			message, expected, actual, diff,
+			showDiff = false,
+			testItem = id( "qunit-test-output-" + details.testId );
 
-function stripHtml( string ) {
+		if ( !testItem ) {
+			return;
+		}
 
-	// Strip tags, html entity and whitespaces
-	return string.replace( /<\/?[^>]+(>|$)/g, "" ).replace( /\&quot;/g, "" ).replace( /\s+/g, "" );
-}
-
-QUnit.log( function( details ) {
-	var assertList, assertLi,
-		message, expected, actual, diff,
-		showDiff = false,
-		testItem = id( "qunit-test-output-" + details.testId );
-
-	if ( !testItem ) {
-		return;
-	}
-
-	message = escapeText( details.message ) || ( details.result ? "okay" : "failed" );
-	message = "<span class='test-message'>" + message + "</span>";
-	message += "<span class='runtime'>@ " + details.runtime + " ms</span>";
+		message = escapeText( details.message ) || ( details.result ? "okay" : "failed" );
+		message = "<span class='test-message'>" + message + "</span>";
+		message += "<span class='runtime'>@ " + details.runtime + " ms</span>";
 
 	// The pushFailure doesn't provide details.expected
 	// when it calls, it's implicit to also not show expected and diff stuff
 	// Also, we need to check details.expected existence, as it can exist and be undefined
-	if ( !details.result && hasOwn.call( details, "expected" ) ) {
-		if ( details.negative ) {
-			expected = "NOT " + QUnit.dump.parse( details.expected );
-		} else {
-			expected = QUnit.dump.parse( details.expected );
-		}
+		if ( !details.result && hasOwn.call( details, "expected" ) ) {
+			if ( details.negative ) {
+				expected = "NOT " + QUnit.dump.parse( details.expected );
+			} else {
+				expected = QUnit.dump.parse( details.expected );
+			}
 
-		actual = QUnit.dump.parse( details.actual );
-		message += "<table><tr class='test-expected'><th>Expected: </th><td><pre>" +
+			actual = QUnit.dump.parse( details.actual );
+			message += "<table><tr class='test-expected'><th>Expected: </th><td><pre>" +
 			escapeText( expected ) +
 			"</pre></td></tr>";
 
-		if ( actual !== expected ) {
+			if ( actual !== expected ) {
 
-			message += "<tr class='test-actual'><th>Result: </th><td><pre>" +
+				message += "<tr class='test-actual'><th>Result: </th><td><pre>" +
 				escapeText( actual ) + "</pre></td></tr>";
 
 			// Don't show diff if actual or expected are booleans
-			if ( !( /^(true|false)$/.test( actual ) ) &&
+				if ( !( /^(true|false)$/.test( actual ) ) &&
 					!( /^(true|false)$/.test( expected ) ) ) {
-				diff = QUnit.diff( expected, actual );
-				showDiff = stripHtml( diff ).length !==
+					diff = QUnit.diff( expected, actual );
+					showDiff = stripHtml( diff ).length !==
 					stripHtml( expected ).length +
 					stripHtml( actual ).length;
-			}
+				}
 
 			// Don't show diff if expected and actual are totally different
-			if ( showDiff ) {
-				message += "<tr class='test-diff'><th>Diff: </th><td><pre>" +
+				if ( showDiff ) {
+					message += "<tr class='test-diff'><th>Diff: </th><td><pre>" +
 					diff + "</pre></td></tr>";
-			}
-		} else if ( expected.indexOf( "[object Array]" ) !== -1 ||
+				}
+			} else if ( expected.indexOf( "[object Array]" ) !== -1 ||
 				expected.indexOf( "[object Object]" ) !== -1 ) {
-			message += "<tr class='test-message'><th>Message: </th><td>" +
+				message += "<tr class='test-message'><th>Message: </th><td>" +
 				"Diff suppressed as the depth of object is more than current max depth (" +
 				QUnit.config.maxDepth + ").<p>Hint: Use <code>QUnit.dump.maxDepth</code> to " +
 				" run with a higher max depth or <a href='" +
 				escapeText( setUrl( { maxDepth: -1 } ) ) + "'>" +
 				"Rerun</a> without max depth.</p></td></tr>";
-		} else {
-			message += "<tr class='test-message'><th>Message: </th><td>" +
+			} else {
+				message += "<tr class='test-message'><th>Message: </th><td>" +
 				"Diff suppressed as the expected and actual results have an equivalent" +
 				" serialization</td></tr>";
-		}
+			}
 
-		if ( details.source ) {
-			message += "<tr class='test-source'><th>Source: </th><td><pre>" +
+			if ( details.source ) {
+				message += "<tr class='test-source'><th>Source: </th><td><pre>" +
 				escapeText( details.source ) + "</pre></td></tr>";
-		}
+			}
 
-		message += "</table>";
+			message += "</table>";
 
 	// This occurs when pushFailure is set and we have an extracted stack trace
-	} else if ( !details.result && details.source ) {
-		message += "<table>" +
+		} else if ( !details.result && details.source ) {
+			message += "<table>" +
 			"<tr class='test-source'><th>Source: </th><td><pre>" +
 			escapeText( details.source ) + "</pre></td></tr>" +
 			"</table>";
-	}
+		}
 
-	assertList = testItem.getElementsByTagName( "ol" )[ 0 ];
+		assertList = testItem.getElementsByTagName( "ol" )[ 0 ];
 
-	assertLi = document.createElement( "li" );
-	assertLi.className = details.result ? "pass" : "fail";
-	assertLi.innerHTML = message;
-	assertList.appendChild( assertLi );
-} );
+		assertLi = document.createElement( "li" );
+		assertLi.className = details.result ? "pass" : "fail";
+		assertLi.innerHTML = message;
+		assertList.appendChild( assertLi );
+	} );
 
-QUnit.testDone( function( details ) {
-	var testTitle, time, testItem, assertList,
-		good, bad, testCounts, skipped, sourceName,
-		tests = id( "qunit-tests" );
+	QUnit.testDone( function( details ) {
+		var testTitle, time, testItem, assertList,
+			good, bad, testCounts, skipped, sourceName,
+			tests = id( "qunit-tests" );
 
-	if ( !tests ) {
-		return;
-	}
+		if ( !tests ) {
+			return;
+		}
 
-	testItem = id( "qunit-test-output-" + details.testId );
+		testItem = id( "qunit-test-output-" + details.testId );
 
-	assertList = testItem.getElementsByTagName( "ol" )[ 0 ];
+		assertList = testItem.getElementsByTagName( "ol" )[ 0 ];
 
-	good = details.passed;
-	bad = details.failed;
+		good = details.passed;
+		bad = details.failed;
 
 	// This test passed if it has no unexpected failed assertions
-	const testPassed = details.failed > 0 ? details.todo : !details.todo;
+		const testPassed = details.failed > 0 ? details.todo : !details.todo;
 
-	if ( testPassed ) {
+		if ( testPassed ) {
 
 		// Collapse the passing tests
-		addClass( assertList, "qunit-collapsed" );
-	} else if ( config.collapse ) {
-		if ( !collapseNext ) {
+			addClass( assertList, "qunit-collapsed" );
+		} else if ( config.collapse ) {
+			if ( !collapseNext ) {
 
 			// Skip collapsing the first failing test
-			collapseNext = true;
-		} else {
+				collapseNext = true;
+			} else {
 
 			// Collapse remaining tests
-			addClass( assertList, "qunit-collapsed" );
+				addClass( assertList, "qunit-collapsed" );
+			}
 		}
-	}
 
 	// The testItem.firstChild is the test name
-	testTitle = testItem.firstChild;
+		testTitle = testItem.firstChild;
 
-	testCounts = bad ?
+		testCounts = bad ?
 		"<b class='failed'>" + bad + "</b>, " + "<b class='passed'>" + good + "</b>, " :
 		"";
 
-	testTitle.innerHTML += " <b class='counts'>(" + testCounts +
+		testTitle.innerHTML += " <b class='counts'>(" + testCounts +
 		details.assertions.length + ")</b>";
 
-	if ( details.skipped ) {
-		stats.skippedTests++;
+		if ( details.skipped ) {
+			stats.skippedTests++;
 
-		testItem.className = "skipped";
-		skipped = document.createElement( "em" );
-		skipped.className = "qunit-skipped-label";
-		skipped.innerHTML = "skipped";
-		testItem.insertBefore( skipped, testTitle );
-	} else {
-		addEvent( testTitle, "click", function() {
-			toggleClass( assertList, "qunit-collapsed" );
-		} );
-
-		testItem.className = testPassed ? "pass" : "fail";
-
-		if ( details.todo ) {
-			const todoLabel = document.createElement( "em" );
-			todoLabel.className = "qunit-todo-label";
-			todoLabel.innerHTML = "todo";
-			testItem.className += " todo";
-			testItem.insertBefore( todoLabel, testTitle );
-		}
-
-		time = document.createElement( "span" );
-		time.className = "runtime";
-		time.innerHTML = details.runtime + " ms";
-		testItem.insertBefore( time, assertList );
-
-		if ( !testPassed ) {
-			stats.failedTests++;
-		} else if ( details.todo ) {
-			stats.todoTests++;
+			testItem.className = "skipped";
+			skipped = document.createElement( "em" );
+			skipped.className = "qunit-skipped-label";
+			skipped.innerHTML = "skipped";
+			testItem.insertBefore( skipped, testTitle );
 		} else {
-			stats.passedTests++;
+			addEvent( testTitle, "click", function() {
+				toggleClass( assertList, "qunit-collapsed" );
+			} );
+
+			testItem.className = testPassed ? "pass" : "fail";
+
+			if ( details.todo ) {
+				const todoLabel = document.createElement( "em" );
+				todoLabel.className = "qunit-todo-label";
+				todoLabel.innerHTML = "todo";
+				testItem.className += " todo";
+				testItem.insertBefore( todoLabel, testTitle );
+			}
+
+			time = document.createElement( "span" );
+			time.className = "runtime";
+			time.innerHTML = details.runtime + " ms";
+			testItem.insertBefore( time, assertList );
+
+			if ( !testPassed ) {
+				stats.failedTests++;
+			} else if ( details.todo ) {
+				stats.todoTests++;
+			} else {
+				stats.passedTests++;
+			}
 		}
-	}
 
 	// Show the source of the test when showing assertions
-	if ( details.source ) {
-		sourceName = document.createElement( "p" );
-		sourceName.innerHTML = "<strong>Source: </strong>" + details.source;
-		addClass( sourceName, "qunit-source" );
-		if ( testPassed ) {
-			addClass( sourceName, "qunit-collapsed" );
+		if ( details.source ) {
+			sourceName = document.createElement( "p" );
+			sourceName.innerHTML = "<strong>Source: </strong>" + details.source;
+			addClass( sourceName, "qunit-source" );
+			if ( testPassed ) {
+				addClass( sourceName, "qunit-collapsed" );
+			}
+			addEvent( testTitle, "click", function() {
+				toggleClass( sourceName, "qunit-collapsed" );
+			} );
+			testItem.appendChild( sourceName );
 		}
-		addEvent( testTitle, "click", function() {
-			toggleClass( sourceName, "qunit-collapsed" );
-		} );
-		testItem.appendChild( sourceName );
-	}
-} );
+	} );
 
 // Avoid readyState issue with phantomjs
 // Ref: #818
-var notPhantom = ( function( p ) {
-	return !( p && p.version && p.version.major > 0 );
-} )( window.phantom );
+	var notPhantom = ( function( p ) {
+		return !( p && p.version && p.version.major > 0 );
+	} )( window.phantom );
 
-if ( notPhantom && document.readyState === "complete" ) {
-	QUnit.load();
-} else {
-	addEvent( window, "load", QUnit.load );
-}
+	if ( notPhantom && document.readyState === "complete" ) {
+		QUnit.load();
+	} else {
+		addEvent( window, "load", QUnit.load );
+	}
 
 // Wrap window.onerror. We will call the original window.onerror to see if
 // the existing handler fully handles the error; if not, we will call the
 // QUnit.onError function.
-var originalWindowOnError = window.onerror;
+	var originalWindowOnError = window.onerror;
 
 // Cover uncaught exceptions
 // Returning true will suppress the default browser handler,
 // returning false will let it run.
-window.onerror = function( message, fileName, lineNumber, ...args ) {
-	var ret = false;
-	if ( originalWindowOnError ) {
-		ret = originalWindowOnError.call( this, message, fileName, lineNumber, ...args );
-	}
+	window.onerror = function( message, fileName, lineNumber, ...args ) {
+		var ret = false;
+		if ( originalWindowOnError ) {
+			ret = originalWindowOnError.call( this, message, fileName, lineNumber, ...args );
+		}
 
 	// Treat return value as window.onerror itself does,
 	// Only do our handling if not suppressed.
-	if ( ret !== true ) {
-		const error = {
-			message,
-			fileName,
-			lineNumber
-		};
+		if ( ret !== true ) {
+			const error = {
+				message,
+				fileName,
+				lineNumber
+			};
 
-		ret = QUnit.onError( error );
-	}
+			ret = QUnit.onError( error );
+		}
 
-	return ret;
-};
+		return ret;
+	};
 
 }() );

--- a/reporter/urlparams.js
+++ b/reporter/urlparams.js
@@ -4,100 +4,100 @@ import { window } from "../src/globals";
 ( function() {
 
 // Only interact with URLs via window.location
-var location = typeof window !== "undefined" && window.location;
-if ( !location ) {
-	return;
-}
+	var location = typeof window !== "undefined" && window.location;
+	if ( !location ) {
+		return;
+	}
 
-var urlParams = getUrlParams();
+	var urlParams = getUrlParams();
 
-QUnit.urlParams = urlParams;
+	QUnit.urlParams = urlParams;
 
 // Match module/test by inclusion in an array
-QUnit.config.moduleId = [].concat( urlParams.moduleId || [] );
-QUnit.config.testId = [].concat( urlParams.testId || [] );
+	QUnit.config.moduleId = [].concat( urlParams.moduleId || [] );
+	QUnit.config.testId = [].concat( urlParams.testId || [] );
 
 // Exact case-insensitive match of the module name
-QUnit.config.module = urlParams.module;
+	QUnit.config.module = urlParams.module;
 
 // Regular expression or case-insenstive substring match against "moduleName: testName"
-QUnit.config.filter = urlParams.filter;
+	QUnit.config.filter = urlParams.filter;
 
 // Test order randomization
-if ( urlParams.seed === true ) {
+	if ( urlParams.seed === true ) {
 
 	// Generate a random seed if the option is specified without a value
-	QUnit.config.seed = Math.random().toString( 36 ).slice( 2 );
-} else if ( urlParams.seed ) {
-	QUnit.config.seed = urlParams.seed;
-}
+		QUnit.config.seed = Math.random().toString( 36 ).slice( 2 );
+	} else if ( urlParams.seed ) {
+		QUnit.config.seed = urlParams.seed;
+	}
 
 // Add URL-parameter-mapped config values with UI form rendering data
-QUnit.config.urlConfig.push(
-	{
-		id: "hidepassed",
-		label: "Hide passed tests",
-		tooltip: "Only show tests and assertions that fail. Stored as query-strings."
-	},
-	{
-		id: "noglobals",
-		label: "Check for Globals",
-		tooltip: "Enabling this will test if any test introduces new properties on the " +
+	QUnit.config.urlConfig.push(
+		{
+			id: "hidepassed",
+			label: "Hide passed tests",
+			tooltip: "Only show tests and assertions that fail. Stored as query-strings."
+		},
+		{
+			id: "noglobals",
+			label: "Check for Globals",
+			tooltip: "Enabling this will test if any test introduces new properties on the " +
 			"global object (`window` in Browsers). Stored as query-strings."
-	},
-	{
-		id: "notrycatch",
-		label: "No try-catch",
-		tooltip: "Enabling this will run tests outside of a try-catch block. Makes debugging " +
+		},
+		{
+			id: "notrycatch",
+			label: "No try-catch",
+			tooltip: "Enabling this will run tests outside of a try-catch block. Makes debugging " +
 			"exceptions in IE reasonable. Stored as query-strings."
-	}
+		}
 );
 
-QUnit.begin( function() {
-	var i, option,
-		urlConfig = QUnit.config.urlConfig;
+	QUnit.begin( function() {
+		var i, option,
+			urlConfig = QUnit.config.urlConfig;
 
-	for ( i = 0; i < urlConfig.length; i++ ) {
+		for ( i = 0; i < urlConfig.length; i++ ) {
 
 		// Options can be either strings or objects with nonempty "id" properties
-		option = QUnit.config.urlConfig[ i ];
-		if ( typeof option !== "string" ) {
-			option = option.id;
-		}
+			option = QUnit.config.urlConfig[ i ];
+			if ( typeof option !== "string" ) {
+				option = option.id;
+			}
 
-		if ( QUnit.config[ option ] === undefined ) {
-			QUnit.config[ option ] = urlParams[ option ];
-		}
-	}
-} );
-
-function getUrlParams() {
-	var i, param, name, value;
-	var urlParams = Object.create( null );
-	var params = location.search.slice( 1 ).split( "&" );
-	var length = params.length;
-
-	for ( i = 0; i < length; i++ ) {
-		if ( params[ i ] ) {
-			param = params[ i ].split( "=" );
-			name = decodeQueryParam( param[ 0 ] );
-
-			// Allow just a key to turn on a flag, e.g., test.html?noglobals
-			value = param.length === 1 ||
-				decodeQueryParam( param.slice( 1 ).join( "=" ) );
-			if ( name in urlParams ) {
-				urlParams[ name ] = [].concat( urlParams[ name ], value );
-			} else {
-				urlParams[ name ] = value;
+			if ( QUnit.config[ option ] === undefined ) {
+				QUnit.config[ option ] = urlParams[ option ];
 			}
 		}
+	} );
+
+	function getUrlParams() {
+		var i, param, name, value;
+		var urlParams = Object.create( null );
+		var params = location.search.slice( 1 ).split( "&" );
+		var length = params.length;
+
+		for ( i = 0; i < length; i++ ) {
+			if ( params[ i ] ) {
+				param = params[ i ].split( "=" );
+				name = decodeQueryParam( param[ 0 ] );
+
+			// Allow just a key to turn on a flag, e.g., test.html?noglobals
+				value = param.length === 1 ||
+				decodeQueryParam( param.slice( 1 ).join( "=" ) );
+				if ( name in urlParams ) {
+					urlParams[ name ] = [].concat( urlParams[ name ], value );
+				} else {
+					urlParams[ name ] = value;
+				}
+			}
+		}
+
+		return urlParams;
 	}
 
-	return urlParams;
-}
-
-function decodeQueryParam( param ) {
-	return decodeURIComponent( param.replace( /\+/g, "%20" ) );
-}
+	function decodeQueryParam( param ) {
+		return decodeURIComponent( param.replace( /\+/g, "%20" ) );
+	}
 
 }() );

--- a/runner/fixture.js
+++ b/runner/fixture.js
@@ -3,41 +3,41 @@ import { window, document } from "../src/globals";
 
 ( function() {
 
-if ( typeof window === "undefined" || typeof document === "undefined" ) {
-	return;
-}
+	if ( typeof window === "undefined" || typeof document === "undefined" ) {
+		return;
+	}
 
-var config = QUnit.config,
-	hasOwn = Object.prototype.hasOwnProperty;
+	var config = QUnit.config,
+		hasOwn = Object.prototype.hasOwnProperty;
 
 // Stores fixture HTML for resetting later
-function storeFixture() {
+	function storeFixture() {
 
 	// Avoid overwriting user-defined values
-	if ( hasOwn.call( config, "fixture" ) ) {
-		return;
+		if ( hasOwn.call( config, "fixture" ) ) {
+			return;
+		}
+
+		var fixture = document.getElementById( "qunit-fixture" );
+		if ( fixture ) {
+			config.fixture = fixture.innerHTML;
+		}
 	}
 
-	var fixture = document.getElementById( "qunit-fixture" );
-	if ( fixture ) {
-		config.fixture = fixture.innerHTML;
-	}
-}
-
-QUnit.begin( storeFixture );
+	QUnit.begin( storeFixture );
 
 // Resets the fixture DOM element if available.
-function resetFixture() {
-	if ( config.fixture == null ) {
-		return;
+	function resetFixture() {
+		if ( config.fixture == null ) {
+			return;
+		}
+
+		var fixture = document.getElementById( "qunit-fixture" );
+		if ( fixture ) {
+			fixture.innerHTML = config.fixture;
+		}
 	}
 
-	var fixture = document.getElementById( "qunit-fixture" );
-	if ( fixture ) {
-		fixture.innerHTML = config.fixture;
-	}
-}
-
-QUnit.testStart( resetFixture );
+	QUnit.testStart( resetFixture );
 
 } )();

--- a/src/export.js
+++ b/src/export.js
@@ -4,34 +4,34 @@ import { window } from "./globals";
 
 export default function exportQUnit( QUnit ) {
 
-if ( defined.document ) {
+	if ( defined.document ) {
 
 	// QUnit may be defined when it is preconfigured but then only QUnit and QUnit.config may be defined.
-	if ( window.QUnit && window.QUnit.version ) {
-		throw new Error( "QUnit has already been defined." );
+		if ( window.QUnit && window.QUnit.version ) {
+			throw new Error( "QUnit has already been defined." );
+		}
+
+		window.QUnit = QUnit;
 	}
 
-	window.QUnit = QUnit;
-}
-
 // For nodejs
-if ( typeof module !== "undefined" && module && module.exports ) {
-	module.exports = QUnit;
+	if ( typeof module !== "undefined" && module && module.exports ) {
+		module.exports = QUnit;
 
 	// For consistency with CommonJS environments' exports
-	module.exports.QUnit = QUnit;
-}
+		module.exports.QUnit = QUnit;
+	}
 
 // For CommonJS with exports, but without module.exports, like Rhino
-if ( typeof exports !== "undefined" && exports ) {
-	exports.QUnit = QUnit;
-}
+	if ( typeof exports !== "undefined" && exports ) {
+		exports.QUnit = QUnit;
+	}
 
-if ( typeof define === "function" && define.amd ) {
-	define( function() {
-		return QUnit;
-	} );
-	QUnit.config.autostart = false;
-}
+	if ( typeof define === "function" && define.amd ) {
+		define( function() {
+			return QUnit;
+		} );
+		QUnit.config.autostart = false;
+	}
 
 }

--- a/test/amd.js
+++ b/test/amd.js
@@ -1,23 +1,23 @@
 /* eslint-env amd */
 define( [ "qunit" ], function( QUnit ) {
 
-return function() {
-	QUnit.module( "AMD autostart", {
-		after: function( assert ) {
-			assert.ok( true, "after hook ran" );
-		}
-	} );
-
-	QUnit.test( "Prove the test run started as expected", function( assert ) {
-		assert.expect( 2 );
-		assert.strictEqual( window.beginData.totalTests, 1, "Should have expected 1 test" );
-	} );
-
-	setTimeout( function() {
-		QUnit.test( "Async-loaded tests should not run after hook again", function( assert ) {
-			assert.expect( 0 );
+	return function() {
+		QUnit.module( "AMD autostart", {
+			after: function( assert ) {
+				assert.ok( true, "after hook ran" );
+			}
 		} );
-	}, 5000 );
-};
+
+		QUnit.test( "Prove the test run started as expected", function( assert ) {
+			assert.expect( 2 );
+			assert.strictEqual( window.beginData.totalTests, 1, "Should have expected 1 test" );
+		} );
+
+		setTimeout( function() {
+			QUnit.test( "Async-loaded tests should not run after hook again", function( assert ) {
+				assert.expect( 0 );
+			} );
+		}, 5000 );
+	};
 
 } );

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -502,29 +502,29 @@ QUnit.test( "multiple `done` calls, final `done` is called BEFORE assertion", fu
 } );
 
 QUnit.test( "cannot allow assertions between first `done` call and second `assert.async` call",
-		function( assert ) {
-	var done2,
-		testContext = this,
-		done1 = assert.async();
+	function( assert ) {
+		var done2,
+			testContext = this,
+			done1 = assert.async();
 
-	assert.expect( 1 );
-	setTimeout( function() {
-		done1();
+		assert.expect( 1 );
+		setTimeout( function() {
+			done1();
 
-		testContext._assertCatch( function() {
+			testContext._assertCatch( function() {
 
 			// FAIL!!! (with duck-punch to force an Error to be thrown instead of `pushFailure`)
-			assert.ok( true, "should fail with a special `done`-related error message if called " +
-				"after final `done` even if result is passing" );
+				assert.ok( true, "should fail with a special `done`-related error message if " +
+				"called after final `done` even if result is passing" );
 
-			done2 = assert.async();
-			setTimeout( function() {
-				assert.ok( false, "Should never reach this point anyway" );
-				done2();
+				done2 = assert.async();
+				setTimeout( function() {
+					assert.ok( false, "Should never reach this point anyway" );
+					done2();
+				} );
 			} );
 		} );
 	} );
-} );
 
 QUnit.module( "assert after last done in before fail, but allow other phases to run", {
 	before: function( assert ) {

--- a/test/main/deepEqual.js
+++ b/test/main/deepEqual.js
@@ -159,38 +159,38 @@ QUnit.test( "Objects basics", function( assert ) {
 QUnit[ typeof Object.create === "function" ? "test" : "skip" ](
 	"Objects with null prototypes", function( assert ) {
 
-	var nonEmptyWithNoProto;
+		var nonEmptyWithNoProto;
 
 	// Objects with no prototype, created via Object.create(null), are used
 	// e.g. as dictionaries.
 	// Being able to test equivalence against object literals is quite useful.
-	assert.equal(
-		QUnit.equiv( Object.create( null ), {} ),
-		true,
-		"empty object without prototype VS empty object"
+		assert.equal(
+			QUnit.equiv( Object.create( null ), {} ),
+			true,
+			"empty object without prototype VS empty object"
 	);
 
-	assert.equal(
-		QUnit.equiv( {}, Object.create( null ) ),
-		true,
-		"empty object VS empty object without prototype"
+		assert.equal(
+			QUnit.equiv( {}, Object.create( null ) ),
+			true,
+			"empty object VS empty object without prototype"
 	);
 
-	nonEmptyWithNoProto = Object.create( null );
-	nonEmptyWithNoProto.foo = "bar";
+		nonEmptyWithNoProto = Object.create( null );
+		nonEmptyWithNoProto.foo = "bar";
 
-	assert.equal(
-		QUnit.equiv( nonEmptyWithNoProto, { foo: "bar" } ),
-		true,
-		"object without prototype VS object"
+		assert.equal(
+			QUnit.equiv( nonEmptyWithNoProto, { foo: "bar" } ),
+			true,
+			"object without prototype VS object"
 	);
 
-	assert.equal(
-		QUnit.equiv( { foo: "bar" }, nonEmptyWithNoProto ),
-		true,
-		"object VS object without prototype"
+		assert.equal(
+			QUnit.equiv( { foo: "bar" }, nonEmptyWithNoProto ),
+			true,
+			"object VS object without prototype"
 	);
-} );
+	} );
 
 // Ref #851
 QUnit[ typeof Object.create === "function" ? "test" : "skip" ](
@@ -201,20 +201,20 @@ QUnit[ typeof Object.create === "function" ? "test" : "skip" ](
 	// To mitigate this cost a specialized NullObject can be used. This
 	// Object has similar safe characteristics, but with dramatically
 	// reduced allocation costs.
-	function NullObject() {}
-	NullObject.prototype = Object.create( null, {
-		constructor: {
-			value: null
-		}
+		function NullObject() {}
+		NullObject.prototype = Object.create( null, {
+			constructor: {
+				value: null
+			}
+		} );
+
+		var a = new NullObject();
+		a.foo = 1;
+		var b = { foo: 1 };
+
+		assert.ok( QUnit.equiv( a, b ) );
+		assert.ok( QUnit.equiv( b, a ) );
 	} );
-
-	var a = new NullObject();
-	a.foo = 1;
-	var b = { foo: 1 };
-
-	assert.ok( QUnit.equiv( a, b ) );
-	assert.ok( QUnit.equiv( b, a ) );
-} );
 
 QUnit.test( "Arrays basics", function( assert ) {
 
@@ -244,153 +244,153 @@ QUnit.test( "Arrays basics", function( assert ) {
 	assert.equal( QUnit.equiv(
 					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
 					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]] ),
-					true );
+		true );
 	assert.equal( QUnit.equiv(
 					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
 					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]] ), // shorter
-					false );
+		false );
 	assert.equal( QUnit.equiv(
 					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[ {} ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]],
 					[[],[],[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]] ), // deepest element not an array
-					false );
+		false );
 
 	// same multidimensional
 	assert.equal( QUnit.equiv(
-							[ 1,2,3,4,5,6,7,8,9, [
-								1,2,3,4,5,6,7,8,9, [
-									1,2,3,4,5,[
-										[ 6,7,8,9, [
-											[
-												1,2,3,4,[
-													2,3,4,[
-														1,2,[
-															1,2,3,4,[
-																1,2,3,4,5,6,7,8,9,[
-																	0
-																],1,2,3,4,5,6,7,8,9
-															],5,6,7,8,9
-														],4,5,6,7,8,9
-													],5,6,7,8,9
-												],5,6,7
-											]
-										]
-									]
-								]
-							]]],
-							[ 1,2,3,4,5,6,7,8,9, [
-								1,2,3,4,5,6,7,8,9, [
-									1,2,3,4,5,[
-										[ 6,7,8,9, [
-											[
-												1,2,3,4,[
-													2,3,4,[
-														1,2,[
-															1,2,3,4,[
-																1,2,3,4,5,6,7,8,9,[
-																	0
-																],1,2,3,4,5,6,7,8,9
-															],5,6,7,8,9
-														],4,5,6,7,8,9
-													],5,6,7,8,9
-												],5,6,7
-											]
-										]
-									]
-								]
-							]]] ),
-							true, "Multidimensional" );
+		[ 1,2,3,4,5,6,7,8,9, [
+			1,2,3,4,5,6,7,8,9, [
+				1,2,3,4,5,[
+					[ 6,7,8,9, [
+						[
+							1,2,3,4,[
+								2,3,4,[
+									1,2,[
+										1,2,3,4,[
+											1,2,3,4,5,6,7,8,9,[
+												0
+											],1,2,3,4,5,6,7,8,9
+										],5,6,7,8,9
+									],4,5,6,7,8,9
+								],5,6,7,8,9
+							],5,6,7
+						]
+					]
+					]
+				]
+			]]],
+		[ 1,2,3,4,5,6,7,8,9, [
+			1,2,3,4,5,6,7,8,9, [
+				1,2,3,4,5,[
+					[ 6,7,8,9, [
+						[
+							1,2,3,4,[
+								2,3,4,[
+									1,2,[
+										1,2,3,4,[
+											1,2,3,4,5,6,7,8,9,[
+												0
+											],1,2,3,4,5,6,7,8,9
+										],5,6,7,8,9
+									],4,5,6,7,8,9
+								],5,6,7,8,9
+							],5,6,7
+						]
+					]
+					]
+				]
+			]]] ),
+		true, "Multidimensional" );
 
 	// different multidimensional
 	assert.equal( QUnit.equiv(
-							[ 1,2,3,4,5,6,7,8,9, [
-								1,2,3,4,5,6,7,8,9, [
-									1,2,3,4,5,[
-										[ 6,7,8,9, [
-											[
-												1,2,3,4,[
-													2,3,4,[
-														1,2,[
-															1,2,3,4,[
-																1,2,3,4,5,6,7,8,9,[
-																	0
-																],1,2,3,4,5,6,7,8,9
-															],5,6,7,8,9
-														],4,5,6,7,8,9
-													],5,6,7,8,9
-												],5,6,7
-											]
-										]
-									]
-								]
-							]]],
-							[ 1,2,3,4,5,6,7,8,9, [
-								1,2,3,4,5,6,7,8,9, [
-									1,2,3,4,5,[
-										[ 6,7,8,9, [
-											[
-												1,2,3,4,[
-													2,3,4,[
-														1,2,[
-															"1",2,3,4,[                 // string instead of number
-																1,2,3,4,5,6,7,8,9,[
-																	0
-																],1,2,3,4,5,6,7,8,9
-															],5,6,7,8,9
-														],4,5,6,7,8,9
-													],5,6,7,8,9
-												],5,6,7
-											]
-										]
-									]
-								]
-							]]] ),
-							false, "Multidimensional" );
+		[ 1,2,3,4,5,6,7,8,9, [
+			1,2,3,4,5,6,7,8,9, [
+				1,2,3,4,5,[
+					[ 6,7,8,9, [
+						[
+							1,2,3,4,[
+								2,3,4,[
+									1,2,[
+										1,2,3,4,[
+											1,2,3,4,5,6,7,8,9,[
+												0
+											],1,2,3,4,5,6,7,8,9
+										],5,6,7,8,9
+									],4,5,6,7,8,9
+								],5,6,7,8,9
+							],5,6,7
+						]
+					]
+					]
+				]
+			]]],
+		[ 1,2,3,4,5,6,7,8,9, [
+			1,2,3,4,5,6,7,8,9, [
+				1,2,3,4,5,[
+					[ 6,7,8,9, [
+						[
+							1,2,3,4,[
+								2,3,4,[
+									1,2,[
+										"1",2,3,4,[                 // string instead of number
+											1,2,3,4,5,6,7,8,9,[
+												0
+											],1,2,3,4,5,6,7,8,9
+										],5,6,7,8,9
+									],4,5,6,7,8,9
+								],5,6,7,8,9
+							],5,6,7
+						]
+					]
+					]
+				]
+			]]] ),
+		false, "Multidimensional" );
 
 	// different multidimensional
 	assert.equal( QUnit.equiv(
-							[ 1,2,3,4,5,6,7,8,9, [
-								1,2,3,4,5,6,7,8,9, [
-									1,2,3,4,5,[
-										[ 6,7,8,9, [
-											[
-												1,2,3,4,[
-													2,3,4,[
-														1,2,[
-															1,2,3,4,[
-																1,2,3,4,5,6,7,8,9,[
-																	0
-																],1,2,3,4,5,6,7,8,9
-															],5,6,7,8,9
-														],4,5,6,7,8,9
-													],5,6,7,8,9
-												],5,6,7
-											]
-										]
-									]
-								]
-							]]],
-							[ 1,2,3,4,5,6,7,8,9, [
-								1,2,3,4,5,6,7,8,9, [
-									1,2,3,4,5,[
-										[ 6,7,8,9, [
-											[
-												1,2,3,4,[
-													2,3,[                   // missing an element (4)
-														1,2,[
-															1,2,3,4,[
-																1,2,3,4,5,6,7,8,9,[
-																	0
-																],1,2,3,4,5,6,7,8,9
-															],5,6,7,8,9
-														],4,5,6,7,8,9
-													],5,6,7,8,9
-												],5,6,7
-											]
-										]
-									]
-								]
-							]]] ),
-							false, "Multidimensional" );
+		[ 1,2,3,4,5,6,7,8,9, [
+			1,2,3,4,5,6,7,8,9, [
+				1,2,3,4,5,[
+					[ 6,7,8,9, [
+						[
+							1,2,3,4,[
+								2,3,4,[
+									1,2,[
+										1,2,3,4,[
+											1,2,3,4,5,6,7,8,9,[
+												0
+											],1,2,3,4,5,6,7,8,9
+										],5,6,7,8,9
+									],4,5,6,7,8,9
+								],5,6,7,8,9
+							],5,6,7
+						]
+					]
+					]
+				]
+			]]],
+		[ 1,2,3,4,5,6,7,8,9, [
+			1,2,3,4,5,6,7,8,9, [
+				1,2,3,4,5,[
+					[ 6,7,8,9, [
+						[
+							1,2,3,4,[
+								2,3,[                   // missing an element (4)
+									1,2,[
+										1,2,3,4,[
+											1,2,3,4,5,6,7,8,9,[
+												0
+											],1,2,3,4,5,6,7,8,9
+										],5,6,7,8,9
+									],4,5,6,7,8,9
+								],5,6,7,8,9
+							],5,6,7
+						]
+					]
+					]
+				]
+			]]] ),
+		false, "Multidimensional" );
 } );
 
 QUnit.test( "Functions", function( assert ) {
@@ -1060,34 +1060,34 @@ QUnit.test( "Complex Arrays", function( assert ) {
 	function fn() {}
 
 	assert.equal( QUnit.equiv(
-				[ 1, 2, 3, true, {}, null, [
-					{
-						a: [ "", "1", 0 ]
-					},
-					5, 6, 7
-				], "foo" ],
-				[ 1, 2, 3, true, {}, null, [
-					{
-						a: [ "", "1", 0 ]
-					},
-					5, 6, 7
-				], "foo" ] ),
-			true );
+		[ 1, 2, 3, true, {}, null, [
+			{
+				a: [ "", "1", 0 ]
+			},
+			5, 6, 7
+		], "foo" ],
+		[ 1, 2, 3, true, {}, null, [
+			{
+				a: [ "", "1", 0 ]
+			},
+			5, 6, 7
+		], "foo" ] ),
+		true );
 
 	assert.equal( QUnit.equiv(
-				[ 1, 2, 3, true, {}, null, [
-					{
-						a: [ "", "1", 0 ]
-					},
-					5, 6, 7
-				], "foo" ],
-				[ 1, 2, 3, true, {}, null, [
-					{
-						b: [ "", "1", 0 ]         // not same property name
-					},
-					5, 6, 7
-				], "foo" ] ),
-			false );
+		[ 1, 2, 3, true, {}, null, [
+			{
+				a: [ "", "1", 0 ]
+			},
+			5, 6, 7
+		], "foo" ],
+		[ 1, 2, 3, true, {}, null, [
+			{
+				b: [ "", "1", 0 ]         // not same property name
+			},
+			5, 6, 7
+		], "foo" ] ),
+		false );
 
 	var a = [ {
 		b: fn,
@@ -1114,130 +1114,130 @@ QUnit.test( "Complex Arrays", function( assert ) {
 	}, {} ] ] ];
 
 	assert.equal( QUnit.equiv( a,
-			[ {
-				b: fn,
-				c: false,
-				"do": "reserved word",
-				"for": {
-					ar: [ 3, 5, 9, "hey!", [], {
-						ar: [ 1, [
-							3,4,6,9, null, [], []
-						]],
-						e: fn,
-						f: undefined
-					} ]
-				},
-				e: 0.43445
-			}, 5, "string", 0, fn, false, null, undefined, 0, [
-				4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
-			], [], [[[], "foo", null, {
-				n: 1 / 0,
-				z: {
-					a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
-					b: {}
-				}
-			}, {}]]] ), true );
+		[ {
+			b: fn,
+			c: false,
+			"do": "reserved word",
+			"for": {
+				ar: [ 3, 5, 9, "hey!", [], {
+					ar: [ 1, [
+						3,4,6,9, null, [], []
+					]],
+					e: fn,
+					f: undefined
+				} ]
+			},
+			e: 0.43445
+		}, 5, "string", 0, fn, false, null, undefined, 0, [
+			4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
+		], [], [[[], "foo", null, {
+			n: 1 / 0,
+			z: {
+				a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
+				b: {}
+			}
+		}, {}]]] ), true );
 
 	assert.equal( QUnit.equiv( a,
-			[ {
-				b: fn,
-				c: false,
-				"do": "reserved word",
-				"for": {
-					ar: [ 3, 5, 9, "hey!", [], {
-						ar: [ 1, [
-							3,4,6,9, null, [], []
-						]],
-						e: fn,
-						f: undefined
-					} ]
-				},
-				e: 0.43445
-			}, 5, "string", 0, fn, false, null, undefined, 0, [
-				4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 2 ]]]], "3"], {}, 1 / 0    // different: [[[[[2]]]]] instead of [[[[[3]]]]]
-			], [], [[[], "foo", null, {
-				n: 1 / 0,
-				z: {
-					a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
-					b: {}
-				}
-			}, {}]]] ), false );
+		[ {
+			b: fn,
+			c: false,
+			"do": "reserved word",
+			"for": {
+				ar: [ 3, 5, 9, "hey!", [], {
+					ar: [ 1, [
+						3,4,6,9, null, [], []
+					]],
+					e: fn,
+					f: undefined
+				} ]
+			},
+			e: 0.43445
+		}, 5, "string", 0, fn, false, null, undefined, 0, [
+			4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 2 ]]]], "3"], {}, 1 / 0    // different: [[[[[2]]]]] instead of [[[[[3]]]]]
+		], [], [[[], "foo", null, {
+			n: 1 / 0,
+			z: {
+				a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
+				b: {}
+			}
+		}, {}]]] ), false );
 
 	assert.equal( QUnit.equiv( a,
-			[ {
-				b: fn,
-				c: false,
-				"do": "reserved word",
-				"for": {
-					ar: [ 3, 5, 9, "hey!", [], {
-						ar: [ 1, [
-							3,4,6,9, null, [], []
-						]],
-						e: fn,
-						f: undefined
-					} ]
-				},
-				e: 0.43445
-			}, 5, "string", 0, fn, false, null, undefined, 0, [
-				4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
-			], [], [[[], "foo", null, {
-				n: -1 / 0,                                                                // different, -Infinity instead of Infinity
-				z: {
-					a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
-					b: {}
-				}
-			}, {}]]] ), false );
+		[ {
+			b: fn,
+			c: false,
+			"do": "reserved word",
+			"for": {
+				ar: [ 3, 5, 9, "hey!", [], {
+					ar: [ 1, [
+						3,4,6,9, null, [], []
+					]],
+					e: fn,
+					f: undefined
+				} ]
+			},
+			e: 0.43445
+		}, 5, "string", 0, fn, false, null, undefined, 0, [
+			4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
+		], [], [[[], "foo", null, {
+			n: -1 / 0,                                                                // different, -Infinity instead of Infinity
+			z: {
+				a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
+				b: {}
+			}
+		}, {}]]] ), false );
 
 	assert.equal( QUnit.equiv( a,
-			[ {
-				b: fn,
-				c: false,
-				"do": "reserved word",
-				"for": {
-					ar: [ 3, 5, 9, "hey!", [], {
-						ar: [ 1, [
-							3,4,6,9, null, [], []
-						]],
-						e: fn,
-						f: undefined
-					} ]
-				},
-				e: 0.43445
-			}, 5, "string", 0, fn, false, null, undefined, 0, [
-				4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
-			], [], [[[], "foo", {                                                       // different: null is missing
-				n: 1 / 0,
-				z: {
-					a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
-					b: {}
-				}
-			}, {}]]] ), false );
+		[ {
+			b: fn,
+			c: false,
+			"do": "reserved word",
+			"for": {
+				ar: [ 3, 5, 9, "hey!", [], {
+					ar: [ 1, [
+						3,4,6,9, null, [], []
+					]],
+					e: fn,
+					f: undefined
+				} ]
+			},
+			e: 0.43445
+		}, 5, "string", 0, fn, false, null, undefined, 0, [
+			4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
+		], [], [[[], "foo", {                                                       // different: null is missing
+			n: 1 / 0,
+			z: {
+				a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
+				b: {}
+			}
+		}, {}]]] ), false );
 
 	assert.equal( QUnit.equiv( a,
-			[ {
-				b: fn,
-				c: false,
-				"do": "reserved word",
-				"for": {
-					ar: [ 3, 5, 9, "hey!", [], {
-						ar: [ 1, [
-							3,4,6,9, null, [], []
-						]],
-						e: fn
+		[ {
+			b: fn,
+			c: false,
+			"do": "reserved word",
+			"for": {
+				ar: [ 3, 5, 9, "hey!", [], {
+					ar: [ 1, [
+						3,4,6,9, null, [], []
+					]],
+					e: fn
 
 																				// different: missing property f: undefined
-					} ]
-				},
-				e: 0.43445
-			}, 5, "string", 0, fn, false, null, undefined, 0, [
-				4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
-			], [], [[[], "foo", null, {
-				n: 1 / 0,
-				z: {
-					a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
-					b: {}
-				}
-			}, {}]]] ), false );
+				} ]
+			},
+			e: 0.43445
+		}, 5, "string", 0, fn, false, null, undefined, 0, [
+			4,5,6,7,8,9,11,22,33,44,55,"66", null, [], [[[[[ 3 ]]]], "3" ], {}, 1 / 0
+		], [], [[[], "foo", null, {
+			n: 1 / 0,
+			z: {
+				a: [ 3, 4, 5, 6, "yep!", undefined, undefined ],
+				b: {}
+			}
+		}, {}]]] ), false );
 } );
 
 QUnit.test( "Prototypal inheritance", function( assert ) {

--- a/test/main/modules.js
+++ b/test/main/modules.js
@@ -152,22 +152,22 @@ QUnit.module( "pre-nested modules" );
 
 QUnit.module( "nested modules", function() {
 	QUnit.module( "first outer", {
-			afterEach: function( assert ) {
-				assert.ok( true, "first outer module afterEach called" );
-			},
-			beforeEach: function( assert ) {
-				assert.ok( true, "first outer beforeEach called" );
-			}
+		afterEach: function( assert ) {
+			assert.ok( true, "first outer module afterEach called" );
 		},
+		beforeEach: function( assert ) {
+			assert.ok( true, "first outer beforeEach called" );
+		}
+	},
 		function() {
 			QUnit.module( "first inner", {
-					afterEach: function( assert ) {
-						assert.ok( true, "first inner module afterEach called" );
-					},
-					beforeEach: function( assert ) {
-						assert.ok( true, "first inner module beforeEach called" );
-					}
+				afterEach: function( assert ) {
+					assert.ok( true, "first inner module afterEach called" );
 				},
+				beforeEach: function( assert ) {
+					assert.ok( true, "first inner module beforeEach called" );
+				}
+			},
 				function() {
 					QUnit.test( "in module, before- and afterEach called in out-in-out " +
 						"order",

--- a/test/node/storage.js
+++ b/test/node/storage.js
@@ -1,20 +1,20 @@
 module.exports = {
-  _store: Object.create( null ),
-  setItem: function( key, value ) {
-    this._store[ key ] = value;
-  },
-  getItem: function( key ) {
-    return key in this._store ? this._store[ key ] : null;
-  },
-  removeItem: function( key ) {
-    if ( key in this._store ) {
-      delete this._store[ key ];
-    }
-  },
-  key: function( i ) {
-    return Object.keys( this._store )[ i ];
-  },
-  get length() {
-    return Object.keys( this._store ).length;
-  }
+	_store: Object.create( null ),
+	setItem: function( key, value ) {
+		this._store[ key ] = value;
+	},
+	getItem: function( key ) {
+		return key in this._store ? this._store[ key ] : null;
+	},
+	removeItem: function( key ) {
+		if ( key in this._store ) {
+			delete this._store[ key ];
+		}
+	},
+	key: function( i ) {
+		return Object.keys( this._store )[ i ];
+	},
+	get length() {
+		return Object.keys( this._store ).length;
+	}
 };

--- a/test/reorder.js
+++ b/test/reorder.js
@@ -5,11 +5,11 @@ var lastTest = "";
 QUnit.module( "Reorder" );
 
 QUnit.test( "First", function( assert ) {
-  assert.strictEqual( lastTest, "Second" );
-  lastTest = "First";
+	assert.strictEqual( lastTest, "Second" );
+	lastTest = "First";
 } );
 
 QUnit.test( "Second", function( assert ) {
-  assert.strictEqual( lastTest, "" );
-  lastTest = "Second";
+	assert.strictEqual( lastTest, "" );
+	lastTest = "Second";
 } );

--- a/test/reporter-html/window-onerror.js
+++ b/test/reporter-html/window-onerror.js
@@ -5,9 +5,9 @@ QUnit.module( "window.onerror (no preexisting handler)", function( hooks ) {
 		originalQUnitOnError = QUnit.onError;
 	} );
 
-    hooks.afterEach( function() {
-        QUnit.onError = originalQUnitOnError;
-    } );
+	hooks.afterEach( function() {
+		QUnit.onError = originalQUnitOnError;
+	} );
 
 	QUnit.test( "Should call QUnit.onError", function( assert ) {
 		assert.expect( 1 );

--- a/test/setTimeout.js
+++ b/test/setTimeout.js
@@ -1,23 +1,23 @@
 ( function( window ) {
 
-QUnit.module( "Module that mucks with time", {
-	beforeEach: function() {
-		this.setTimeout = window.setTimeout;
-		window.setTimeout = function() {};
-	},
+	QUnit.module( "Module that mucks with time", {
+		beforeEach: function() {
+			this.setTimeout = window.setTimeout;
+			window.setTimeout = function() {};
+		},
 
-	afterEach: function() {
-		window.setTimeout = this.setTimeout;
-	}
-} );
+		afterEach: function() {
+			window.setTimeout = this.setTimeout;
+		}
+	} );
 
-QUnit.test( "just a test", function( assert ) {
-	assert.ok( true );
-} );
+	QUnit.test( "just a test", function( assert ) {
+		assert.ok( true );
+	} );
 
-QUnit.test( "just a test", function( assert ) {
-	assert.ok( true );
-} );
+	QUnit.test( "just a test", function( assert ) {
+		assert.ok( true );
+	} );
 
 }( ( function() {
 	return this;

--- a/test/startError.js
+++ b/test/startError.js
@@ -7,8 +7,8 @@ QUnit.test( "start() throws when QUnit.config.autostart === true", function( ass
 } );
 
 QUnit.test( "Throws after calling start() too many times outside of a test context",
-		function( assert ) {
-	assert.expect( 1 );
-	assert.equal( window.tooManyStartsError.message,
-		"Called start() outside of a test context too many times" );
-} );
+	function( assert ) {
+		assert.expect( 1 );
+		assert.equal( window.tooManyStartsError.message,
+			"Called start() outside of a test context too many times" );
+	} );


### PR DESCRIPTION
This enables the ESLint "indent" rule.

There are some limitations of this rule which would force us to deviate from the jQuery style guide, especially around full file closures (whether IIFEs or factory functions). This PR chooses to have pure IIFEs be indented 1 tab, which is further from the style guide but results in consistent indentation between pure IIFEs and factory functions.

PR #1142 is the zero-tab IIFE version.