### PR TITLE
Build: Register events after requiring test file in test-on-node task

### DIFF
--- a/build/tasks/test-on-node.js
+++ b/build/tasks/test-on-node.js
@@ -76,11 +76,11 @@ module.exports = function( grunt ) {
 		// Expose QUnit to the global scope to be seen on the other tests.
 		global.QUnit = QUnit;
 
-		registerEvents( QUnit, file, runEnd );
-
 		QUnit.config.autostart = false;
 
 		require( "../../" + file );
+
+		registerEvents( QUnit, file, runEnd );
 
 		QUnit.start();
 	}


### PR DESCRIPTION
I came across this issue while working on implementing/testing `QUnit.module.skip`.

The issue basically was that a test (In my case, I have a test inside a `QUnit.done` callback) from a previous file was caught by `testDone` callback of the current file.

This happens because the callback `QUnit.done` defined in `test-on-node` task will be the first one to be called which will pass to test the next file without waiting for other `QUnit.done` callbacks, in case there are any, to finish their treatments.