### PR TITLE
Core: Release objects from memory in equiv

### DIFF
--- a/src/equiv.js
+++ b/src/equiv.js
@@ -336,5 +336,11 @@ export default ( function() {
 		return arguments.length === 2 || innerEquiv.apply( this, [].slice.call( arguments, 1 ) );
 	}
 
-	return innerEquiv;
+	return ( ...args ) => {
+		const result = innerEquiv( ...args );
+
+		// Release any retained objects
+		pairs.length = 0;
+		return result;
+	};
 }() );


### PR DESCRIPTION
Fixes https://github.com/qunitjs/qunit/issues/1192.

There's likely a better solution here that involves "popping" each element in the array after it has finished being used, but I could not find it (the logic is complex and has multiple return points). I'd like to go with this naive approach for now and refactor later when we update this file to use ES6 syntax.