### PR TITLE
Core: Release all processing locks when Promise rejects from a test

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -513,7 +513,7 @@ Test.prototype = {
 							saveGlobal();
 
 							// Unblock
-							resume();
+							internalRecover( test );
 						}
 					);
 				}

--- a/test/main/promise.js
+++ b/test/main/promise.js
@@ -205,3 +205,19 @@ QUnit.test( "rejected Promise with string value", function( assert ) {
 
 	return createMockPromise( assert, true, "this is an error" );
 } );
+
+QUnit.test( "rejected Promise with async lock", function( assert ) {
+	assert.expect( 2 );
+
+	assert.async(); // Important! We don't explicitly release the async lock
+
+	this.pushFailure = assert.test.pushFailure;
+	assert.test.pushFailure = function( message ) {
+		assert.strictEqual(
+			message,
+			"Promise rejected during \"rejected Promise with async lock\": this is an error"
+		);
+	};
+
+	return createMockPromise( assert, true, "this is an error" );
+} );


### PR DESCRIPTION
Fixes https://github.com/qunitjs/qunit/issues/1229.

When a Promise rejects, we were previously only releasing the processing lock from that Promise. Now we'll release all processing locks when that occurs, similarly to what we do for exceptions that occur during a non-Promise test.