### PR TITLE
Assert: Allow assertions after async

### DIFF
--- a/docs/assert/async.md
+++ b/docs/assert/async.md
@@ -17,7 +17,7 @@ Instruct QUnit to wait for an asynchronous operation.
 
 ### Description
 
-The callback returned from `assert.async()` will throw an Error if it is invoked more than once (or more often than the accepted call count, if provided).
+`assert.async()` returns a callback function and pauses test processing until the callback function is invoked the specified number of times. The callback will throw an `Error` if it is invoked more often than the accepted call count.
 
 This replaces functionality previously provided by [`QUnit.stop()`](/QUnit/stop) and [`QUnit.start()`](/QUnit/start).
 

--- a/src/assert.js
+++ b/src/assert.js
@@ -52,7 +52,6 @@ class Assert {
 			acceptCallCount = 1;
 		}
 
-		test.usedAsync = true;
 		const resume = internalStop( test );
 
 		return function done() {
@@ -105,13 +104,6 @@ class Assert {
 		// not exactly the test where assertion were intended to be called.
 		if ( !currentTest ) {
 			throw new Error( "assertion outside test context, in " + sourceFromStacktrace( 2 ) );
-		}
-
-		if ( currentTest.usedAsync === true && currentTest.semaphore === 0 ) {
-			currentTest.pushFailure( "Assertion after the final `assert.async` was resolved",
-				sourceFromStacktrace( 2 ) );
-
-			// Allow this assertion to continue running anyway...
 		}
 
 		if ( !( assert instanceof Assert ) ) {

--- a/src/core/processing-queue.js
+++ b/src/core/processing-queue.js
@@ -34,12 +34,6 @@ function advance() {
 		const elapsedTime = now() - start;
 
 		if ( !defined.setTimeout || config.updateRate <= 0 || elapsedTime < config.updateRate ) {
-			if ( config.current ) {
-
-				// Reset async tracking for each phase of the Test lifecycle
-				config.current.usedAsync = false;
-			}
-
 			if ( priorityCount > 0 ) {
 				priorityCount--;
 			}

--- a/src/test.js
+++ b/src/test.js
@@ -33,7 +33,6 @@ export default function Test( settings ) {
 	extend( this, settings );
 	this.assertions = [];
 	this.semaphore = 0;
-	this.usedAsync = false;
 	this.module = config.currentModule;
 	this.stack = sourceFromStacktrace( 3 );
 	this.steps = [];


### PR DESCRIPTION
~~Implements the feature discussed in https://github.com/qunitjs/qunit/issues/1145.~~

Allow assertions after the `assert.async()` callback is invoked. As discussed in https://github.com/qunitjs/qunit/issues/1145.