### PR TITLE
Assert: Support rejecting falsy values against no matcher in rejects

### DIFF
--- a/test/main/assert.js
+++ b/test/main/assert.js
@@ -287,7 +287,7 @@ QUnit.test( "throws", function( assert ) {
 } );
 
 QUnit.test( "rejects", function( assert ) {
-	assert.expect( 15 );
+	assert.expect( 16 );
 
 	function CustomError( message ) {
 		this.message = message;
@@ -395,6 +395,11 @@ QUnit.test( "rejects", function( assert ) {
 		buildMockPromise( new this.CustomError( "some error description" ) ),
 		/description/,
 		"throw error from property of 'this' context"
+	);
+
+	assert.rejects(
+		buildMockPromise( undefined ),
+		"reject with undefined against no matcher"
 	);
 } );
 


### PR DESCRIPTION
Fixes https://github.com/qunitjs/qunit/issues/1268

Bulk of changes are whitespace; might want to add `?w=1` to the URL when viewing the diff.