### PR TITLE
Core: Throw error if no tests are run

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -38,6 +38,10 @@ function run( args, options ) {
 		QUnit.onUnhandledRejection( reason );
 	} );
 
+	process.on( "uncaughtException", function( error ) {
+		QUnit.onError( error );
+	} );
+
 	const files = utils.getFilesFromArgs( args );
 
 	QUnit = requireQUnit();
@@ -87,9 +91,6 @@ function run( args, options ) {
 		running = false;
 
 		if ( data.testCounts.failed ) {
-			process.exitCode = 1;
-		} else if ( data.testCounts.total === 0 ) {
-			console.error( "Error: No tests were run" );
 			process.exitCode = 1;
 		} else {
 			process.exitCode = 0;

--- a/src/core/processing-queue.js
+++ b/src/core/processing-queue.js
@@ -148,6 +148,28 @@ function done() {
 	const runtime = now() - config.started;
 	const passed = config.stats.all - config.stats.bad;
 
+	if ( config.stats.all === 0 ) {
+
+		if ( config.filter && config.filter.length ) {
+			throw new Error( `No tests matched the filter "${config.filter}".` );
+		}
+
+		if ( config.module && config.module.length ) {
+			throw new Error( `No tests matched the module "${config.module}".` );
+		}
+
+		if ( config.moduleId && config.moduleId.length ) {
+			throw new Error( `No tests matched the moduleId "${config.moduleId}".` );
+		}
+
+		if ( config.testId && config.testId.length ) {
+			throw new Error( `No tests matched the testId "${config.testId}".` );
+		}
+
+		throw new Error( "No tests were run." );
+
+	}
+
 	emit( "runEnd", globalSuite.end( true ) );
 	runLoggingCallbacks( "done", {
 		passed,

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -124,5 +124,39 @@ not ok 2 global failure
 # skip 0
 # todo 0
 # fail 2
+`,
+
+	"qunit no-tests":
+`TAP version 13
+not ok 1 global failure
+  ---
+  message: "No tests were run."
+  severity: failed
+  actual: null
+  expected: undefined
+  stack: undefined:undefined
+  ...
+1..1
+# pass 0
+# skip 0
+# todo 0
+# fail 1
+`,
+
+	"qunit qunit --filter 'no matches' test":
+`TAP version 13
+not ok 1 global failure
+  ---
+  message: "No tests matched the filter "no matches"."
+  severity: failed
+  actual: null
+  expected: undefined
+  stack: undefined:undefined
+  ...
+1..1
+# pass 0
+# skip 0
+# todo 0
+# fail 1
 `
 };

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -87,11 +87,13 @@ QUnit.module( "CLI Main", function() {
 	} ) );
 
 	QUnit.test( "exit code is 1 when no tests are run", co.wrap( function* ( assert ) {
+		const command = "qunit no-tests";
 		try {
-			yield execute( "qunit no-tests" );
+			yield execute( command );
 		} catch ( e ) {
 			assert.equal( e.code, 1 );
-			assert.equal( e.stderr, "Error: No tests were run\n" );
+			assert.equal( e.stderr, "" );
+			assert.equal( e.stdout, expectedOutput[ command ] );
 		}
 	} ) );
 
@@ -130,6 +132,17 @@ QUnit.module( "CLI Main", function() {
 			assert.equal( execution.code, 0 );
 			assert.equal( execution.stderr, "" );
 			assert.equal( execution.stdout, expectedOutput[ equivalentCommand ] );
+		} ) );
+
+		QUnit.test( "exit code is 1 when no tests match filter", co.wrap( function* ( assert ) {
+			const command = "qunit qunit --filter 'no matches' test";
+			try {
+				yield execute( command );
+			} catch ( e ) {
+				assert.equal( e.code, 1 );
+				assert.equal( e.stderr, "" );
+				assert.equal( e.stdout, expectedOutput[ command ] );
+			}
 		} ) );
 	} );
 

--- a/test/startError.html
+++ b/test/startError.html
@@ -8,28 +8,6 @@
 <body>
 	<div id="qunit"></div>
 	<script src="../dist/qunit.js"></script>
-	<script>
-
-		try {
-			QUnit.config.autostart = true;
-			QUnit.start();
-		} catch ( thrownError ) {
-			window.autostartStartError = thrownError;
-		}
-
-		try {
-			QUnit.start();
-		} catch ( thrownError ) {
-			window.tooManyStartsError = thrownError;
-		}
-
-		// Delete QUnit global so we can reload it
-		delete window.QUnit;
-	</script>
-
-	<!-- INTENTIONALLY reload QUnit -->
-	<script src="../dist/qunit.js"></script>
-
 	<script src="startError.js"></script>
 </body>
 </html>

--- a/test/startError.js
+++ b/test/startError.js
@@ -1,3 +1,16 @@
+try {
+	QUnit.config.autostart = true;
+	QUnit.start();
+} catch ( thrownError ) {
+	window.autostartStartError = thrownError;
+}
+
+try {
+	QUnit.start();
+} catch ( thrownError ) {
+	window.tooManyStartsError = thrownError;
+}
+
 QUnit.module( "global start unrecoverable errors" );
 
 QUnit.test( "start() throws when QUnit.config.autostart === true", function( assert ) {
@@ -6,9 +19,8 @@ QUnit.test( "start() throws when QUnit.config.autostart === true", function( ass
 		"Called start() outside of a test context when QUnit.config.autostart was true" );
 } );
 
-QUnit.test( "Throws after calling start() too many times outside of a test context",
-	function( assert ) {
-		assert.expect( 1 );
-		assert.equal( window.tooManyStartsError.message,
-			"Called start() outside of a test context too many times" );
-	} );
+QUnit.test( "Throws after calling start() too many times outside of a test context", function( assert ) {
+	assert.expect( 1 );
+	assert.equal( window.tooManyStartsError.message,
+		"Called start() outside of a test context too many times" );
+} );


### PR DESCRIPTION
Fixes https://github.com/qunitjs/qunit/issues/569 (finally).

We throw an error if no tests are run. Optionally includes a more specific message if a filter is being used. The error should report as a global failure via the `QUnit.onError` handler.

Need to add some new tests to verify behavior.