### PR TITLE
Build: Fix grunt watch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -173,7 +173,7 @@ module.exports = function( grunt ) {
 				"test/node/storage-2"
 			]
 		},
-		watch: {
+		"watch-repeatable": {
 			options: {
 				atBegin: true,
 				spawn: false,
@@ -187,7 +187,7 @@ module.exports = function( grunt ) {
 				"src/qunit.css",
 				"test/**/*.html"
 			],
-			tasks: "default"
+			tasks: [ "build", "test-in-watch" ]
 		},
 
 		instrument: {
@@ -235,8 +235,9 @@ module.exports = function( grunt ) {
 
 	grunt.loadTasks( "build/tasks" );
 	grunt.registerTask( "build", [ "rollup:src", "copy:src-js", "copy:src-css" ] );
-	grunt.registerTask( "qunit-test", [ "connect", "qunit" ] );
-	grunt.registerTask( "test", [ "eslint", "search", "test-on-node", "qunit-test" ] );
+	grunt.registerTask( "test-base", [ "eslint", "search", "test-on-node" ] );
+	grunt.registerTask( "test", [ "test-base", "connect", "qunit" ] );
+	grunt.registerTask( "test-in-watch", [ "test-base", "qunit" ] );
 	grunt.registerTask( "coverage", [
 		"build",
 		"instrument",
@@ -248,6 +249,12 @@ module.exports = function( grunt ) {
 		"makeReport",
 		"coveralls"
 	] );
+
+	// Start the web server in a watch pre-task
+	// https://github.com/gruntjs/grunt-contrib-watch/issues/50
+	grunt.renameTask( "watch", "watch-repeatable" );
+	grunt.registerTask( "watch", [ "connect", "watch-repeatable" ] );
+
 	grunt.registerTask( "default", [ "build", "test" ] );
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,8 @@ module.exports = function( grunt ) {
 			server: {
 				options: {
 					port: 8000,
-					base: "."
+					base: ".",
+					livereload: true
 				}
 			}
 		},
@@ -177,7 +178,8 @@ module.exports = function( grunt ) {
 			options: {
 				atBegin: true,
 				spawn: false,
-				interrupt: true
+				interrupt: true,
+				livereload: true
 			},
 			files: [
 				".eslintrc.json",
@@ -185,8 +187,12 @@ module.exports = function( grunt ) {
 				"build/*.js",
 				"{src,test,reporter}/**/*.js",
 				"src/qunit.css",
+				"test/*.{html,js}",
 				"test/**/*.html"
 			],
+
+			// TODO insert a new task to prompt reloads between "build" and "test-in-watch"
+			// https://github.com/gruntjs/grunt-contrib-watch/issues/186#issuecomment-72180420
 			tasks: [ "build", "test-in-watch" ]
 		},
 


### PR DESCRIPTION
https://gitter.im/qunitjs/qunit?at=58f961fecfec9192725cf2f6
> `grunt watch` will run the tests in node, but I'm pretty sure it won't reload them in any open browser windows (and in fact the webserver aspect appears to be partially broken, I'm seeing a new port claimed every time a watched file changes)