### PR TITLE
Ensure `notrycatch` avoids installing rejection handler.

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -489,23 +489,27 @@ Test.prototype = {
 			then = promise.then;
 			if ( objectType( then ) === "function" ) {
 				resume = internalStop( test );
-				then.call(
-					promise,
-					function() { resume(); },
-					function( error ) {
-						message = "Promise rejected " +
-							( !phase ? "during" : phase.replace( /Each$/, "" ) ) +
-							" \"" + test.testName + "\": " +
-							( ( error && error.message ) || error );
-						test.pushFailure( message, extractStacktrace( error, 0 ) );
+				if ( config.notrycatch ) {
+					then.call( promise, function() { resume(); } );
+				} else {
+					then.call(
+						promise,
+						function() { resume(); },
+						function( error ) {
+							message = "Promise rejected " +
+								( !phase ? "during" : phase.replace( /Each$/, "" ) ) +
+								" \"" + test.testName + "\": " +
+								( ( error && error.message ) || error );
+							test.pushFailure( message, extractStacktrace( error, 0 ) );
 
-						// Else next test will carry the responsibility
-						saveGlobal();
+							// Else next test will carry the responsibility
+							saveGlobal();
 
-						// Unblock
-						resume();
-					}
-				);
+							// Unblock
+							resume();
+						}
+					);
+				}
 			}
 		}
 	},

--- a/test/cli/fixtures/notrycatch/returns-rejection.js
+++ b/test/cli/fixtures/notrycatch/returns-rejection.js
@@ -1,0 +1,20 @@
+"use strict";
+
+process.on( "unhandledRejection", ( reason ) => {
+	console.log( "Unhandled Rejection:", reason );
+} );
+
+QUnit.module( "notrycatch", function( hooks ) {
+	hooks.beforeEach( function() {
+		this.originalNotrycatch = QUnit.config.notrycatch;
+		QUnit.config.notrycatch = true;
+	} );
+
+	hooks.afterEach( function() {
+		QUnit.config.notrycatch = this.originalNotrycatch;
+	} );
+
+	QUnit.test( "returns a rejected promise", function() {
+		return Promise.reject( "bad things happen sometimes" );
+	} );
+} );

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -127,4 +127,21 @@ QUnit.module( "CLI Main", function() {
 			assert.equal( execution.stdout, expectedOutput[ command ] );
 		} ) );
 	} );
+
+	QUnit.module( "notrycatch", function() {
+		QUnit.test( "errors if notrycatch is used and a rejection occurs", co.wrap( function* ( assert ) {
+			assert.expect( 1 );
+
+			try {
+				yield execute( "qunit notrycatch/returns-rejection.js" );
+			} catch ( e ) {
+				assert.pushResult( {
+
+					// only in stdout due to using `console.log` in manual `unhandledRejection` handler
+					result: e.stdout.indexOf( "Unhandled Rejection: bad things happen sometimes" ) > -1,
+					actual: e.stdout + "\n" + e.stderr
+				} );
+			}
+		} ) );
+	} );
 } );


### PR DESCRIPTION
Avoid adding a rejection handler when `notrycatch` is set. This enables much nicer "break on uncaught" exception ergonomics.

As suggested in #1154, I added the failing test to the set of tests that only run on node. However, I did not add an `unhandledRejection` handler due to the deprecation added in Node 7 which suggests that a future Node version will `process.exit(1)` for unhandled rejections (ultimately meaning any tests we build around it will need to be refactored). Instead, I used the CLI test system to execute a test file with `notrycatch` set and ensured that the rejection reason ended up in the processes stderr.  I also confirmed that the test fails before the changes in `src/test.js` (due to the `stderr` output being empty) and passes after.

I took care to preserve @NaridaL's original commit from #1154 (only modifying it in order to rebase), then added a follow up commit with the requested tests.

Fixes #1149
Originally from #1154 