### PR TITLE
Build: Add my new name to .mailmap, update it in AUTHORS.txt

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -90,3 +90,4 @@ Matthew DuVall <mduvall89@gmail.com>
 Dave K. Smith <dave.k.smith@gmail.com>
 David Vollbracht <david.vollbracht@gmail.com>
 Jochen Ulrich <jochenulrich@t-online.de>
+Michał Gołębiowski-Owczarek <m.goleb@gmail.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -80,7 +80,7 @@ Leonardo Balter <leonardo.balter@gmail.com>
 Jeff Cooper <jeff@kickstorming.com>
 Corey Frang <gnarf37@gmail.com>
 Nathan Dauber <nathan@radialogica.com>
-Michał Gołębiowski <m.goleb@gmail.com>
+Michał Gołębiowski-Owczarek <m.goleb@gmail.com>
 XhmikosR <xhmikosr@yahoo.com>
 Patrick Stapleton <github@gdi2290.com>
 DarkPark <darkpark@pisem.net>


### PR DESCRIPTION
This also unifies my past contributions under one persona - so far I had entries
with 2 different ways to write "ę" which treated me as 2 distinct people.