### PR TITLE
HTML Reporter: numerical diff of differing numbers instead of str-diff.

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -785,19 +785,16 @@ export function escapeText( s ) {
 					showDiff = true;
 					diff = ( details.actual - details.expected );
 					diff = ( diff > 0 ? "+" : "" ) + diff;
-				} else {
+				} else if ( "boolean" !== typeof details.actual &&
+							"boolean" !== typeof details.expected ) {
+					diff = QUnit.diff( expected, actual );
 
-					// Don't show diff if actual or expected are booleans
-					if ( !( /^(true|false)$/.test( actual ) ) &&
-						!( /^(true|false)$/.test( expected ) ) ) {
-						diff = QUnit.diff( expected, actual );
-						showDiff = stripHtml( diff ).length !==
-							stripHtml( expected ).length +
-							stripHtml( actual ).length;
-					}
+					// don't show diff if there is zero overlap
+					showDiff = stripHtml( diff ).length !==
+						stripHtml( expected ).length +
+						stripHtml( actual ).length;
 				}
 
-				// Don't show diff if expected and actual are totally different
 				if ( showDiff ) {
 					message += "<tr class='test-diff'><th>Diff: </th><td><pre>" +
 					diff + "</pre></td></tr>";

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -782,9 +782,11 @@ export function escapeText( s ) {
 					escapeText( actual ) + "</pre></td></tr>";
 
 				if ( typeof details.actual === "number" && typeof details.expected === "number" ) {
-					showDiff = true;
-					diff = ( details.actual - details.expected );
-					diff = ( diff > 0 ? "+" : "" ) + diff;
+					if ( !isNaN( details.actual ) && !isNaN( details.expected ) ) {
+						showDiff = true;
+						diff = ( details.actual - details.expected );
+						diff = ( diff > 0 ? "+" : "" ) + diff;
+					}
 				} else if ( typeof details.actual !== "boolean" &&
 							typeof details.expected !== "boolean" ) {
 					diff = QUnit.diff( expected, actual );

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -779,18 +779,25 @@ export function escapeText( s ) {
 			if ( actual !== expected ) {
 
 				message += "<tr class='test-actual'><th>Result: </th><td><pre>" +
-				escapeText( actual ) + "</pre></td></tr>";
+					escapeText( actual ) + "</pre></td></tr>";
 
-			// Don't show diff if actual or expected are booleans
-				if ( !( /^(true|false)$/.test( actual ) ) &&
-					!( /^(true|false)$/.test( expected ) ) ) {
-					diff = QUnit.diff( expected, actual );
-					showDiff = stripHtml( diff ).length !==
-					stripHtml( expected ).length +
-					stripHtml( actual ).length;
+				if ( "number" === typeof details.actual && "number" === typeof details.expected ) {
+					showDiff = true;
+					diff = ( details.actual - details.expected );
+					diff = ( diff > 0 ? "+" : "" ) + diff;
+				} else {
+
+					// Don't show diff if actual or expected are booleans
+					if ( !( /^(true|false)$/.test( actual ) ) &&
+						!( /^(true|false)$/.test( expected ) ) ) {
+						diff = QUnit.diff( expected, actual );
+						showDiff = stripHtml( diff ).length !==
+							stripHtml( expected ).length +
+							stripHtml( actual ).length;
+					}
 				}
 
-			// Don't show diff if expected and actual are totally different
+				// Don't show diff if expected and actual are totally different
 				if ( showDiff ) {
 					message += "<tr class='test-diff'><th>Diff: </th><td><pre>" +
 					diff + "</pre></td></tr>";

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -781,12 +781,12 @@ export function escapeText( s ) {
 				message += "<tr class='test-actual'><th>Result: </th><td><pre>" +
 					escapeText( actual ) + "</pre></td></tr>";
 
-				if ( "number" === typeof details.actual && "number" === typeof details.expected ) {
+				if ( typeof details.actual === "number" && typeof details.expected === "number" ) {
 					showDiff = true;
 					diff = ( details.actual - details.expected );
 					diff = ( diff > 0 ? "+" : "" ) + diff;
-				} else if ( "boolean" !== typeof details.actual &&
-							"boolean" !== typeof details.expected ) {
+				} else if ( typeof details.actual !== "boolean" &&
+							typeof details.expected !== "boolean" ) {
 					diff = QUnit.diff( expected, actual );
 
 					// don't show diff if there is zero overlap


### PR DESCRIPTION
The HTML reporter does a str diff on differing numbers, which is uniquely useless. This shows the numerical difference. This checks if the values actually have typeof number, which I find preferable, but I guess checking if both values are parsable as numbers is also possible.