### PR TITLE
Docs: Fix broken QUnit.stop link from assert/async and add redirect

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -21,6 +21,7 @@ gem "minima", "~> 2.0"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.6"
+   gem "jekyll-redirect-from", "0.13.0"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -19,6 +19,8 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-feed (0.9.2)
       jekyll (~> 3.3)
+    jekyll-redirect-from (0.13.0)
+      jekyll (~> 3.3)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
     jekyll-watch (1.5.0)
@@ -47,6 +49,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (= 3.4.3)
   jekyll-feed (~> 0.6)
+  jekyll-redirect-from (= 0.13.0)
   minima (~> 2.0)
   tzinfo-data
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,6 +7,11 @@
 ## Site settings
 ## https://jekyllrb.com/docs/configuration/
 
+# Plugins
+plugins:
+  # https://help.github.com/articles/redirects-on-github-pages/
+  - jekyll-redirect-from
+
 # Conversion
 highlighter: rouge
 markdown: kramdown

--- a/docs/assert/async.md
+++ b/docs/assert/async.md
@@ -5,6 +5,8 @@ description: Instruct QUnit to wait for an asynchronous operation.
 categories:
   - assert
   - async
+redirect_from:
+  - "/QUnit/stop"
 ---
 
 ## `async( [ acceptCallCount = 1 ] )`
@@ -19,7 +21,7 @@ Instruct QUnit to wait for an asynchronous operation.
 
 `assert.async()` returns a callback function and pauses test processing until the callback function is invoked the specified number of times. The callback will throw an `Error` if it is invoked more often than the accepted call count.
 
-This replaces functionality previously provided by [`QUnit.stop()`](/QUnit/stop) and [`QUnit.start()`](/QUnit/start).
+This replaces functionality previously provided by `QUnit.stop()` and [`QUnit.start()`](/QUnit/start).
 
 ### Examples
 

--- a/test/main/modules.js
+++ b/test/main/modules.js
@@ -121,7 +121,7 @@ QUnit.test( "keys", function( assert ) {
 	this.contextTest = true;
 } );
 
-QUnit.module( "afterEach and QUnit.stop", {
+QUnit.module( "afterEach and assert.async", {
 	beforeEach: function() {
 		this.state = false;
 	},


### PR DESCRIPTION
Proof of concept for https://github.com/qunitjs/qunit/issues/1289.

* Fix broken link to /QUnit/stop which no longer exists.
* For incoming links from elsewhere, set up a redirect from there
  to the closest currently related page, which is /assert/async.

The redirect logic uses the Jekyll Redirect From plugin, which
is also allowed and preinstalled on GitHub Pages. For local dev,
add the same name and version of that gem, per
<https://pages.github.com/versions/>.