### PR TITLE
Ensure unhandled rejections cause test failure.

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -33,6 +33,11 @@ function run( args, options ) {
 		}
 	} );
 
+	// Listen for unhandled rejections, and call QUnit.onError.
+	process.on( "unhandledRejection", function( reason ) {
+		QUnit.onError( reason );
+	} );
+
 	const files = utils.getFilesFromArgs( args );
 
 	QUnit = requireQUnit();

--- a/bin/run.js
+++ b/bin/run.js
@@ -33,9 +33,9 @@ function run( args, options ) {
 		}
 	} );
 
-	// Listen for unhandled rejections, and call QUnit.onError.
+	// Listen for unhandled rejections, and call QUnit.onUnhandledRejection
 	process.on( "unhandledRejection", function( reason ) {
-		QUnit.onError( reason );
+		QUnit.onUnhandledRejection( reason );
 	} );
 
 	const files = utils.getFilesFromArgs( args );

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -979,5 +979,4 @@ export function escapeText( s ) {
 
 		return ret;
 	};
-
 }() );

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -980,8 +980,8 @@ export function escapeText( s ) {
 		return ret;
 	};
 
-	// Listen for unhandled rejections, and call QUnit.onError.
+	// Listen for unhandled rejections, and call QUnit.onUnhandledRejection
 	window.addEventListener( "unhandledrejection", function( event ) {
-		QUnit.onError( event.reason );
+		QUnit.onUnhandledRejection( event.reason );
 	} );
 }() );

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -979,4 +979,9 @@ export function escapeText( s ) {
 
 		return ret;
 	};
+
+	// Listen for unhandled rejections, and call QUnit.onError.
+	window.addEventListener( "unhandledrejection", function( event ) {
+		QUnit.onError( event.reason );
+	} );
 }() );

--- a/src/core.js
+++ b/src/core.js
@@ -16,6 +16,7 @@ import SuiteReport from "./reports/suite";
 
 import { on, emit } from "./events";
 import onError from "./core/onerror";
+import onUnhandledRejection from "./core/on-unhandled-rejection";
 
 let focused = false;
 const QUnit = {};
@@ -251,7 +252,9 @@ extend( QUnit, {
 		return sourceFromStacktrace( offset );
 	},
 
-	onError
+	onError,
+
+	onUnhandledRejection
 } );
 
 QUnit.pushFailure = pushFailure;

--- a/src/core/on-unhandled-rejection.js
+++ b/src/core/on-unhandled-rejection.js
@@ -2,6 +2,7 @@ import { test } from "../test";
 
 import config from "./config";
 import { extend } from "./utilities";
+import { sourceFromStacktrace } from "./stacktrace";
 
 // Handle an unhandled rejection
 export default function onUnhandledRejection( reason ) {
@@ -9,7 +10,7 @@ export default function onUnhandledRejection( reason ) {
 		result: false,
 		message: reason.message || "error",
 		actual: reason,
-		source: reason.stack
+		source: reason.stack || sourceFromStacktrace( 3 )
 	};
 
 	const currentTest = config.current;

--- a/src/core/on-unhandled-rejection.js
+++ b/src/core/on-unhandled-rejection.js
@@ -1,0 +1,24 @@
+import { test } from "../test";
+
+import config from "./config";
+import { extend } from "./utilities";
+
+// Handle an unhandled rejection
+export default function onUnhandledRejection( reason ) {
+	const resultInfo = {
+		result: false,
+		message: reason.message || "error",
+		actual: reason,
+		source: reason.stack
+	};
+
+	const currentTest = config.current;
+	if ( currentTest ) {
+		currentTest.assert.pushResult( resultInfo );
+	} else {
+		test( "global failure", extend( function( assert ) {
+			assert.pushResult( resultInfo );
+		}, { validTest: true } ) );
+	}
+}
+

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Expected outputs from the TapReporter for the commands run in CLI tests
 module.exports = {
 	"qunit":
@@ -97,21 +99,25 @@ not ok 1 Unhandled Rejections > test passes just fine, but has a rejected promis
   ---
   message: "Error thrown in non-returned promise!"
   severity: failed
-  actual: {}
+  actual: {
+  "message": "Error thrown in non-returned promise!",
+  "stack": "Error: Error thrown in non-returned promise!\\n    at /some/path/wherever/unhandled-rejection.js:13:11"
+}
   expected: undefined
   stack: Error: Error thrown in non-returned promise!
-    at /Users/rjackson/src/open-source/qunit/test/cli/fixtures/unhandled-rejection.js:13:11
-    at <anonymous>
+    at /some/path/wherever/unhandled-rejection.js:13:11
   ...
 not ok 2 global failure
   ---
   message: "outside of a test context"
   severity: failed
   actual: {
-  "message": "outside of a test context"
+  "message": "outside of a test context",
+  "stack": "Error: outside of a test context\\n    at Object.<anonymous> (/some/path/wherever/unhandled-rejection.js:20:18)"
 }
   expected: undefined
-  stack:     at runTest (/Users/rjackson/src/open-source/qunit/dist/qunit.js:1478:30)
+  stack: Error: outside of a test context
+    at Object.<anonymous> (/some/path/wherever/unhandled-rejection.js:20:18)
   ...
 1..2
 # pass 0

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -89,6 +89,22 @@ Available custom reporters from dependencies are: npm-reporter
 	/* eslint-disable max-len */
 	"qunit hanging-test": `Error: Process exited before tests finished running
 Last test to run (hanging) has an async hold. Ensure all assert.async() callbacks are invoked and Promises resolve. You should also set a standard timeout via QUnit.config.testTimeout.
-`
+`,
 	/* eslint-enable max-len */
+	"qunit unhandled-rejection.js":
+`TAP version 13
+not ok 1 Unhandled Rejections > test passes just fine, but has a rejected promise
+  ---
+  message: "Error thrown in non-returned promise!"
+  severity: failed
+  actual: null
+  expected: undefined
+  stack: undefined:undefined
+  ...
+1..1
+# pass 0
+# skip 0
+# todo 0
+# fail 1
+`
 };

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -97,14 +97,26 @@ not ok 1 Unhandled Rejections > test passes just fine, but has a rejected promis
   ---
   message: "Error thrown in non-returned promise!"
   severity: failed
-  actual: null
+  actual: {}
   expected: undefined
-  stack: undefined:undefined
+  stack: Error: Error thrown in non-returned promise!
+    at /Users/rjackson/src/open-source/qunit/test/cli/fixtures/unhandled-rejection.js:13:11
+    at <anonymous>
   ...
-1..1
+not ok 2 global failure
+  ---
+  message: "outside of a test context"
+  severity: failed
+  actual: {
+  "message": "outside of a test context"
+}
+  expected: undefined
+  stack:     at runTest (/Users/rjackson/src/open-source/qunit/dist/qunit.js:1478:30)
+  ...
+1..2
 # pass 0
 # skip 0
 # todo 0
-# fail 1
+# fail 2
 `
 };

--- a/test/cli/fixtures/unhandled-rejection.js
+++ b/test/cli/fixtures/unhandled-rejection.js
@@ -10,12 +10,25 @@ QUnit.module( "Unhandled Rejections", function() {
 			setTimeout( resolve );
 		} )
 			.then( function() {
-				throw new Error( "Error thrown in non-returned promise!" );
+
+				// throwing a non-Error here because stack trace representation
+				// across Node versions is not stable (they continue to get better)
+				throw {
+					message: "Error thrown in non-returned promise!",
+					stack: `Error: Error thrown in non-returned promise!
+    at /some/path/wherever/unhandled-rejection.js:13:11`
+				};
 			} );
 
 		// prevent test from exiting before unhandled rejection fires
 		setTimeout( done, 10 );
 	} );
 
-	Promise.reject( { message: "outside of a test context" } );
+	// rejecting with a non-Error here because stack trace representation
+	// across Node versions is not stable (they continue to get better)
+	Promise.reject( {
+		message: "outside of a test context",
+		stack: `Error: outside of a test context
+    at Object.<anonymous> (/some/path/wherever/unhandled-rejection.js:20:18)`
+	} );
 } );

--- a/test/cli/fixtures/unhandled-rejection.js
+++ b/test/cli/fixtures/unhandled-rejection.js
@@ -6,19 +6,16 @@ QUnit.module( "Unhandled Rejections", function() {
 
 		const done = assert.async();
 
-		new Promise( function( resolve ) {
-			setTimeout( resolve );
-		} )
-			.then( function() {
+		Promise.resolve().then( function() {
 
-				// throwing a non-Error here because stack trace representation
-				// across Node versions is not stable (they continue to get better)
-				throw {
-					message: "Error thrown in non-returned promise!",
-					stack: `Error: Error thrown in non-returned promise!
+			// throwing a non-Error here because stack trace representation
+			// across Node versions is not stable (they continue to get better)
+			throw {
+				message: "Error thrown in non-returned promise!",
+				stack: `Error: Error thrown in non-returned promise!
     at /some/path/wherever/unhandled-rejection.js:13:11`
-				};
-			} );
+			};
+		} );
 
 		// prevent test from exiting before unhandled rejection fires
 		setTimeout( done, 10 );

--- a/test/cli/fixtures/unhandled-rejection.js
+++ b/test/cli/fixtures/unhandled-rejection.js
@@ -16,4 +16,6 @@ QUnit.module( "Unhandled Rejections", function() {
 		// prevent test from exiting before unhandled rejection fires
 		setTimeout( done, 10 );
 	} );
+
+	Promise.reject( { message: "outside of a test context" } );
 } );

--- a/test/cli/fixtures/unhandled-rejection.js
+++ b/test/cli/fixtures/unhandled-rejection.js
@@ -1,0 +1,19 @@
+"use strict";
+
+QUnit.module( "Unhandled Rejections", function() {
+	QUnit.test( "test passes just fine, but has a rejected promise", function( assert ) {
+		assert.ok( true );
+
+		const done = assert.async();
+
+		new Promise( function( resolve ) {
+			setTimeout( resolve );
+		} )
+			.then( function() {
+				throw new Error( "Error thrown in non-returned promise!" );
+			} );
+
+		// prevent test from exiting before unhandled rejection fires
+		setTimeout( done, 10 );
+	} );
+} );

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -105,6 +105,22 @@ QUnit.module( "CLI Main", function() {
 		}
 	} ) );
 
+	QUnit.test( "unhandled rejections fail tests", co.wrap( function* ( assert ) {
+		const command = "qunit unhandled-rejection.js";
+
+		try {
+			const result = yield execute( command );
+			assert.pushResult( {
+				result: false,
+				actual: result.stdout
+			} );
+		} catch ( e ) {
+			assert.equal( e.code, 1 );
+			assert.equal( e.stderr, "" );
+			assert.equal( e.stdout, expectedOutput[ command ] );
+		}
+	} ) );
+
 	QUnit.module( "filter", function() {
 		QUnit.test( "can properly filter tests", co.wrap( function* ( assert ) {
 			const command = "qunit --filter 'single' test single.js 'glob/**/*-test.js'";

--- a/test/index.html
+++ b/test/index.html
@@ -19,6 +19,7 @@
 	<script src="setTimeout.js"></script>
 	<script src="reporter-html/reporter-html.js"></script>
 	<script src="reporter-html/diff.js"></script>
+	<script src="reporter-html/unhandled-rejection.js"></script>
 	<script src="onerror/inside-test.js"></script>
 	<script src="onerror/outside-test.js"></script>
 </head>

--- a/test/reporter-html/unhandled-rejection.js
+++ b/test/reporter-html/unhandled-rejection.js
@@ -1,0 +1,36 @@
+// Detect if the current browser supports `onunhandledrejection` (avoiding
+// errors for browsers without the capability)
+const HAS_UNHANDLED_REJECTION_HANDLER = "onunhandledrejection" in window;
+
+QUnit.module( "Unhandled Rejections", function( hooks ) {
+	var originalQUnitOnError;
+
+	hooks.beforeEach( function() {
+		originalQUnitOnError = QUnit.onError;
+	} );
+
+	hooks.afterEach( function() {
+		QUnit.onError = originalQUnitOnError;
+	} );
+
+	if ( HAS_UNHANDLED_REJECTION_HANDLER ) {
+		QUnit.test( "test passes just fine, but has a rejected promise", function( assert ) {
+
+			QUnit.onError = function() {
+				assert.ok( true, "QUnit.onError was called" );
+			};
+
+			const done = assert.async();
+
+			new Promise( function( resolve ) {
+				setTimeout( resolve );
+			} )
+				.then( function() {
+					throw new Error( "Error thrown in non-returned promise!" );
+				} );
+
+			// prevent test from exiting before unhandled rejection fires
+			setTimeout( done, 10 );
+		} );
+	}
+} );

--- a/test/reporter-html/unhandled-rejection.js
+++ b/test/reporter-html/unhandled-rejection.js
@@ -17,12 +17,9 @@ if ( HAS_UNHANDLED_REJECTION_HANDLER ) {
 		QUnit.test( "test passes just fine, but has a rejected promise", function( assert ) {
 			const done = assert.async();
 
-			new Promise( function( resolve ) {
-				setTimeout( resolve );
-			} )
-				.then( function() {
-					throw new Error( "Error thrown in non-returned promise!" );
-				} );
+			Promise.resolve().then( function() {
+				throw new Error( "Error thrown in non-returned promise!" );
+			} );
 
 			// prevent test from exiting before unhandled rejection fires
 			setTimeout( done, 10 );

--- a/test/reporter-html/unhandled-rejection.js
+++ b/test/reporter-html/unhandled-rejection.js
@@ -1,25 +1,20 @@
 // Detect if the current browser supports `onunhandledrejection` (avoiding
 // errors for browsers without the capability)
-const HAS_UNHANDLED_REJECTION_HANDLER = "onunhandledrejection" in window;
+var HAS_UNHANDLED_REJECTION_HANDLER = "onunhandledrejection" in window;
 
-QUnit.module( "Unhandled Rejections", function( hooks ) {
-	var originalQUnitOnError;
+if ( HAS_UNHANDLED_REJECTION_HANDLER ) {
+	QUnit.module( "Unhandled Rejections inside test context", function( hooks ) {
+		hooks.beforeEach( function( assert ) {
+			var originalPushResult = assert.pushResult;
+			assert.pushResult = function( resultInfo ) {
 
-	hooks.beforeEach( function() {
-		originalQUnitOnError = QUnit.onError;
-	} );
-
-	hooks.afterEach( function() {
-		QUnit.onError = originalQUnitOnError;
-	} );
-
-	if ( HAS_UNHANDLED_REJECTION_HANDLER ) {
-		QUnit.test( "test passes just fine, but has a rejected promise", function( assert ) {
-
-			QUnit.onError = function() {
-				assert.ok( true, "QUnit.onError was called" );
+			// Inverts the result so we can test failing assertions
+				resultInfo.result = !resultInfo.result;
+				originalPushResult( resultInfo );
 			};
+		} );
 
+		QUnit.test( "test passes just fine, but has a rejected promise", function( assert ) {
 			const done = assert.async();
 
 			new Promise( function( resolve ) {
@@ -32,5 +27,52 @@ QUnit.module( "Unhandled Rejections", function( hooks ) {
 			// prevent test from exiting before unhandled rejection fires
 			setTimeout( done, 10 );
 		} );
-	}
-} );
+
+	} );
+
+	QUnit.module( "Unhandled Rejections outside test context", function( hooks ) {
+		var originalPushResult;
+
+		hooks.beforeEach( function( assert ) {
+
+			// Duck-punch pushResult so we can check test name and assert args.
+			originalPushResult = assert.pushResult;
+
+			assert.pushResult = function( resultInfo ) {
+
+				// Restore pushResult for this assert object, to allow following assertions.
+				this.pushResult = originalPushResult;
+
+				this.strictEqual( this.test.testName, "global failure", "Test is appropriately named" );
+
+				this.deepEqual(
+					resultInfo,
+					{
+						message: "Error message",
+						source: "filePath.js:1",
+						result: false,
+						actual: {
+							message: "Error message",
+							fileName: "filePath.js",
+							lineNumber: 1,
+							stack: "filePath.js:1"
+						}
+					},
+					"Expected assert.pushResult to be called with correct args"
+				);
+			};
+		} );
+
+		hooks.afterEach( function() {
+			QUnit.config.current.pushResult = originalPushResult;
+		} );
+
+		// Actual test (outside QUnit.test context)
+		QUnit.onUnhandledRejection( {
+			message: "Error message",
+			fileName: "filePath.js",
+			lineNumber: 1,
+			stack: "filePath.js:1"
+		} );
+	} );
+}

--- a/test/reporter-html/unhandled-rejection.js
+++ b/test/reporter-html/unhandled-rejection.js
@@ -8,7 +8,7 @@ if ( HAS_UNHANDLED_REJECTION_HANDLER ) {
 			var originalPushResult = assert.pushResult;
 			assert.pushResult = function( resultInfo ) {
 
-			// Inverts the result so we can test failing assertions
+				// Inverts the result so we can test failing assertions
 				resultInfo.result = !resultInfo.result;
 				originalPushResult( resultInfo );
 			};


### PR DESCRIPTION
Prior to this change, an unhandled exception in a promise that was not returned from the `test` callback would not cause test failure.

For example, the following (using default out of the box settings) results in test failures:

```js
test('native promises cause an unhandled rejection', function(assert) {
  // imagine this was "deep" inside various method calls
  setTimeout(function() {
    throw new Error('whoops!');
  });

  // other things that we are trying to test
  assert.deepEqual(someMethod(), ['one', 'two']);
});
```

And this (prior to this PR) would result in a passing test suite:

```js
test('native promises cause an unhandled rejection', function(assert) {
  // imagine this was "deep" inside various method calls
  Promise.resolve().then(function() {
    throw new Error('whoops!');
  });

  // other things that we are trying to test
  assert.deepEqual(someMethod(), ['one', 'two']);
});
```

The reason that what we are doing already isn't good enough is:

* HTML Reporter: the default `unhandledRejection` handler does not dispatch to `window.onerror` at all... 😩 
* Node CLI: unhandled rejections in Node 6.6 and higher emit a console warning, but nothing else