### PR TITLE
Core: Ensure assertions occur while test is running

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -359,6 +359,9 @@ Test.prototype = {
 	},
 
 	pushResult: function( resultInfo ) {
+		if ( this !== config.current ) {
+			throw new Error( "Assertion occured after test had finished." );
+		}
 
 		// Destructure of resultInfo = { result, actual, expected, message, negative }
 		var source,

--- a/test/main/assert.js
+++ b/test/main/assert.js
@@ -390,3 +390,21 @@ QUnit.test( "throws", function( assert ) {
 		"throws fail when regexp doesn't match the error message"
 	);
 } );
+
+( function() {
+	var previousTestAssert;
+
+	QUnit.module( "delayed assertions" );
+
+	QUnit.test( "assertions after test finishes throws an error - part 1", function( assert ) {
+		assert.expect( 0 );
+		previousTestAssert = assert;
+	} );
+
+	QUnit.test( "assertions after test finishes throws an error - part 2", function( assert ) {
+		assert.expect( 1 );
+		assert.throws( function() {
+			previousTestAssert.ok( true );
+		}, /Assertion occured after test had finished/ );
+	} );
+}() );


### PR DESCRIPTION
Based on discussion in https://github.com/qunitjs/qunit/issues/1145#issuecomment-292290443, I investigated if we properly erred when asserting outside the active test, and it turns out we do not. This fixes that and adds a test.

There's a potential that this could break some currently passing test suites, but I would consider those bugs as it poor testing practice to have assertions take place outside the actual test they're associated with.