### PR TITLE
CLI: List available reporters when option is specified with no value

### DIFF
--- a/bin/find-reporter.js
+++ b/bin/find-reporter.js
@@ -6,7 +6,7 @@ const findup = require( "findup-sync" );
 const utils = require( "./utils" );
 const pkg = require( "../package.json" );
 
-module.exports = function findReporter( reporterName ) {
+function findReporter( reporterName ) {
 	if ( !reporterName ) {
 		return JSReporters.TapReporter;
 	}
@@ -33,13 +33,16 @@ module.exports = function findReporter( reporterName ) {
 	displayAvailableReporters( reporterName );
 };
 
-function displayAvailableReporters( input ) {
+function displayAvailableReporters( inputReporterName ) {
+	const message = [];
+
+	if ( inputReporterName ) {
+		message.push( `No reporter found matching "${inputReporterName}".` );
+	}
+
 	const jsReporters = getReportersFromJSReporters();
 
-	const message = [
-		`No reporter found matching "${input}".`,
-		`Available reporters from JS Reporters are: ${jsReporters.join( ", " )}`
-	];
+	message.push( `Available reporters from JS Reporters are: ${jsReporters.join( ", " )}` );
 
 	const npmReporters = getReportersFromDependencies();
 	if ( npmReporters.length ) {
@@ -80,3 +83,8 @@ function getReportersFromDependencies() {
 		return false;
 	} );
 }
+
+module.exports = {
+	findReporter,
+	displayAvailableReporters
+};

--- a/bin/qunit
+++ b/bin/qunit
@@ -4,8 +4,11 @@
 
 const program = require( "commander" );
 const run = require( "./run" );
-const findReporter = require( "./find-reporter" );
+const FindReporter = require( "./find-reporter" );
 const pkg = require( "../package.json" );
+
+const findReporter = FindReporter.findReporter;
+const displayAvailableReporters = FindReporter.displayAvailableReporters;
 
 const description = `Runs tests using the QUnit framework.
 
@@ -20,12 +23,17 @@ program
 	.usage( "[options] [files]" )
 	.description( description )
 	.option( "-f, --filter <filter>", "filter which tests run" )
-	.option( "-r, --reporter <name>", "specify the reporter to use; " +
-		"if no match is found a list of available reporters will be displayed" )
+	.option( "-r, --reporter [name]", "specify the reporter to use; " +
+		"if no match is found or no name is provided, a list of available " +
+		"reporters will be displayed" )
 	.option( "--seed [value]", "specify a seed to order your tests; " +
 		"if option is specified without a value, one will be generated" )
 	.option( "-w, --watch", "Watch files for changes and re-run the test suite" )
 	.parse( process.argv );
+
+if ( program.reporter === true ) {
+	displayAvailableReporters();
+}
 
 const args = program.args;
 const options = {

--- a/test/cli/custom-reporter.js
+++ b/test/cli/custom-reporter.js
@@ -2,7 +2,7 @@ const co = require( "co" );
 const JSReporters = require( "js-reporters" );
 const NPMReporter = require( "npm-reporter" );
 
-const findReporter = require( "../../bin/find-reporter" );
+const findReporter = require( "../../bin/find-reporter" ).findReporter;
 
 const expectedOutput = require( "./fixtures/expected/tap-outputs" );
 const execute = require( "./helpers/execute" );
@@ -29,9 +29,20 @@ QUnit.module( "CLI Reporter", function() {
 		assert.equal( execution.stdout, expectedOutput[ command ] );
 	} ) );
 
-	// eslint-disable-next-line max-len
 	QUnit.test( "exits early and lists available reporters if reporter is not found", co.wrap( function* ( assert ) {
 		const command = "qunit --reporter does-not-exist";
+
+		try {
+			yield execute( command );
+		} catch ( e ) {
+			assert.equal( e.code, 1 );
+			assert.equal( e.stderr, expectedOutput[ command ] );
+			assert.equal( e.stdout, "" );
+		}
+	} ) );
+
+	QUnit.test( "exits early and lists available reporters if reporter option is used with no value", co.wrap( function* ( assert ) {
+		const command = "qunit --reporter";
 
 		try {
 			yield execute( command );

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -82,6 +82,10 @@ Available reporters from JS Reporters are: console, tap
 Available custom reporters from dependencies are: npm-reporter
 `,
 
+	"qunit --reporter": `Available reporters from JS Reporters are: console, tap
+Available custom reporters from dependencies are: npm-reporter
+`,
+
 	/* eslint-disable max-len */
 	"qunit hanging-test": `Error: Process exited before tests finished running
 Last test to run (hanging) has an async hold. Ensure all assert.async() callbacks are invoked and Promises resolve. You should also set a standard timeout via QUnit.config.testTimeout.


### PR DESCRIPTION
Addressing #1216.

When using `qunit --reporter` you will now get a list of available reports displayed. It does not list available reporters when running `qunit --help`. I think it is best to keep the general help command minimal to ensure it stays useful for users.