### PR TITLE
Assert: Introduce timeout to set per-test timeout durations

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -165,6 +165,7 @@ module.exports = function( grunt ) {
 				"test/main/test",
 				"test/main/assert",
 				"test/main/assert/step",
+				"test/main/assert/timeout",
 				"test/main/async",
 				"test/main/promise",
 				"test/main/modules",

--- a/docs/assert/timeout.md
+++ b/docs/assert/timeout.md
@@ -1,0 +1,46 @@
+---
+layout: default
+title: timeout
+description: Sets the length of time to wait for async operations before failing the test.
+categories:
+  - assert
+  - async
+---
+
+## `timeout( duration )`
+
+Sets the length of time to wait for async operations before failing the test.
+
+| name | description |
+|------|-------------|
+| `duration` (Number) | The length of time, in milliseconds, to wait for async operations. |
+
+### Description
+
+`assert.timeout()` sets the length of time, in milliseconds, to wait for async operations in the current test. This is equivalent to setting `config.testTimeout` on a per-test basis. The timeout length only applies when performing async operations.
+
+If `0` is passed, then the test will be assumed to be completely synchronous. If a non-numeric value is passed as an argument, the function will throw an error.
+
+### Examples
+
+```js
+QUnit.test( "Waiting for focus event", function( assert ) {
+  assert.timeout( 1000 ); // Timeout of 1 second
+  var done = assert.async();
+  var input = $( "#test-input" ).focus();
+  setTimeout(function() {
+    assert.equal( document.activeElement, input[0], "Input was focused" );
+    done();
+  });
+});
+```
+
+```js
+QUnit.test( "Waiting for async function", function( assert ) {
+  assert.timeout( 500 ); // Timeout of .5 seconds
+  var promise = asyncFunction();
+  return promise.then( function( result ) {
+    assert.ok( result );
+  } );
+});
+```

--- a/src/assert.js
+++ b/src/assert.js
@@ -14,6 +14,14 @@ class Assert {
 
 	// Assert helpers
 
+	timeout( duration ) {
+		if ( typeof duration !== "number" ) {
+			throw new Error( "You must pass a number as the duration to assert.timeout" );
+		}
+
+		this.test.timeout = duration;
+	}
+
 	// Documents a "step", which is a string value, in a test as a passing assertion
 	step( message ) {
 		const result = !!message;

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -13,5 +13,8 @@
 	"globals": {
 		"QUnit": false,
 		"console": false
+	},
+	"rules": {
+		"max-len": "off"
 	}
 }

--- a/test/index.html
+++ b/test/index.html
@@ -8,6 +8,7 @@
 	<script src="main/test.js"></script>
 	<script src="main/assert.js"></script>
 	<script src="main/assert/step.js"></script>
+	<script src="main/assert/timeout.js"></script>
 	<script src="main/async.js"></script>
 	<script src="main/promise.js"></script>
 	<script src="main/dump.js"></script>

--- a/test/main/assert/timeout.js
+++ b/test/main/assert/timeout.js
@@ -1,0 +1,101 @@
+QUnit.module( "assert.timeout", function() {
+	QUnit.test( "pushes a failure if test times out when using async", function( assert ) {
+		assert.timeout( 10 );
+		assert.expect( 1 );
+
+		var originalPushFailure = QUnit.config.current.pushFailure;
+		QUnit.config.current.pushFailure = function pushFailureStub( message ) {
+			QUnit.config.current.pushFailure = originalPushFailure;
+
+			assert.equal( message, "Test took longer than 10ms; test timed out." );
+		};
+
+		assert.async();
+	} );
+
+	QUnit.test( "pushes a failure if test times out when using a promise", function( assert ) {
+		assert.timeout( 10 );
+		assert.expect( 1 );
+
+		var originalPushFailure = QUnit.config.current.pushFailure;
+		QUnit.config.current.pushFailure = function pushFailureStub( message ) {
+			QUnit.config.current.pushFailure = originalPushFailure;
+
+			assert.equal( message, "Test took longer than 10ms; test timed out." );
+		};
+
+		// Return a "thenable" to serve as a mock Promise
+		return {
+			then: function() {}
+		};
+	} );
+
+	QUnit.test( "does not push a failure if test is synchronous", function( assert ) {
+		assert.timeout( 1 );
+
+		var wait = Date.now() + 10;
+		while ( Date.now() < wait ) {}
+
+		assert.ok( true );
+	} );
+
+	QUnit.test( "throws an error if a non-numeric value is passed as duration", function( assert ) {
+		assert.throws( function() {
+			assert.timeout( null );
+		}, /You must pass a number as the duration to assert.timeout/ );
+	} );
+
+	QUnit.module( "a value of zero", function() {
+		function stubPushFailure( assert ) {
+			var originalPushFailure = QUnit.config.current.pushFailure;
+			QUnit.config.current.pushFailure = function pushFailureStub( message ) {
+				QUnit.config.current.pushFailure = originalPushFailure;
+
+				assert.equal(
+					message,
+					"Test did not finish synchronously even though assert.timeout( 0 ) was used."
+				);
+			};
+		}
+
+		QUnit.test( "does not fail a synchronous test using assert.async", function( assert ) {
+			assert.timeout( 0 );
+			var done = assert.async();
+			assert.ok( true );
+			done();
+		} );
+
+		QUnit.test( "fails a test using assert.async and a setTimeout of 0", function( assert ) {
+			assert.timeout( 0 );
+			assert.expect( 1 );
+
+			stubPushFailure( assert );
+
+			var done = assert.async();
+			setTimeout( done, 0 );
+		} );
+
+		if ( typeof Promise !== "undefined" ) {
+			QUnit.test( "fails a test returning an immediately resolved Promise", function( assert ) {
+				assert.timeout( 0 );
+				assert.expect( 1 );
+
+				stubPushFailure( assert );
+
+				return Promise.resolve();
+			} );
+
+			QUnit.test( "fails a test using assert.async and an immediately resolved Promise", function( assert ) {
+				assert.timeout( 0 );
+				assert.expect( 1 );
+
+				stubPushFailure( assert );
+
+				var done = assert.async();
+				Promise.resolve().then( done );
+			} );
+		}
+	} );
+} );
+
+


### PR DESCRIPTION
As discussed in https://github.com/qunitjs/qunit/issues/1132.

This makes it easy to set per-test timeouts, instead of the globally configured `QUnit.config.testTimeout`.