### PR TITLE
HTML Reporter: Ensure attributes on qunit-fixture are reset.

### DIFF
--- a/runner/fixture.js
+++ b/runner/fixture.js
@@ -20,7 +20,7 @@ import { window, document } from "../src/globals";
 
 		var fixture = document.getElementById( "qunit-fixture" );
 		if ( fixture ) {
-			config.fixture = fixture.innerHTML;
+			config.fixture = fixture.cloneNode( true );
 		}
 	}
 
@@ -33,8 +33,17 @@ import { window, document } from "../src/globals";
 		}
 
 		var fixture = document.getElementById( "qunit-fixture" );
-		if ( fixture ) {
-			fixture.innerHTML = config.fixture;
+		var resetFixtureType = typeof config.fixture;
+		if ( resetFixtureType === "string" ) {
+
+			// support user defined values for `config.fixture`
+			var newFixture = document.createElement( "div" );
+			newFixture.setAttribute( "id", "qunit-fixture" );
+			newFixture.innerHTML = config.fixture;
+			fixture.parentNode.replaceChild( newFixture, fixture );
+		} else {
+			const clonedFixture = config.fixture.cloneNode( true );
+			fixture.parentNode.replaceChild( clonedFixture, fixture );
 		}
 	}
 

--- a/test/main/test.js
+++ b/test/main/test.js
@@ -11,11 +11,18 @@ if ( typeof document !== "undefined" ) {
 
 	QUnit.module( "fixture", function( hooks ) {
 		var failure = false,
-			values = [ /* initial value (see unshift below), */ "<b>ar</b>", undefined ],
+			values = [
+
+				/* initial value (see unshift below), */
+				/* initial value (see unshift below), */
+				"<b>ar</b>",
+				undefined
+			],
 			originalValue;
 
 		hooks.before( function() {
 			originalValue = QUnit.config.fixture;
+			values.unshift( originalValue );
 			values.unshift( originalValue );
 		} );
 
@@ -67,13 +74,25 @@ if ( typeof document !== "undefined" ) {
 		} );
 
 		QUnit.test( "setup", function( assert ) {
-			assert.equal( values.length, 3, "proper sequence" );
+			assert.equal( values.length, 4, "proper sequence" );
 
 			// setup for next test
 			document.getElementById( "qunit-fixture" ).innerHTML = "foo";
 		} );
 
 		QUnit.test( "automatically reset", function( assert ) {
+			assert.fixtureEquals( {
+				tagName: "div",
+				attributes: { id: "qunit-fixture" },
+				content: originalValue
+			} );
+			assert.equal( values.length, 3, "proper sequence" );
+
+			// setup for next test
+			document.getElementById( "qunit-fixture" ).setAttribute( "data-foo", "blah" );
+		} );
+
+		QUnit.test( "automatically reset after attribute value mutation", function( assert ) {
 			assert.fixtureEquals( {
 				tagName: "div",
 				attributes: { id: "qunit-fixture" },

--- a/test/main/test.js
+++ b/test/main/test.js
@@ -16,6 +16,7 @@ if ( typeof document !== "undefined" ) {
 				/* initial value (see unshift below), */
 				/* initial value (see unshift below), */
 				"<b>ar</b>",
+				"<p>bc</p>",
 				undefined
 			],
 			originalValue;
@@ -24,6 +25,11 @@ if ( typeof document !== "undefined" ) {
 			originalValue = QUnit.config.fixture;
 			values.unshift( originalValue );
 			values.unshift( originalValue );
+
+			var customFixtureNode = document.createElement( "span" );
+			customFixtureNode.setAttribute( "id", "qunit-fixture" );
+			customFixtureNode.setAttribute( "data-baz", "huzzah!" );
+			values.push( customFixtureNode );
 		} );
 
 		hooks.beforeEach( function( assert ) {
@@ -74,7 +80,7 @@ if ( typeof document !== "undefined" ) {
 		} );
 
 		QUnit.test( "setup", function( assert ) {
-			assert.equal( values.length, 4, "proper sequence" );
+			assert.equal( values.length, 6, "proper sequence" );
 
 			// setup for next test
 			document.getElementById( "qunit-fixture" ).innerHTML = "foo";
@@ -84,9 +90,9 @@ if ( typeof document !== "undefined" ) {
 			assert.fixtureEquals( {
 				tagName: "div",
 				attributes: { id: "qunit-fixture" },
-				content: originalValue
+				content: originalValue.innerHTML
 			} );
-			assert.equal( values.length, 3, "proper sequence" );
+			assert.equal( values.length, 5, "proper sequence" );
 
 			// setup for next test
 			document.getElementById( "qunit-fixture" ).setAttribute( "data-foo", "blah" );
@@ -96,18 +102,30 @@ if ( typeof document !== "undefined" ) {
 			assert.fixtureEquals( {
 				tagName: "div",
 				attributes: { id: "qunit-fixture" },
-				content: originalValue
+				content: originalValue.innerHTML
 			} );
-			assert.equal( values.length, 2, "proper sequence" );
+			assert.equal( values.length, 4, "proper sequence" );
 		} );
 
-		QUnit.test( "user-specified", function( assert ) {
+		QUnit.test( "user-specified string", function( assert ) {
 			assert.fixtureEquals( {
 				tagName: "div",
 				attributes: { id: "qunit-fixture" },
 				content: "<b>ar</b>"
 			} );
-			assert.equal( values.length, 1, "proper sequence" );
+			assert.equal( values.length, 3, "proper sequence" );
+
+			// setup for next test
+			document.getElementById( "qunit-fixture" ).setAttribute( "data-foo", "blah" );
+		} );
+
+		QUnit.test( "user-specified string automatically resets attribute value mutation", function( assert ) {
+			assert.fixtureEquals( {
+				tagName: "div",
+				attributes: { id: "qunit-fixture" },
+				content: "<p>bc</p>"
+			} );
+			assert.equal( values.length, 2, "proper sequence" );
 
 			// setup for next test
 			document.getElementById( "qunit-fixture" ).innerHTML = "baz";
@@ -118,6 +136,18 @@ if ( typeof document !== "undefined" ) {
 				tagName: "div",
 				attributes: { id: "qunit-fixture" },
 				content: "baz"
+			} );
+			assert.equal( values.length, 1, "proper sequence" );
+		} );
+
+		QUnit.test( "user-specified DOM node", function( assert ) {
+			assert.fixtureEquals( {
+				tagName: "span",
+				attributes: {
+					id: "qunit-fixture",
+					"data-baz": "huzzah!"
+				},
+				content: ""
 			} );
 			assert.equal( values.length, 0, "proper sequence" );
 		} );


### PR DESCRIPTION
This change leverages `Node.prototype.cloneNode` to deeply clone the original `qunit-fixture` before any tests have started, then for each test replaces (using `Node.prototype.replaceChild`) the current `qunit-fixture` with a clone of the original.

Fixes https://github.com/qunitjs/qunit/issues/1224.