### PR TITLE
Core: Remove delay from setTimeouts in processing code

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -272,7 +272,7 @@ function scheduleBegin() {
 	if ( defined.setTimeout ) {
 		setTimeout( function() {
 			begin();
-		}, 13 );
+		} );
 	} else {
 		begin();
 	}

--- a/src/core/processing-queue.js
+++ b/src/core/processing-queue.js
@@ -40,7 +40,7 @@ function advance() {
 
 			config.queue.shift()();
 		} else {
-			setTimeout( advance, 13 );
+			setTimeout( advance );
 			break;
 		}
 	}

--- a/src/test.js
+++ b/src/test.js
@@ -789,7 +789,7 @@ function internalStart( test ) {
 			}
 
 			begin();
-		}, 13 );
+		} );
 	} else {
 		begin();
 	}

--- a/test/main/promise.js
+++ b/test/main/promise.js
@@ -13,7 +13,7 @@ function createMockPromise( assert, reject, value ) {
 				return reject ?
 					rejectedCallback.call( thenable, value ) :
 					fulfilledCallback.call( thenable, value );
-			}, 13 );
+			} );
 		}
 	};
 	return thenable;


### PR DESCRIPTION
Per https://github.com/qunitjs/qunit/issues/1245 these can build up and cause larger test suites to have some significant performance hits. They don't seem to be needed and I can't find any reason in the history as to why they are needed. In fact, the one comment I can find relating to them is a suggestion to [remove it](https://github.com/qunitjs/qunit/pull/653#discussion_r17195204).