### PR TITLE
Docs: Fix Jekyll build (remove conflicting file/dir names)

### DIFF
--- a/docs/QUnit/module.md
+++ b/docs/QUnit/module.md
@@ -5,9 +5,7 @@ description: Group related tests under a single label.
 categories:
   - main
 redirect_from:
-  - "/QUnit.module"
   - "/QUnit.module/"
-  - "/module"
   - "/module/"
 ---
 

--- a/docs/QUnit/start.md
+++ b/docs/QUnit/start.md
@@ -6,7 +6,6 @@ categories:
   - main
   - async
 redirect_from:
-  - "/start"
   - "/start/"
 ---
 

--- a/docs/QUnit/test.md
+++ b/docs/QUnit/test.md
@@ -6,13 +6,9 @@ categories:
   - main
   - async
 redirect_from:
-  - "/QUnit.asyncTest"
   - "/QUnit.asyncTest/"
-  - "/QUnit.test"
   - "/QUnit.test/"
-  - "/asyncTest"
   - "/asyncTest/"
-  - "/test"
   - "/test/"
 ---
 

--- a/docs/assert/async.md
+++ b/docs/assert/async.md
@@ -6,10 +6,8 @@ categories:
   - assert
   - async
 redirect_from:
-  - "/QUnit.stop"
   - "/QUnit.stop/"
-  - "/QUnit/stop"
-  - "/stop"
+  - "/QUnit/stop/"
   - "/stop/"
 ---
 

--- a/docs/assert/deepEqual.md
+++ b/docs/assert/deepEqual.md
@@ -5,7 +5,6 @@ description: A deep recursive comparison, working on primitive types, arrays, ob
 categories:
   - assert
 redirect_from:
-  - "/deepEqual"
   - "/deepEqual/"
 ---
 

--- a/docs/assert/equal.md
+++ b/docs/assert/equal.md
@@ -5,7 +5,6 @@ description: A non-strict comparison.
 categories:
   - assert
 redirect_from:
-  - "/equal"
   - "/equal/"
 ---
 

--- a/docs/assert/expect.md
+++ b/docs/assert/expect.md
@@ -5,7 +5,6 @@ description: Specify how many assertions are expected to run within a test.
 categories:
   - assert
 redirect_from:
-  - "/expect"
   - "/expect/"
 ---
 

--- a/docs/assert/notDeepEqual.md
+++ b/docs/assert/notDeepEqual.md
@@ -5,7 +5,6 @@ description: An inverted deep recursive comparison, working on primitive types, 
 categories:
   - assert
 redirect_from:
-  - "/notDeepEqual"
   - "/notDeepEqual/"
 ---
 

--- a/docs/assert/notEqual.md
+++ b/docs/assert/notEqual.md
@@ -5,7 +5,6 @@ description: A non-strict comparison, checking for inequality.
 categories:
   - assert
 redirect_from:
-  - "/notEqual"
   - "/notEqual/"
 ---
 

--- a/docs/assert/notStrictEqual.md
+++ b/docs/assert/notStrictEqual.md
@@ -5,7 +5,6 @@ description: A strict comparison, checking for inequality.
 categories:
   - assert
 redirect_from:
-  - "/notStrictEqual"
   - "/notStrictEqual/"
 ---
 

--- a/docs/assert/ok.md
+++ b/docs/assert/ok.md
@@ -5,7 +5,6 @@ description: A boolean check, equivalent to CommonJS's assert.ok() and JUnit's a
 categories:
   - assert
 redirect_from:
-  - "/ok"
   - "/ok/"
 ---
 

--- a/docs/assert/strictEqual.md
+++ b/docs/assert/strictEqual.md
@@ -5,7 +5,6 @@ description: A strict type and value comparison.
 categories:
   - assert
 redirect_from:
-  - "/strictEqual"
   - "/strictEqual/"
 ---
 

--- a/docs/assert/throws.md
+++ b/docs/assert/throws.md
@@ -5,7 +5,6 @@ description: Test if a callback throws an exception, and optionally compare the 
 categories:
   - assert
 redirect_from:
-  - "/throws"
   - "/throws/"
 ---
 

--- a/docs/config/QUnit.dump.parse.md
+++ b/docs/config/QUnit.dump.parse.md
@@ -4,8 +4,8 @@ categories: [config]
 title: QUnit.dump.parse
 description: Advanced and extensible data dumping for JavaScript
 redirect_from:
-  - "/QUnit.dump.parse"
-  - "/QUnit.jsDump.parse"
+  - "/QUnit.dump.parse/"
+  - "/QUnit.jsDump.parse/"
 ---
 
 ## `QUnit.dump.parse( data )`


### PR DESCRIPTION
Follows-up a7ccfcb.

Having an entry for both "foo" and "foo/" is supported, however
a problem happens if the "foo" part contains one or more dots.

Normally, "foo" creates `_site/foo.html` and
"foo/" creates `_site/foo/index.html`. However, if the name
contains a dot, then the file name won't have ".html" appended.

This causes the Jekyll build to fail because it cannot, for example
create "_site/QUnit.module" as both a file and a directory.

```
jekyll 3.4.3 | Error:
> File exists @ dir_s_mkdir - qunit/docs/_site/QUnit.module
```

Rather than trying to find a way to enforce `.html` in the filename,
I found out that the Jekyll plugin actually handles redirects for
slashless variants as well, so we only need the versions with a slash
and everything will continue to work fine.