### PR TITLE
Docs: Set up redirects for old urls

### DIFF
--- a/docs/QUnit/module.md
+++ b/docs/QUnit/module.md
@@ -4,6 +4,11 @@ title: module
 description: Group related tests under a single label.
 categories:
   - main
+redirect_from:
+  - "/QUnit.module"
+  - "/QUnit.module/"
+  - "/module"
+  - "/module/"
 ---
 
 ## `QUnit.module( name [, hooks] [, nested ] )`

--- a/docs/QUnit/start.md
+++ b/docs/QUnit/start.md
@@ -5,6 +5,9 @@ description: QUnit.start() is used to start an async test set
 categories:
   - main
   - async
+redirect_from:
+  - "/start"
+  - "/start/"
 ---
 
 ## `QUnit.start()`

--- a/docs/QUnit/test.md
+++ b/docs/QUnit/test.md
@@ -5,6 +5,15 @@ description: Add a test to run.
 categories:
   - main
   - async
+redirect_from:
+  - "/QUnit.asyncTest"
+  - "/QUnit.asyncTest/"
+  - "/QUnit.test"
+  - "/QUnit.test/"
+  - "/asyncTest"
+  - "/asyncTest/"
+  - "/test"
+  - "/test/"
 ---
 
 ## `QUnit.test( name, callback )`

--- a/docs/assert/async.md
+++ b/docs/assert/async.md
@@ -6,7 +6,11 @@ categories:
   - assert
   - async
 redirect_from:
+  - "/QUnit.stop"
+  - "/QUnit.stop/"
   - "/QUnit/stop"
+  - "/stop"
+  - "/stop/"
 ---
 
 ## `async( [ acceptCallCount = 1 ] )`

--- a/docs/assert/deepEqual.md
+++ b/docs/assert/deepEqual.md
@@ -4,6 +4,9 @@ title: deepEqual
 description: A deep recursive comparison, working on primitive types, arrays, objects, regular expressions, dates and functions.
 categories:
   - assert
+redirect_from:
+  - "/deepEqual"
+  - "/deepEqual/"
 ---
 
 ## `deepEqual( actual, expected [, message ] )`

--- a/docs/assert/equal.md
+++ b/docs/assert/equal.md
@@ -4,6 +4,9 @@ title: equal
 description: A non-strict comparison.
 categories:
   - assert
+redirect_from:
+  - "/equal"
+  - "/equal/"
 ---
 
 ## `equal( actual, expected [, message ] )`

--- a/docs/assert/expect.md
+++ b/docs/assert/expect.md
@@ -4,6 +4,9 @@ title: expect
 description: Specify how many assertions are expected to run within a test.
 categories:
   - assert
+redirect_from:
+  - "/expect"
+  - "/expect/"
 ---
 
 ## `expect( amount )`

--- a/docs/assert/notDeepEqual.md
+++ b/docs/assert/notDeepEqual.md
@@ -4,6 +4,9 @@ title: notDeepEqual
 description: An inverted deep recursive comparison, working on primitive types, arrays, objects, regular expressions, dates and functions.
 categories:
   - assert
+redirect_from:
+  - "/notDeepEqual"
+  - "/notDeepEqual/"
 ---
 
 ## `notDeepEqual( actual, expected [, message ] )`

--- a/docs/assert/notEqual.md
+++ b/docs/assert/notEqual.md
@@ -4,6 +4,9 @@ title: notEqual
 description: A non-strict comparison, checking for inequality.
 categories:
   - assert
+redirect_from:
+  - "/notEqual"
+  - "/notEqual/"
 ---
 
 ## `notEqual( actual, expected [, message ] )`

--- a/docs/assert/notStrictEqual.md
+++ b/docs/assert/notStrictEqual.md
@@ -4,6 +4,9 @@ title: notStrictEqual
 description: A strict comparison, checking for inequality.
 categories:
   - assert
+redirect_from:
+  - "/notStrictEqual"
+  - "/notStrictEqual/"
 ---
 
 ## `notStrictEqual( actual, expected [, message ] )`

--- a/docs/assert/ok.md
+++ b/docs/assert/ok.md
@@ -4,6 +4,9 @@ title: ok
 description: A boolean check, equivalent to CommonJS's assert.ok() and JUnit's assertTrue(). Passes if the first argument is truthy.
 categories:
   - assert
+redirect_from:
+  - "/ok"
+  - "/ok/"
 ---
 
 ## `ok( state [, message ] )`

--- a/docs/assert/strictEqual.md
+++ b/docs/assert/strictEqual.md
@@ -4,6 +4,9 @@ title: strictEqual
 description: A strict type and value comparison.
 categories:
   - assert
+redirect_from:
+  - "/strictEqual"
+  - "/strictEqual/"
 ---
 
 ## `strictEqual( actual, expected [, message ] )`

--- a/docs/assert/throws.md
+++ b/docs/assert/throws.md
@@ -4,6 +4,9 @@ title: throws
 description: Test if a callback throws an exception, and optionally compare the thrown error.
 categories:
   - assert
+redirect_from:
+  - "/throws"
+  - "/throws/"
 ---
 
 ## `throws( blockFn[, expectedMatcher][, message ] )`

--- a/docs/config/QUnit.dump.parse.md
+++ b/docs/config/QUnit.dump.parse.md
@@ -3,6 +3,9 @@ layout: default
 categories: [config]
 title: QUnit.dump.parse
 description: Advanced and extensible data dumping for JavaScript
+redirect_from:
+  - "/QUnit.dump.parse"
+  - "/QUnit.jsDump.parse"
 ---
 
 ## `QUnit.dump.parse( data )`


### PR DESCRIPTION
Fixes #1289.

----


Follows proof-of-concept from https://github.com/qunitjs/qunit/pull/1291 which worked. <https://api.qunitjs.com/QUnit/stop> now redirects to <http://api.qunitjs.com/assert/async>.