### PR TITLE
Docs: Remove trailing slash from some urls

### DIFF
--- a/docs/QUnit/skip.md
+++ b/docs/QUnit/skip.md
@@ -16,7 +16,7 @@ Adds a test like object to be skipped
 
 ### Description
 
-Use this method to replace [`QUnit.test()`](/QUnit/test/) instead of commenting out entire tests.
+Use this method to replace [`QUnit.test()`](/QUnit/test) instead of commenting out entire tests.
 
 This test's prototype will be listed on the suite as a skipped test, ignoring the callback argument and the respective global and module's hooks.
 

--- a/docs/QUnit/start.md
+++ b/docs/QUnit/start.md
@@ -9,9 +9,9 @@ categories:
 
 ## `QUnit.start()`
 
-`QUnit.start()` must be used to start a test run that has [`QUnit.config.autostart`](/config/QUnit.config/) set to `false`.
+`QUnit.start()` must be used to start a test run that has [`QUnit.config.autostart`](/config/QUnit.config) set to `false`.
 
-<p class="warning" markdown="1">Warning: This method was previously used to control async tests on text contexts along with `QUnit.stop`. For asynchronous tests, use [`assert.async`](/assert/async/) instead.</p>
+<p class="warning" markdown="1">Warning: This method was previously used to control async tests on text contexts along with `QUnit.stop`. For asynchronous tests, use [`assert.async`](/assert/async) instead.</p>
 
 When your async test has multiple exit points, call `QUnit.start()` for the corresponding number of `QUnit.stop()` increments.
 

--- a/docs/assert/deepEqual.md
+++ b/docs/assert/deepEqual.md
@@ -20,7 +20,7 @@ A deep recursive comparison, working on primitive types, arrays, objects, regula
 
 The `deepEqual()` assertion can be used just like `equal()` when comparing the value of objects, such that `{ key: value }` is equal to `{ key: value }`. For non-scalar values, identity will be disregarded by `deepEqual`.
 
-[`notDeepEqual()`](/assert/notDeepEqual/) can be used to explicitly test deep, strict inequality.
+[`notDeepEqual()`](/assert/notDeepEqual) can be used to explicitly test deep, strict inequality.
 
 ### Examples
 

--- a/docs/assert/equal.md
+++ b/docs/assert/equal.md
@@ -20,9 +20,9 @@ A non-strict comparison, roughly equivalent to JUnit's `assertEquals`.
 
 The `equal` assertion uses the simple comparison operator (`==`) to compare the actual and expected arguments. When they are equal, the assertion passes; otherwise, it fails. When it fails, both actual and expected values are displayed in the test result, in addition to a given message.
 
-[`notEqual()`](/assert/notEqual/) can be used to explicitly test inequality.
+[`notEqual()`](/assert/notEqual) can be used to explicitly test inequality.
 
-[`strictEqual()`](/assert/strictEqual/) can be used to test strict equality.
+[`strictEqual()`](/assert/strictEqual) can be used to test strict equality.
 
 ### Examples
 

--- a/docs/assert/notDeepEqual.md
+++ b/docs/assert/notDeepEqual.md
@@ -20,7 +20,7 @@ An inverted deep recursive comparison, working on primitive types, arrays, objec
 
 The `notDeepEqual()` assertion can be used just like `equal()` when comparing the value of objects, such that `{ key: value }` is equal to `{ key: value }`. For non-scalar values, identity will be disregarded by `notDeepEqual`.
 
-[`deepEqual()`](/assert/deepEqual/) can be used to explicitly test deep, strict equality.
+[`deepEqual()`](/assert/deepEqual) can be used to explicitly test deep, strict equality.
 
 ### Examples
 

--- a/docs/assert/notPropEqual.md
+++ b/docs/assert/notPropEqual.md
@@ -20,9 +20,9 @@ The `notPropEqual` assertion uses the strict inverted comparison operator (`!==`
 
 When they aren't equal, the assertion passes; otherwise, it fails. When it fails, both actual and expected values are displayed in the test result, in addition to a given message.
 
-[`equal()`](/assert/equal/) can be used to test equality.
+[`equal()`](/assert/equal) can be used to test equality.
 
-[`propEqual()`](/assert/propEqual/) can be used to test strict equality of an Object properties.
+[`propEqual()`](/assert/propEqual) can be used to test strict equality of an Object properties.
 
 ### Examples
 

--- a/docs/assert/notStrictEqual.md
+++ b/docs/assert/notStrictEqual.md
@@ -20,9 +20,9 @@ A strict comparison, checking for inequality.
 
 The `notStrictEqual` assertion uses the strict inverted comparison operator (`!==`) to compare the actual and expected arguments. When they aren't equal, the assertion passes; otherwise, it fails. When it fails, both actual and expected values are displayed in the test result, in addition to a given message.
 
-[`equal()`](/assert/equal/) can be used to test equality.
+[`equal()`](/assert/equal) can be used to test equality.
 
-[`strictEqual()`](/assert/strictEqual/) can be used to test strict equality.
+[`strictEqual()`](/assert/strictEqual) can be used to test strict equality.
 
 ### Examples
 

--- a/docs/assert/propEqual.md
+++ b/docs/assert/propEqual.md
@@ -20,9 +20,9 @@ A strict type and value comparison of an object's own properties.
 
 The `propEqual()` assertion provides strictly (`===`) comparison of Object properties. Unlike `deepEqual()`, this assertion can be used to compare two objects made with different constructors and prototype.
 
-[`strictEqual()`](/assert/strictEqual/) can be used to test strict equality.
+[`strictEqual()`](/assert/strictEqual) can be used to test strict equality.
 
-[`notPropEqual()`](/assert/notPropEqual/) can be used to explicitly test strict inequality of Object properties.
+[`notPropEqual()`](/assert/notPropEqual) can be used to explicitly test strict inequality of Object properties.
 
 ### Example
 

--- a/docs/assert/strictEqual.md
+++ b/docs/assert/strictEqual.md
@@ -20,9 +20,9 @@ A strict type and value comparison.
 
 The `strictEqual()` assertion provides the most rigid comparison of type and value with the strict equality operator (`===`).
 
-[`equal()`](/assert/equal/) can be used to test non-strict equality.
+[`equal()`](/assert/equal) can be used to test non-strict equality.
 
-[`notStrictEqual()`](/assert/notStrictEqual/) can be used to explicitly test strict inequality.
+[`notStrictEqual()`](/assert/notStrictEqual) can be used to explicitly test strict inequality.
 
 ### Example
 

--- a/docs/callbacks/QUnit.log.md
+++ b/docs/callbacks/QUnit.log.md
@@ -28,7 +28,7 @@ The properties of the details argument are listed below as options.
 | `source` (string) | The associated stacktrace, either from an exception or pointing to the source of the assertion. Depends on browser support for providing stacktraces, so can be undefined. |
 | `module` (string) | The test module name of the assertion. If the assertion is not connected to any module, the property's value will be _undefined_. |
 | `name` (string) | The test block name of the assertion. |
-| `runtime` (number) | The time elapsed in milliseconds since the start of the containing [`QUnit.test()`](/QUnit/test/), including setup. |
+| `runtime` (number) | The time elapsed in milliseconds since the start of the containing [`QUnit.test()`](/QUnit/test), including setup. |
 
 ### Examples
 

--- a/docs/config/QUnit.push.md
+++ b/docs/config/QUnit.push.md
@@ -17,8 +17,8 @@ __DEPRECATED__: Report the result of a custom assertion
 | `expected`         | Known comparison value               |
 | `message` (string) | A short description of the assertion |
 
-<p class="warning" markdown="1">This method is __deprecated__ and it's recommended to use [`pushResult`](/assert/pushResult/) on its direct reference in the assertion context.</p>
+<p class="warning" markdown="1">This method is __deprecated__ and it's recommended to use [`pushResult`](/assert/pushResult) on its direct reference in the assertion context.</p>
 
-`QUnit.push` reflects to the current running test, and it may leak assertions in asynchronous mode. Checkout [`assert.pushResult()`](/assert/pushResult/) to set a proper custom assertion.
+`QUnit.push` reflects to the current running test, and it may leak assertions in asynchronous mode. Checkout [`assert.pushResult()`](/assert/pushResult) to set a proper custom assertion.
 
 Invoking `QUnit.push` allows to create a readable expectation that is not defined by any of QUnit's built-in assertions.

--- a/docs/config/QUnit.stack.md
+++ b/docs/config/QUnit.stack.md
@@ -23,7 +23,7 @@ Not all [browsers support retrieving stracktraces][browsers]. In those, `QUnit.s
 
 ### Example
 
-The stacktrace line can be used on custom assertions and reporters. The following example [logs](/callbacks/QUnit.log/) the line of each passing assertion.
+The stacktrace line can be used on custom assertions and reporters. The following example [logs](/callbacks/QUnit.log) the line of each passing assertion.
 
 ```js
 QUnit.log( function( details ) {


### PR DESCRIPTION
In order to avoid `File not found` error from GitHub pages.