### PR TITLE
Core: Fallback to `typeof obj` in `QUnit.objectType`.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -165,6 +165,7 @@ module.exports = function( grunt ) {
 				"test/main/modules",
 				"test/main/deepEqual",
 				"test/main/stack",
+				"test/main/utilities",
 				"test/events",
 				"test/events-in-test",
 				"test/onerror/inside-test",

--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -102,10 +102,8 @@ export function objectType( obj ) {
 	case "Function":
 	case "Symbol":
 		return type.toLowerCase();
-	}
-
-	if ( typeof obj === "object" ) {
-		return "object";
+	default:
+		return typeof obj;
 	}
 }
 

--- a/test/index.html
+++ b/test/index.html
@@ -14,6 +14,7 @@
 	<script src="main/modules.js"></script>
 	<script src="main/deepEqual.js"></script>
 	<script src="main/stack.js"></script>
+	<script src="main/utilities.js"></script>
 	<script src="setTimeout.js"></script>
 	<script src="reporter-html/reporter-html.js"></script>
 	<script src="reporter-html/diff.js"></script>

--- a/test/main/utilities.js
+++ b/test/main/utilities.js
@@ -1,0 +1,60 @@
+QUnit.module( "QUnit.objectType" );
+
+function Foo( ) { }
+
+function validateObjectType( item, expected ) {
+	QUnit.test( "should properly detect " + expected, function( assert ) {
+		assert.expect( 1 );
+
+		var actual = QUnit.objectType( item );
+		assert.equal( actual, expected );
+	} );
+}
+
+function maybeValidateObjectType( string, expected ) {
+	try {
+		var value = new Function( "return " + string + ";" )( );
+		validateObjectType( value, expected );
+	} catch ( e ) {
+
+		// do nothing if parsing failed
+		if ( e.name === "SyntaxError" ) {
+			return;
+		}
+
+		// do not hide other errors
+		throw e;
+	}
+}
+
+validateObjectType( 1, "number" );
+validateObjectType( "", "string" );
+validateObjectType( "foo", "string" );
+validateObjectType( null, "null" );
+validateObjectType( true, "boolean" );
+validateObjectType( false, "boolean" );
+validateObjectType( [ ], "array" );
+validateObjectType( new Date( ), "date" );
+validateObjectType( /foo/, "regexp" );
+validateObjectType( NaN, "nan" );
+validateObjectType( undefined, "undefined" );
+validateObjectType( { }, "object" );
+validateObjectType( new Foo( ), "object" );
+
+
+if ( typeof Symbol === "function" ) {
+	validateObjectType( Symbol( "HI!" ), "symbol" );
+}
+
+if ( typeof Map === "function" ) {
+	validateObjectType( new Map( ), "map" );
+}
+
+if ( typeof Set === "function" ) {
+	validateObjectType( new Set( ), "set" );
+}
+
+maybeValidateObjectType( "async function() { }", "function" );
+maybeValidateObjectType( "async () => { }", "function" );
+maybeValidateObjectType( "() => { }", "function" );
+maybeValidateObjectType( "function* { }", "function" );


### PR DESCRIPTION
Prior to these changes, `QUnit.objectType(async function() { });` would return `undefined` (because `Object.prototype.toString.call(async function() {})` equals `[object AsyncFunction])`).

This updates `QUnit.objectType` to fallback to returning `typeof obj` if no match was found, and adds explicit tests for the various expected inputs and outputs.

I discovered during the investigation of #1197 which is failing in qunitjs@2.3.3 due to `QUnit.objectType` not being aware of async functions (but master was fixed by a refactor done in #1188).