### PR TITLE
CLI: Better handle various failure scenarios

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -12,6 +12,10 @@ const IGNORED_GLOBS = [
 let QUnit;
 
 function run( args, options ) {
+
+	// Default to non-zero exit code to avoid false positives
+	process.exitCode = 1;
+
 	const files = utils.getFilesFromArgs( args );
 
 	QUnit = requireQUnit();

--- a/bin/run.js
+++ b/bin/run.js
@@ -48,6 +48,9 @@ function run( args, options ) {
 	QUnit.on( "runEnd", function setExitCode( data ) {
 		if ( data.testCounts.failed ) {
 			process.exitCode = 1;
+		} else if ( data.testCounts.total === 0 ) {
+			console.error( "Error: No tests were run" );
+			process.exitCode = 1;
 		} else {
 			process.exitCode = 0;
 		}

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -80,5 +80,11 @@ ok 5 A-Test > derp
 	"qunit --reporter does-not-exist": `No reporter found matching "does-not-exist".
 Available reporters from JS Reporters are: console, tap
 Available custom reporters from dependencies are: npm-reporter
+`,
+
+	/* eslint-disable max-len */
+	"qunit hanging-test": `Error: Process exited before tests finished running
+Last test to run (hanging) has an async hold. Ensure all assert.async() callbacks are invoked and Promises resolve. You should also set a standard timeout via QUnit.config.testTimeout.
 `
+	/* eslint-enable max-len */
 };

--- a/test/cli/fixtures/hanging-test/index.js
+++ b/test/cli/fixtures/hanging-test/index.js
@@ -1,0 +1,3 @@
+QUnit.test( "hanging", function( assert ) {
+	assert.async();
+} );

--- a/test/cli/fixtures/no-tests/index.js
+++ b/test/cli/fixtures/no-tests/index.js
@@ -1,0 +1,1 @@
+// This test file has no tests!

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -85,6 +85,16 @@ QUnit.module( "CLI Main", function() {
 		}
 	} ) );
 
+	QUnit.test( "exit code is 1 when no tests exit before done", co.wrap( function* ( assert ) {
+		const command = "qunit hanging-test";
+		try {
+			yield execute( command );
+		} catch ( e ) {
+			assert.equal( e.code, 1 );
+			assert.equal( e.stderr, expectedOutput[ command ] );
+		}
+	} ) );
+
 	QUnit.module( "filter", function() {
 		QUnit.test( "can properly filter tests", co.wrap( function* ( assert ) {
 			const command = "qunit --filter 'single' test single.js 'glob/**/*-test.js'";

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -76,6 +76,15 @@ QUnit.module( "CLI Main", function() {
 		}
 	} ) );
 
+	QUnit.test( "exit code is 1 when no tests are run", co.wrap( function* ( assert ) {
+		try {
+			yield execute( "qunit no-tests" );
+		} catch ( e ) {
+			assert.equal( e.code, 1 );
+			assert.equal( e.stderr, "Error: No tests were run\n" );
+		}
+	} ) );
+
 	QUnit.module( "filter", function() {
 		QUnit.test( "can properly filter tests", co.wrap( function* ( assert ) {
 			const command = "qunit --filter 'single' test single.js 'glob/**/*-test.js'";


### PR DESCRIPTION
Addressing some of the feedback from https://github.com/qunitjs/qunit/issues/1132.

After this PR, the only remaining item from that issue would be to change the default for `testTimeout` which we won't be able to do until `3.0`.