### PR TITLE
Core: Add support for multiple hooks

### DIFF
--- a/docs/QUnit/module.md
+++ b/docs/QUnit/module.md
@@ -29,11 +29,11 @@ Group related tests under a single label.
 
 #### Nested module: `nested( hooks )`
 
-A callback with grouped tests and nested modules to run under the current module label.
+A callback which groups tests and nested modules to run under the current module label.
 
 | name | description |
 |-----------|-------------|
-| `hooks` (object) | Runs before the first test. |
+| `hooks` (object) | An object with functions to define `before`/`beforeEach`/`afterEach`/`after` hooks. |
 
 ### Description
 
@@ -199,10 +199,12 @@ QUnit.test( "makes a car", function( assert ) {
 
 ---
 
-Hooks stack on nested modules
+`before`/`beforeEach` hooks queue on nested modules. `after`/`afterEach` hooks stack on nested modules.
 
 ```js
 QUnit.module( "grouped tests argument hooks", function( hooks ) {
+
+  // You can invoke the hooks methods more than once.
   hooks.beforeEach( function( assert ) {
     assert.ok( true, "beforeEach called" );
   } );

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -46,7 +46,13 @@ const config = {
 		tests: [],
 		childModules: [],
 		testsRun: 0,
-		unskippedTestsRun: 0
+		unskippedTestsRun: 0,
+		hooks: {
+			before: [],
+			beforeEach: [],
+			afterEach: [],
+			after: []
+		}
 	},
 
 	callbacks: {},

--- a/test/main/modules.js
+++ b/test/main/modules.js
@@ -384,3 +384,38 @@ QUnit.module( "nested modules before/after", {
 		} );
 	} );
 } );
+
+QUnit.module( "modules with multiple hooks", function( hooks ) {
+	hooks.before( function( assert ) { assert.step( "before1" ); } );
+	hooks.before( function( assert ) { assert.step( "before2" ); } );
+
+	hooks.beforeEach( function( assert ) { assert.step( "beforeEach1" ); } );
+	hooks.beforeEach( function( assert ) { assert.step( "beforeEach2" ); } );
+
+	hooks.afterEach( function( assert ) { assert.step( "afterEach1" ); } );
+	hooks.afterEach( function( assert ) { assert.step( "afterEach2" ); } );
+
+	hooks.after( function( assert ) {
+		assert.verifySteps( [
+
+			// before/beforeEach execute in FIFO order
+			"before1",
+			"before2",
+			"beforeEach1",
+			"beforeEach2",
+
+			// after/afterEach execute in LIFO order
+			"afterEach2",
+			"afterEach1",
+			"after2",
+			"after1"
+		] );
+	} );
+
+	hooks.after( function( assert ) { assert.step( "after1" ); } );
+	hooks.after( function( assert ) { assert.step( "after2" ); } );
+
+	QUnit.test( "all hooks", function( assert ) {
+		assert.expect( 9 );
+	} );
+} );


### PR DESCRIPTION
Fixes #977.

When using the nested module pattern, you can now define a multiple of each hook (`before`/`beforeEach`/`afterEach`/`after`). `before`/`beforeEach` hooks are run FIFO order and `after`/`afterEach` are run in LIFO order. This is consistent with the behavior already exhibited by those hooks when nested in modules.

cc @rwjblue (who I believe is interested in this feature for ember-qunit).