### PR TITLE
Tests: Reject async test promise when config.notrycatch is set.

### DIFF
--- a/docs/config/QUnit.config.md
+++ b/docs/config/QUnit.config.md
@@ -63,6 +63,8 @@ By default, QUnit will run tests within a `try-catch` block to prevent uncaught 
 
 Enabling this flag will run tests without the `try-catch` to allow exceptions to remain uncaught for easier debugging in certain environments.
 
+If set, no rejection handler will be attached to promises returned by tests. This has a similar effect and allows debuggers to pause at the right location if an error occurs.
+
 ### `QUnit.config.noglobals` (boolean) | default: `false`
 
 Enabling this flag will cause QUnit to check if any new properties have been added to the global context after each test. New global properties being found will result in test failures to help ensure your tests are not leaking state.

--- a/src/test.js
+++ b/src/test.js
@@ -437,23 +437,27 @@ Test.prototype = {
 			then = promise.then;
 			if ( objectType( then ) === "function" ) {
 				resume = internalStop( test );
-				then.call(
-					promise,
-					function() { resume(); },
-					function( error ) {
-						message = "Promise rejected " +
-							( !phase ? "during" : phase.replace( /Each$/, "" ) ) +
-							" \"" + test.testName + "\": " +
-							( ( error && error.message ) || error );
-						test.pushFailure( message, extractStacktrace( error, 0 ) );
+				if ( config.notrycatch ) {
+					then.call( promise, function() { resume(); } );
+				} else {
+					then.call(
+						promise,
+						function() { resume(); },
+						function( error ) {
+							message = "Promise rejected " +
+								( !phase ? "during" : phase.replace( /Each$/, "" ) ) +
+								" \"" + test.testName + "\": " +
+								( ( error && error.message ) || error );
+							test.pushFailure( message, extractStacktrace( error, 0 ) );
 
-						// Else next test will carry the responsibility
-						saveGlobal();
+							// Else next test will carry the responsibility
+							saveGlobal();
 
-						// Unblock
-						resume();
-					}
-				);
+							// Unblock
+							resume();
+						}
+					);
+				}
 			}
 		}
 	},


### PR DESCRIPTION
Fixes #1149 

Soo.. as far as I can tell the following is semantically equivalent to the changed version in the PR. But the resume at // unblock is undefined?
EDIT: NVM 