### PR TITLE
 Assert: Clone actual steps array to avoid passing internal reference

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -44,7 +44,10 @@ class Assert {
 
 	// Verifies the steps in a test match a given array of string values
 	verifySteps( steps, message ) {
-		this.deepEqual( this.test.steps, steps, message );
+
+		// Since the steps array is just string values, we can clone with slice
+		const actualStepsClone = this.test.steps.slice();
+		this.deepEqual( actualStepsClone, steps, message );
 		this.test.steps.length = 0;
 	}
 

--- a/test/main/assert/step.js
+++ b/test/main/assert/step.js
@@ -132,3 +132,30 @@ QUnit.test( "errors if not called when `assert.step` is used", function( assert 
 		assert.equal( message, "Expected assert.verifySteps() to be called before end of test after using assert.step(). Unverified steps: one" );
 	};
 } );
+
+// Testing to ensure steps array is not passed by reference: https://github.com/qunitjs/qunit/issues/1266
+QUnit.module( "assert.verifySteps value reference", function() {
+
+	var loggedAssertions = {};
+
+	QUnit.log( function( details ) {
+
+		if ( details.message === "verification-assertion" ) {
+			loggedAssertions[ details.message ] = details;
+		}
+
+	} );
+
+	QUnit.test( "passing test to see if steps array is passed by reference to logging function", function( assert ) {
+		assert.step( "step one" );
+		assert.step( "step two" );
+
+		assert.verifySteps( [ "step one", "step two" ], "verification-assertion" );
+	} );
+
+	QUnit.todo( "steps array should not be reset in logging function", function( assert ) {
+		const result = loggedAssertions[ "verification-assertion" ].actual;
+		assert.deepEqual( result, [ "step one", "step two" ] );
+	} );
+
+} );

--- a/test/main/assert/step.js
+++ b/test/main/assert/step.js
@@ -153,7 +153,7 @@ QUnit.module( "assert.verifySteps value reference", function() {
 		assert.verifySteps( [ "step one", "step two" ], "verification-assertion" );
 	} );
 
-	QUnit.todo( "steps array should not be reset in logging function", function( assert ) {
+	QUnit.test( "steps array should not be reset in logging function", function( assert ) {
 		const result = loggedAssertions[ "verification-assertion" ].actual;
 		assert.deepEqual( result, [ "step one", "step two" ] );
 	} );


### PR DESCRIPTION
Fixes https://github.com/qunitjs/qunit/issues/1266

The test setup is a bit awkward to verify this fix, so if anyone has a better idea, let me know!