### PR TITLE
Docs: Fix typo in docs for QUnit.module

### DIFF
--- a/docs/QUnit/module.md
+++ b/docs/QUnit/module.md
@@ -303,7 +303,7 @@ QUnit.module( "Robot", function() {
 // Currenly working on implementing features related to androids
 QUnit.module.only( "Android", function( hooks ) {
   hooks.beforeEach( function() {
-    this.adnroid = new Android();
+    this.android = new Android();
   } );
 
   QUnit.test( "Say hello", function( assert ) {


### PR DESCRIPTION
Typo in the Code example on how to "Only run a subset of tests"