### PR TITLE
Core: Ensure late-add high-priority tests are inserted in proper order

### DIFF
--- a/src/core/processing-queue.js
+++ b/src/core/processing-queue.js
@@ -49,8 +49,6 @@ function advanceTaskQueue() {
 		const elapsedTime = now() - start;
 
 		if ( !defined.setTimeout || config.updateRate <= 0 || elapsedTime < config.updateRate ) {
-
-			// TODO: reintroduce priorityCount decrement to start higher priority test
 			const task = taskQueue.shift();
 			task();
 		} else {
@@ -73,6 +71,11 @@ function advanceTestQueue() {
 
 	const testTasks = config.queue.shift();
 	addToTaskQueue( testTasks() );
+
+	if ( priorityCount > 0 ) {
+		priorityCount--;
+	}
+
 	advance();
 }
 

--- a/test/reorder.js
+++ b/test/reorder.js
@@ -1,15 +1,24 @@
 window.sessionStorage.setItem( "qunit-test-Reorder-Second", 1 );
+window.sessionStorage.setItem( "qunit-test-Reorder-Third", 1 );
 
 var lastTest = "";
 
 QUnit.module( "Reorder" );
 
 QUnit.test( "First", function( assert ) {
-	assert.strictEqual( lastTest, "Second" );
+	assert.strictEqual( lastTest, "Third" );
 	lastTest = "First";
 } );
 
 QUnit.test( "Second", function( assert ) {
 	assert.strictEqual( lastTest, "" );
 	lastTest = "Second";
+
+	// This test is "high priority" so it should execute before test "First"
+	// even though it is added to the queue late
+	QUnit.config.reorder = true; // For some reason PhantomJS mutates config.reorder
+	QUnit.test( "Third", function( assert ) {
+		assert.strictEqual( lastTest, "Second" );
+		lastTest = "Third";
+	} );
 } );


### PR DESCRIPTION
As mentioned in this comment: https://github.com/qunitjs/qunit/pull/1260/files#r169779552

(Note: Test has some weird behavior in PhantomJS, but verified it works as expected in Chrome, Safari, and FireFox)