### PR TITLE
Core: Updates for Node.js version 8 compatibility and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "4"
   - "6"
   - "7"
+  - "8"
 env:
   - NPM_SCRIPT=test
   - NPM_SCRIPT=test:cli

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "7"
+    - nodejs_version: "8"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
   },
   "main": "qunit/qunit.js",
   "engines": {
-    "node": "4.* || 6.* || 7.*"
+    "node": ">=4"
   }
 }


### PR DESCRIPTION
Add node 8 to travis and appveyor, change engines list to >=4.