### PR TITLE
Core: extractStacktrace removes config.projectPath from lines.

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -51,7 +51,11 @@ const config = {
 	callbacks: {},
 
 	// The storage module to use for reordering tests
-	storage: localSessionStorage
+	storage: localSessionStorage,
+
+	// Project path. If set, the first occurrence on each line of the stack trace
+	// will be removed. Serves to clean up the output. This is it's only use.
+	projectPath: undefined
 };
 
 // take a predefined QUnit.config and extend the defaults

--- a/src/core/stacktrace.js
+++ b/src/core/stacktrace.js
@@ -1,3 +1,5 @@
+import config from "./config";
+
 // Doesn't support IE9, it will return undefined on these browsers
 // See also https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error/Stack
 var fileName = ( sourceFromStacktrace( 0 ) || "" )
@@ -7,7 +9,7 @@ var fileName = ( sourceFromStacktrace( 0 ) || "" )
 export function extractStacktrace( e, offset ) {
 	offset = offset === undefined ? 4 : offset;
 
-	var stack, include, i;
+	var stack, include, includeLine, i;
 
 	if ( e && e.stack ) {
 		stack = e.stack.split( "\n" );
@@ -20,7 +22,13 @@ export function extractStacktrace( e, offset ) {
 				if ( stack[ i ].indexOf( fileName ) !== -1 ) {
 					break;
 				}
-				include.push( stack[ i ] );
+				includeLine = stack[ i ];
+				if ( config.projectPath ) {
+
+					// replace on each line separately so only one occurence per line is replaced
+					includeLine = includeLine.replace( config.projectPath, "" );
+				}
+				include.push( includeLine );
 			}
 			if ( include.length ) {
 				return include.join( "\n" );


### PR DESCRIPTION
I added a config option config.projectPath: string, which is removed from stack traces in extractStacktrace in order to clean up the output. e.g. config.projectPath = "http://localhost:12345/".

Is there any interest in pulling this?