### PR TITLE
Tests: Add tests using native async functions.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,16 +2,19 @@
 
 var path = require( "path" );
 var fs = require( "fs-extra" );
+var semver = require( "semver" );
 
 var instrumentedDir = "build/instrumented";
 var reportDir = "build/report";
+
+var HAS_ASYNC_FUNCTIONS = semver.satisfies( process.version, ">= 7.10" );
 
 module.exports = function( grunt ) {
 
 // Load grunt tasks from NPM packages
 	require( "load-grunt-tasks" )( grunt );
 
-	function process( code ) {
+	function preprocess( code ) {
 		return code
 
 		// Embed version
@@ -33,7 +36,7 @@ module.exports = function( grunt ) {
 			}
 		},
 		copy: {
-			options: { process: process },
+			options: { process: preprocess },
 
 			"src-js": {
 				src: "dist/qunit.js",
@@ -174,8 +177,9 @@ module.exports = function( grunt ) {
 				"test/main/dump",
 				"test/node/storage-1",
 				"test/node/storage-2",
-				"test/module-only"
-			]
+				"test/module-only",
+				HAS_ASYNC_FUNCTIONS ? "test/es2017/async-functions" : null
+			].filter( Boolean )
 		},
 		"watch-repeatable": {
 			options: {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "npm-reporter": "file:./test/cli/fixtures/npm-reporter",
     "proxyquire": "1.7.11",
     "requirejs": "2.3.2",
-    "rollup-plugin-babel": "2.6.1"
+    "rollup-plugin-babel": "2.6.1",
+    "semver": "5.3.0"
   },
   "scripts": {
     "browserstack": "grunt build && sh build/run-browserstack.sh",

--- a/test/es2017/.eslintrc.json
+++ b/test/es2017/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+		"parserOptions": {
+				"ecmaVersion": 2017
+		}
+}

--- a/test/es2017/async-functions.js
+++ b/test/es2017/async-functions.js
@@ -1,0 +1,34 @@
+QUnit.module( "modules with async hooks", function( hooks ) {
+	hooks.before( async function( assert ) { assert.step( "before" ); } );
+	hooks.beforeEach( async function( assert ) { assert.step( "beforeEach" ); } );
+	hooks.afterEach( async function( assert ) { assert.step( "afterEach" ); } );
+
+	hooks.after( function( assert ) {
+		assert.verifySteps( [
+			"before",
+			"beforeEach",
+			"afterEach"
+		] );
+	} );
+
+	QUnit.test( "all hooks", function( assert ) {
+		assert.expect( 4 );
+	} );
+} );
+
+QUnit.module( "before/beforeEach/afterEach/after", {
+	before: async function( assert ) { assert.step( "before" ); },
+	beforeEach: async function( assert ) { assert.step( "beforeEach" ); },
+	afterEach: async function( assert ) { assert.step( "afterEach" ); },
+	after: async function( assert ) {
+		assert.verifySteps( [
+			"before",
+			"beforeEach",
+			"afterEach"
+		] );
+	}
+} );
+
+QUnit.test( "async hooks order", function( assert ) {
+	assert.expect( 4 );
+} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3165,7 +3165,7 @@ safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.1.0, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 


### PR DESCRIPTION
Adds tests ensuring that using async functions for callback arguments is under test.

Closes https://github.com/qunitjs/qunit/issues/1197.

Tested locally in Phantom (which can not parse `async function() {}`) and Chrome (which can). Tests pass in both environment, and in Chrome I verified that the new tests are running.