### PR TITLE
Core: Allow hooks via `this.hooks` in nested modules.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -93,7 +93,9 @@ function processModule( name, options, executeNow ) {
 	if ( objectType( executeNow ) === "function" ) {
 		moduleStack.push( module );
 		config.currentModule = module;
-		executeNow.call( module.testEnvironment, moduleFns );
+		testEnvironment.hooks = moduleFns;
+		executeNow.call( testEnvironment, moduleFns );
+		delete testEnvironment.hooks;
 		moduleStack.pop();
 		module = module.parentModule || currentModule;
 	}

--- a/test/main/modules.js
+++ b/test/main/modules.js
@@ -419,3 +419,29 @@ QUnit.module( "modules with multiple hooks", function( hooks ) {
 		assert.expect( 9 );
 	} );
 } );
+
+QUnit.module( "modules with hooks added via `this.hooks.*`", function( hooks ) {
+	var hooksMatchesThisHooks = hooks === this.hooks;
+
+	this.hooks.before( function( assert ) { assert.step( "before1" ); } );
+	this.hooks.beforeEach( function( assert ) { assert.step( "beforeEach1" ); } );
+	this.hooks.afterEach( function( assert ) { assert.step( "afterEach1" ); } );
+
+	this.hooks.after( function( assert ) {
+		assert.ok( hooksMatchesThisHooks, "`this.hooks` matches `hooks` argument" );
+		assert.step( "after1" );
+
+		assert.verifySteps( [
+			"before1",
+			"beforeEach1",
+			"afterEach1",
+			"after1"
+		] );
+
+	} );
+
+	QUnit.test( "all hooks", function( assert ) {
+		assert.expect( 7 );
+		assert.equal( this.hooks, undefined );
+	} );
+} );


### PR DESCRIPTION
During review of the new Ember testing RFC (https://github.com/emberjs/rfcs/pull/232) the required `hooks` argument has "raised some eyebrows". 

---

To summarize that RFC proposal briefly, I am proposing that we leverage nested modules as the default and stop wrapping QUnit functionality with our own custom APIs.

Roughly, instead of `moduleFor` (which generates a `QUnit.module` with the proper `beforeEach`/`afterEach` callbacks), we leverage nested modules and provide simpler helper functions that setup the `beforeEach`/`afterEach`:

```js
// before
moduleFor('service:foo');
test(....);

// after
module('service:foo', function(hooks) {
  setupTest(hooks);
});
```

---

Some of the concerns raised during that RFC center around the `hook` object:

* Teaching folks what `hooks` means is a bit more difficult because it does not represent the "test environment", but rather just the hooks.
* Passing only `hooks` to the helper functions proposed in the RFC means that if we ever need to thread more information through, we either have to use `hooks` as a transport or change our API to add more arguments.
* It seems somewhat impossible to communicate across multiple helpers (again without using `hooks` as a state/transport mechanism).


The concerns seemed reasonable, so I figured I'd kick off some discussion here (with a PR adding the functionality that I think would assuage the concerns).

---

Open questions:

- [ ] Should I allow `testEnvironment.hooks` to already be present (e.g. `module('foo', { hooks: 'fishing' }, function(hooks) {})`)? 
- [ ] Do we need any additional test cases (e.g. multiple levels of nesting, interchanging `this.hooks.*` with `hooks.*`, etc)?