### PR TITLE
CLI: Implement --require option

### DIFF
--- a/bin/qunit
+++ b/bin/qunit
@@ -17,6 +17,11 @@ const description = `Runs tests using the QUnit framework.
 
   For more info on working with QUnit, check out http://qunitjs.com.`;
 
+function collect( val, collection ) {
+	collection.push( val );
+	return collection;
+}
+
 program._name = "qunit";
 program
 	.version( pkg.version )
@@ -26,6 +31,8 @@ program
 	.option( "-r, --reporter [name]", "specify the reporter to use; " +
 		"if no match is found or no name is provided, a list of available " +
 		"reporters will be displayed" )
+	.option( "--require <module>", "specify a module to require prior to running " +
+		"any tests.", collect, [] )
 	.option( "--seed [value]", "specify a seed to order your tests; " +
 		"if option is specified without a value, one will be generated" )
 	.option( "-w, --watch", "Watch files for changes and re-run the test suite" )
@@ -39,6 +46,7 @@ const args = program.args;
 const options = {
 	filter: program.filter,
 	reporter: findReporter( program.reporter ),
+	requires: program.require,
 	seed: program.seed
 };
 

--- a/bin/require-from-cwd.js
+++ b/bin/require-from-cwd.js
@@ -1,0 +1,6 @@
+const resolve = require( "resolve" );
+
+module.exports = function requireFromCWD( mod ) {
+	const resolvedPath = resolve.sync( mod, { basedir: process.cwd() } );
+	return require( resolvedPath );
+};

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -158,5 +158,16 @@ not ok 1 global failure
 # skip 0
 # todo 0
 # fail 1
-`
+`,
+
+	"qunit single.js --require require-dep --require './node_modules/require-dep/module.js'":
+`required require-dep/index.js
+required require-dep/module.js
+TAP version 13
+ok 1 Single > has a test
+1..1
+# pass 1
+# skip 0
+# todo 0
+# fail 0`
 };

--- a/test/cli/fixtures/node_modules/require-dep/index.js
+++ b/test/cli/fixtures/node_modules/require-dep/index.js
@@ -1,0 +1,1 @@
+console.log( "required require-dep/index.js" );

--- a/test/cli/fixtures/node_modules/require-dep/module.js
+++ b/test/cli/fixtures/node_modules/require-dep/module.js
@@ -1,0 +1,1 @@
+console.log( "required require-dep/module.js" );

--- a/test/cli/fixtures/node_modules/require-dep/package.json
+++ b/test/cli/fixtures/node_modules/require-dep/package.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0.0",
+  "name": "require-dep"
+}

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -146,6 +146,28 @@ QUnit.module( "CLI Main", function() {
 		} ) );
 	} );
 
+	QUnit.module( "require", function() {
+		QUnit.test( "can properly require dependencies and modules", co.wrap( function* ( assert ) {
+			const command = "qunit single.js --require require-dep --require './node_modules/require-dep/module.js'";
+			const execution = yield execute( command );
+
+			assert.equal( execution.code, 0 );
+			assert.equal( execution.stderr, "" );
+			assert.equal( execution.stdout, expectedOutput[ command ] );
+		} ) );
+
+		QUnit.test( "displays helpful error when failing to require a file", co.wrap( function* ( assert ) {
+			const command = "qunit single.js --require 'does-not-exist-at-all'";
+			try {
+				yield execute( command );
+			} catch ( e ) {
+				assert.equal( e.code, 1 );
+				assert.ok( e.stderr.includes( "Error: Cannot find module 'does-not-exist-at-all'" ) );
+				assert.equal( e.stdout, "" );
+			}
+		} ) );
+	} );
+
 	QUnit.module( "seed", function() {
 		QUnit.test( "can properly seed tests", co.wrap( function* ( assert ) {
 			const command = "qunit --seed 's33d' test single.js 'glob/**/*-test.js'";


### PR DESCRIPTION
This PR implements a `--require` option for the CLI. It allows for any number of dependencies or files to be `require`d prior to the test suite run actually starting.

Fixes https://github.com/qunitjs/qunit/issues/1222