### PR TITLE
Build: Improve watch and livereload tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -191,8 +191,7 @@ module.exports = function( grunt ) {
 			options: {
 				atBegin: true,
 				spawn: false,
-				interrupt: true,
-				livereload: true
+				interrupt: true
 			},
 			files: [
 				".eslintrc.json",
@@ -203,10 +202,7 @@ module.exports = function( grunt ) {
 				"test/*.{html,js}",
 				"test/**/*.html"
 			],
-
-			// TODO insert a new task to prompt reloads between "build" and "test-in-watch"
-			// https://github.com/gruntjs/grunt-contrib-watch/issues/186#issuecomment-72180420
-			tasks: [ "build", "test-in-watch" ]
+			tasks: [ "build", "livereload", "test-in-watch" ]
 		},
 
 		instrument: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,8 +10,9 @@ var reportDir = "build/report";
 var HAS_ASYNC_FUNCTIONS = semver.satisfies( process.version, ">= 7.10" );
 
 module.exports = function( grunt ) {
+	var livereloadPort = grunt.option( "livereload-port" ) || 35729;
 
-// Load grunt tasks from NPM packages
+	// Load grunt tasks from NPM packages
 	require( "load-grunt-tasks" )( grunt );
 
 	function preprocess( code ) {
@@ -31,7 +32,7 @@ module.exports = function( grunt ) {
 				options: {
 					port: 8000,
 					base: ".",
-					livereload: true
+					livereload: livereloadPort
 				}
 			}
 		},
@@ -203,6 +204,12 @@ module.exports = function( grunt ) {
 				"test/**/*.html"
 			],
 			tasks: [ "build", "livereload", "test-in-watch" ]
+		},
+
+		livereload: {
+			options: {
+				port: livereloadPort
+			}
 		},
 
 		instrument: {

--- a/build/tasks/livereload.js
+++ b/build/tasks/livereload.js
@@ -5,12 +5,13 @@ var server;
 module.exports = function( grunt ) {
 	grunt.registerTask( "livereload", function() {
 		if ( !server ) {
+			var port = this.options().port;
 			server = livereload();
-			server.listen( 35729, function() {
-				console.log( "Livereload server listening on port 35729" );
+			server.listen( port, function() {
+				console.log( "Livereload server listening on port " + port );
 			} );
 		}
 
-		server.changed( { body: { files: [ "qunit.js" ] } } );
+		server.changed( { body: { files: [ "file-path-does-not-matter.js" ] } } );
 	} );
 };

--- a/build/tasks/livereload.js
+++ b/build/tasks/livereload.js
@@ -1,0 +1,16 @@
+/* eslint-env node */
+var livereload = require( "tiny-lr" );
+var server;
+
+module.exports = function( grunt ) {
+	grunt.registerTask( "livereload", function() {
+		if ( !server ) {
+			server = livereload();
+			server.listen( 35729, function() {
+				console.log( "Livereload server listening on port 35729" );
+			} );
+		}
+
+		server.changed( { body: { files: [ "qunit.js" ] } } );
+	} );
+};

--- a/build/tasks/test-on-node.js
+++ b/build/tasks/test-on-node.js
@@ -2,7 +2,6 @@
 "use strict";
 
 var async = require( "async" );
-var path = require( "path" );
 
 module.exports = function( grunt ) {
 	grunt.registerMultiTask( "test-on-node", function() {
@@ -64,21 +63,24 @@ module.exports = function( grunt ) {
 		].join( "" );
 	}
 
+	function requireFresh( path ) {
+		var resolvedPath = require.resolve( path );
+		delete require.cache[ resolvedPath ];
+		return require( path );
+	}
+
 	function runQUnit( file, runEnd ) {
 
 		// Resolve current QUnit path and remove it from the require cache
 		// to avoid stacking the QUnit logs.
-		var QUnitFile = path.resolve( __dirname, "../../dist/qunit.js" );
-		delete require.cache[ QUnitFile ];
-
-		var QUnit = require( QUnitFile );
+		var QUnit = requireFresh( "../../dist/qunit" );
 
 		// Expose QUnit to the global scope to be seen on the other tests.
 		global.QUnit = QUnit;
 
 		QUnit.config.autostart = false;
 
-		require( "../../" + file );
+		requireFresh( "../../" + file );
 
 		registerEvents( QUnit, file, runEnd );
 


### PR DESCRIPTION
Continues https://github.com/qunitjs/qunit/pull/1167.

After this, you can run `grunt watch` and then visit the tests in a browser at `localhost:8000/test`. Whenever you make a file change, the browser will reload. However, `watch` only restarts after the currently executing task finishes, so if you're on the `qunit` task, it may be a bit slow.