### PR TITLE
Rejects docs updates

### DIFF
--- a/docs/assert/rejects.md
+++ b/docs/assert/rejects.md
@@ -26,6 +26,7 @@ comparison.
 The `expectedMatcher` argument can be:
 
 * A function that returns `true` when the assertion should be considered passing.
+* An Error object
 * A base constructor to use ala `rejectionValue instanceof expectedMatcher`
 * A RegExp that matches (or partially matches) `rejectionValue.toString()`
 

--- a/docs/assert/rejects.md
+++ b/docs/assert/rejects.md
@@ -74,7 +74,7 @@ QUnit.test( "rejects", function( assert ) {
   );
 
   assert.rejects(
-    Promise.reject(throw new CustomError("some error description")),
+    Promise.reject(new CustomError("some error description")),
     function( err ) {
       return err.toString() === "some error description";
     },

--- a/docs/assert/rejects.md
+++ b/docs/assert/rejects.md
@@ -6,7 +6,7 @@ categories:
   - assert
 ---
 
-## `rejects( promise, expectedMatcher [, message ] )`
+## `rejects( promise[, expectedMatcher][, message ] )`
 
 Test if the provided promise rejects, and optionally compare the rejection value.
 


### PR DESCRIPTION
Hi everyone,

This PR contains the following changes:
1. Marking the second parameter of `assert.rejects()` as optional
2. Adding `error object` as possible values of `expectedMatcher`
3. Removing an unexpected `throw` statement in examples