### PR TITLE
Core: Fix bug calling hooks with skipped tests

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -44,8 +44,10 @@ function createModule( name, testEnvironment ) {
 		name: moduleName,
 		parentModule: parentModule,
 		tests: [],
+		unskippedTests: [],
 		moduleId: generateHash( moduleName ),
 		testsRun: 0,
+		unskippedTestsRun: 0,
 		childModules: [],
 		suiteReport: new SuiteReport( name, parentSuite )
 	};

--- a/src/core.js
+++ b/src/core.js
@@ -44,7 +44,6 @@ function createModule( name, testEnvironment ) {
 		name: moduleName,
 		parentModule: parentModule,
 		tests: [],
-		unskippedTests: [],
 		moduleId: generateHash( moduleName ),
 		testsRun: 0,
 		unskippedTestsRun: 0,

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -44,7 +44,6 @@ const config = {
 	currentModule: {
 		name: "",
 		tests: [],
-		unskippedTests: [],
 		childModules: [],
 		testsRun: 0,
 		unskippedTestsRun: 0

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -44,8 +44,10 @@ const config = {
 	currentModule: {
 		name: "",
 		tests: [],
+		unskippedTests: [],
 		childModules: [],
-		testsRun: 0
+		testsRun: 0,
+		unskippedTestsRun: 0
 	},
 
 	callbacks: {},

--- a/src/test.js
+++ b/src/test.js
@@ -761,17 +761,13 @@ function numberOfUnskippedTests( module ) {
 }
 
 function notifyTestsRan( module, skipped ) {
-	const thisModule = module;
-
 	module.testsRun++;
+	if ( !skipped ) {
+		module.unskippedTestsRun++;
+	}
 	while ( ( module = module.parentModule ) ) {
 		module.testsRun++;
-	}
-
-	if ( !skipped ) {
-		module = thisModule;
-		module.unskippedTestsRun++;
-		while ( ( module = module.parentModule ) ) {
+		if ( !skipped ) {
 			module.unskippedTestsRun++;
 		}
 	}

--- a/src/test.js
+++ b/src/test.js
@@ -742,13 +742,13 @@ function internalStart( test ) {
 }
 
 function collectTests( module, key ) {
-	let tests = [].concat( module[ key ] );
+	const tests = [].concat( module[ key ] );
 	const modules = [ ...module.childModules ];
 
 	// Do a breadth-first traversal of the child modules
 	while ( modules.length ) {
 		const nextModule =  modules.shift();
-		tests = tests.concat( nextModule[ key ] );
+		tests.push.apply( tests, nextModule[ key ] );
 		modules.push( ...nextModule.childModules );
 	}
 

--- a/src/test.js
+++ b/src/test.js
@@ -54,7 +54,8 @@ export default function Test( settings ) {
 
 	this.module.tests.push( {
 		name: this.testName,
-		testId: this.testId
+		testId: this.testId,
+		skip: !!settings.skip
 	} );
 
 	if ( settings.skip ) {
@@ -64,10 +65,6 @@ export default function Test( settings ) {
 		this.async = false;
 		this.expected = 0;
 	} else {
-		this.module.unskippedTests.push( {
-			name: this.testName,
-			testId: this.testId
-		} );
 		this.assert = new Assert( this );
 	}
 }
@@ -741,14 +738,14 @@ function internalStart( test ) {
 	}
 }
 
-function collectTests( module, key ) {
-	const tests = [].concat( module[ key ] );
+function collectTests( module ) {
+	const tests = [].concat( module.tests );
 	const modules = [ ...module.childModules ];
 
 	// Do a breadth-first traversal of the child modules
 	while ( modules.length ) {
 		const nextModule =  modules.shift();
-		tests.push.apply( tests, nextModule[ key ] );
+		tests.push.apply( tests, nextModule.tests );
 		modules.push( ...nextModule.childModules );
 	}
 
@@ -756,11 +753,11 @@ function collectTests( module, key ) {
 }
 
 function numberOfTests( module ) {
-	return collectTests( module, "tests" ).length;
+	return collectTests( module ).length;
 }
 
 function numberOfUnskippedTests( module ) {
-	return collectTests( module, "unskippedTests" ).length;
+	return collectTests( module ).filter( test => !test.skip ).length;
 }
 
 function notifyTestsRan( module, skipped ) {

--- a/test/logs.js
+++ b/test/logs.js
@@ -15,11 +15,13 @@ var totalTests, moduleContext, moduleDoneContext, testContext, testDoneContext, 
 		tests: [
 			( module1Test1 = {
 				"name": "test1",
-				"testId": "646e9e25"
+				"testId": "646e9e25",
+				"skip": false
 			} ),
 			( module1Test2 = {
 				"name": "test2",
-				"testId": "646e9e26"
+				"testId": "646e9e26",
+				"skip": false
 			} )
 		]
 	},
@@ -28,27 +30,33 @@ var totalTests, moduleContext, moduleDoneContext, testContext, testDoneContext, 
 		tests: [
 			( module2Test1 = {
 				"name": "test1",
-				"testId": "9954d966"
+				"testId": "9954d966",
+				"skip": false
 			} ),
 			( module2Test2 = {
 				"name": "test2",
-				"testId": "9954d967"
+				"testId": "9954d967",
+				"skip": false
 			} ),
 			( module2Test3 = {
 				"name": "a skipped test",
-				"testId": "3e797d3a"
+				"testId": "3e797d3a",
+				"skip": true
 			} ),
 			( module2Test4 = {
 				"name": "test the log for the skipped test",
-				"testId": "d3266148"
+				"testId": "d3266148",
+				"skip": false
 			} ),
 			( module2Test5 = {
 				"name": "a todo test",
-				"testId": "77a47174"
+				"testId": "77a47174",
+				"skip": false
 			} ),
 			( module2Test6 = {
 				"name": "test the log for the todo test",
-				"testId": "5f5ab826"
+				"testId": "5f5ab826",
+				"skip": false
 			} )
 		]
 	};

--- a/test/main/modules.js
+++ b/test/main/modules.js
@@ -49,6 +49,30 @@ QUnit.test( "does not run before subsequent tests", function( assert ) {
 	assert.equal( this.beforeCount, 1, "beforeCount did not increase from last test" );
 } );
 
+QUnit.module( "before (skip)", {
+	before: function( assert ) {
+		assert.ok( true, "before hook ran" );
+
+		if ( typeof this.beforeCount === "undefined" ) {
+			this.beforeCount = 0;
+		}
+
+		this.beforeCount++;
+	}
+} );
+
+QUnit.skip( "first test in module is skipped" );
+
+QUnit.test( "runs before first unskipped test", function( assert ) {
+	assert.expect( 2 );
+	assert.equal( this.beforeCount, 1, "beforeCount should be one" );
+} );
+
+QUnit.test( "does not run before subsequent tests", function( assert ) {
+	assert.expect( 1 );
+	assert.equal( this.beforeCount, 1, "beforeCount did not increase from last test" );
+} );
+
 QUnit.module( "after", {
 	after: function( assert ) {
 		assert.ok( true, "after hook ran" );
@@ -61,6 +85,46 @@ QUnit.test( "does not run after initial tests", function( assert ) {
 
 QUnit.test( "runs after final test", function( assert ) {
 	assert.expect( 1 );
+} );
+
+QUnit.module( "after (skip)", {
+	after: function( assert ) {
+		assert.ok( true, "after hook ran" );
+	}
+} );
+
+QUnit.test( "does not run after initial tests", function( assert ) {
+	assert.expect( 0 );
+} );
+
+QUnit.test( "runs after final unskipped test", function( assert ) {
+	assert.expect( 1 );
+} );
+
+QUnit.skip( "last test in module is skipped" );
+
+QUnit.module( "before/after with all tests skipped (wrapper)", function() {
+	var ranBeforeHook = 0;
+	var ranAfterHook = 0;
+
+	QUnit.module( "main", function( hooks ) {
+		hooks.before = function() {
+			ranBeforeHook += 1;
+		};
+		hooks.after = function() {
+			ranAfterHook += 1;
+		};
+
+		QUnit.skip( "only test in module is skipped" );
+	} );
+
+	QUnit.module( "verifier", function() {
+		QUnit.test( "hooks did not run", function( assert ) {
+			assert.expect( 2 );
+			assert.equal( ranBeforeHook, 0, "before hook did not run" );
+			assert.equal( ranAfterHook, 0, "after hook did not run" );
+		} );
+	} );
 } );
 
 QUnit.module( "Test context object", {

--- a/test/main/modules.js
+++ b/test/main/modules.js
@@ -52,25 +52,13 @@ QUnit.test( "does not run before subsequent tests", function( assert ) {
 QUnit.module( "before (skip)", {
 	before: function( assert ) {
 		assert.ok( true, "before hook ran" );
-
-		if ( typeof this.beforeCount === "undefined" ) {
-			this.beforeCount = 0;
-		}
-
-		this.beforeCount++;
 	}
 } );
 
 QUnit.skip( "first test in module is skipped" );
 
 QUnit.test( "runs before first unskipped test", function( assert ) {
-	assert.expect( 2 );
-	assert.equal( this.beforeCount, 1, "beforeCount should be one" );
-} );
-
-QUnit.test( "does not run before subsequent tests", function( assert ) {
 	assert.expect( 1 );
-	assert.equal( this.beforeCount, 1, "beforeCount did not increase from last test" );
 } );
 
 QUnit.module( "after", {
@@ -103,28 +91,16 @@ QUnit.test( "runs after final unskipped test", function( assert ) {
 
 QUnit.skip( "last test in module is skipped" );
 
-QUnit.module( "before/after with all tests skipped (wrapper)", function() {
-	var ranBeforeHook = 0;
-	var ranAfterHook = 0;
-
-	QUnit.module( "main", function( hooks ) {
-		hooks.before = function() {
-			ranBeforeHook += 1;
-		};
-		hooks.after = function() {
-			ranAfterHook += 1;
-		};
-
-		QUnit.skip( "only test in module is skipped" );
-	} );
-
-	QUnit.module( "verifier", function() {
-		QUnit.test( "hooks did not run", function( assert ) {
-			assert.equal( ranBeforeHook, 0, "before hook did not run" );
-			assert.equal( ranAfterHook, 0, "after hook did not run" );
-		} );
-	} );
+QUnit.module( "before/after with all tests skipped", {
+	before: function( assert ) {
+		assert.ok( false, "should not occur" );
+	},
+	after: function( assert ) {
+		assert.ok( false, "should not occur" );
+	}
 } );
+
+QUnit.skip( "verifier" );
 
 QUnit.module( "Test context object", {
 	beforeEach: function( assert ) {

--- a/test/main/modules.js
+++ b/test/main/modules.js
@@ -120,7 +120,6 @@ QUnit.module( "before/after with all tests skipped (wrapper)", function() {
 
 	QUnit.module( "verifier", function() {
 		QUnit.test( "hooks did not run", function( assert ) {
-			assert.expect( 2 );
 			assert.equal( ranBeforeHook, 0, "before hook did not run" );
 			assert.equal( ranAfterHook, 0, "after hook did not run" );
 		} );


### PR DESCRIPTION
When the first/last test in a module was skipped, it would cause the module's
before()/after() hook to not be called. This ensures those hooks will always be
called.