### PR TITLE
All: Rename package to QUnit

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,7 +42,7 @@ Follow the prompts along the way and you should be all good. This process will c
 You can verify all of the above were correctly published by using the following:
 
 - Bower: `bower info qunit`
-- NPM: `npm view qunitjs`
+- NPM: `npm view qunit`
 - CDN: visit `https://code.jquery.com/qunit/qunit-x.x.x.js`
 
 Additionally, we publish a new `git` version of QUnit after every change, so we should verify that is still working. You can do so by visiting `https://code.jquery.com/qunit/qunit-git.js` and ensuring the version number matches the latest `-pre` version. Note that it may take a couple minutes for this version to update as the build happens.

--- a/bin/require-qunit.js
+++ b/bin/require-qunit.js
@@ -6,7 +6,7 @@ module.exports = function requireQUnit() {
 	try {
 
 		// First we attempt to find QUnit relative to the current working directory.
-		const localQUnitPath = resolve.sync( "qunitjs", { basedir: process.cwd() } );
+		const localQUnitPath = resolve.sync( "qunit", { basedir: process.cwd() } );
 		delete require.cache[ localQUnitPath ];
 		return require( localQUnitPath );
 	} catch ( e ) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "qunitjs",
+  "name": "qunit",
   "title": "QUnit",
   "description": "An easy-to-use JavaScript Unit Testing framework.",
   "version": "2.4.2-pre",

--- a/test/cli/require-qunit-test.js
+++ b/test/cli/require-qunit-test.js
@@ -12,7 +12,7 @@ QUnit.module( "requireQUnit", function() {
 		};
 		const requireQUnit = proxyquire( "../../bin/require-qunit", {
 			"resolve": resolveStub,
-			"qunitjs": localQUnit
+			"qunit": localQUnit
 		} );
 
 		assert.strictEqual( requireQUnit(), localQUnit );
@@ -24,7 +24,7 @@ QUnit.module( "requireQUnit", function() {
 		};
 		const requireQUnit = proxyquire( "../../bin/require-qunit", {
 			"resolve": resolveStub,
-			"qunitjs": null,
+			"qunit": null,
 			"../qunit/qunit": globalQUnit
 		} );
 
@@ -37,7 +37,7 @@ QUnit.module( "requireQUnit", function() {
 		};
 		const requireQUnit = proxyquire( "../../bin/require-qunit", {
 			"resolve": resolveStub,
-			"qunitjs": null,
+			"qunit": null,
 			"../qunit/qunit": null,
 			"../dist/qunit": devQUnit
 		} );
@@ -48,7 +48,7 @@ QUnit.module( "requireQUnit", function() {
 	QUnit.test( "throws error if none of the modules are found", function( assert ) {
 		const requireQUnit = proxyquire( "../../bin/require-qunit", {
 			"resolve": resolveStub,
-			"qunitjs": null,
+			"qunit": null,
 			"../qunit/qunit": null,
 			"../dist/qunit": null
 		} );


### PR DESCRIPTION
First step of fixing https://github.com/qunitjs/node-qunit/issues/136.

After merging, I will manually do another 2.4.1 release under the `qunit` package name, so that users can migrate directly from `qunitjs@2.4.1` to `qunit@2.4.1`. Then, we will deprecate `qunitjs@2.4.1` with a message stating that users should switch to the `qunit` package.

All future releases will then be under the `qunit` name.

As for the current `qunit` package, we will be switching that to be released as `node-qunit`. I've reached out to the owner of the current `node-qunit` package (which is deprecated) and he is fine with us taking over the name.