### PR TITLE
HTML Reporter: add norender flag to avoid deeply nested divs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -154,6 +154,7 @@ module.exports = function( grunt ) {
 						"test/reporter-html/window-onerror.html",
 						"test/reporter-html/window-onerror-preexisting-handler.html",
 						"test/reporter-urlparams.html",
+						"test/reporter-urlparams-norender.html",
 						"test/moduleId.html",
 						"test/onerror/inside-test.html",
 						"test/onerror/outside-test.html",

--- a/docs/config/QUnit.config.md
+++ b/docs/config/QUnit.config.md
@@ -43,6 +43,10 @@ By default QUnit will use whatever the starting content of `#qunit-fixture` is a
 
 By default, the HTML Reporter will show all the tests results. Enabling this option will make it show only the failing tests, hiding all that pass. This can also be managed by the HTML interface.
 
+### `QUnit.config.norender` (string) | default: `undefined`
+
+Don't render the selected status filters that match the results. When running multiple tests the dom starts to get cluttered and slow down browser responsiveness. Enabling this flag will only render test results that don't match the given filter. For example `?norender=pass,fail,skip` will only show todo tests in the dom after they have run. _This will still show content as the test is running, but will not keep the test results in the dom._
+
 ### `QUnit.config.maxDepth` (number) | default: `5`
 
 Specifies the depth up-to which an object will be dumped during a diff. To run without a max depth, use a value of `-1`.

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -754,7 +754,7 @@ export function escapeText( s ) {
 
 	QUnit.log( function( details ) {
 		var assertList, assertLi,
-			message, expected, actual, diff,
+			status, message, expected, actual, diff,
 			showDiff = false,
 			testItem = id( "qunit-test-output-" + details.testId );
 
@@ -762,8 +762,8 @@ export function escapeText( s ) {
 			return;
 		}
 
-		message = escapeText( details.message ) || ( details.result ? "okay" : "failed" );
-		message = "<span class='test-message'>" + message + "</span>";
+		status = escapeText( details.message ) || ( details.result ? "okay" : "failed" );
+		message = "<span class='test-message'>" + status + "</span>";
 		message += "<span class='runtime'>@ " + details.runtime + " ms</span>";
 
 		// The pushFailure doesn't provide details.expected
@@ -844,7 +844,7 @@ export function escapeText( s ) {
 	} );
 
 	QUnit.testDone( function( details ) {
-		var testTitle, time, testItem, assertList,
+		var testTitle, time, testItem, assertList, status,
 			good, bad, testCounts, skipped, sourceName,
 			tests = id( "qunit-tests" );
 
@@ -852,7 +852,21 @@ export function escapeText( s ) {
 			return;
 		}
 
+
 		testItem = id( "qunit-test-output-" + details.testId );
+
+		if ( details.failed > 0 ) {
+			status = "failed";
+		} else if ( details.todo ) {
+			status = "todo";
+		} else {
+			status = details.skipped ? "skipped" : "passed";
+		}
+
+		// can accept 'passed' or 'passed,skipped,todo'
+		if ( config.norender && config.norender.split( "," ).indexOf( status ) > -1 ) {
+			testItem.remove();
+		}
 
 		assertList = testItem.getElementsByTagName( "ol" )[ 0 ];
 

--- a/reporter/urlparams.js
+++ b/reporter/urlparams.js
@@ -23,6 +23,8 @@ import { window } from "../src/globals";
 	// Regular expression or case-insenstive substring match against "moduleName: testName"
 	QUnit.config.filter = urlParams.filter;
 
+	QUnit.config.norender = urlParams.norender;
+
 	// Test order randomization
 	if ( urlParams.seed === true ) {
 

--- a/test/reporter-urlparams-norender.html
+++ b/test/reporter-urlparams-norender.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>QUnit URL Parameters Test Suite</title>
+		<link rel="stylesheet" href="../dist/qunit.css">
+		<script src="../dist/qunit.js"></script>
+		<script src="reporter-urlparams-norender.js"></script>
+	</head>
+	<body>
+		<div id="qunit"></div>
+	</body>
+</html>

--- a/test/reporter-urlparams-norender.js
+++ b/test/reporter-urlparams-norender.js
@@ -1,0 +1,19 @@
+if ( !location.search ) {
+	location.replace( "?norender=passed,skipped" );
+}
+
+// Don't change this module name without also changing the module parameter when loading this suite
+QUnit.module( "urlParams norender module", function() {
+	QUnit.skip( "Skip", function() {} );
+	QUnit.skip( "Skip", function() {} );
+
+	QUnit.test( "Should set norender correctly", function( assert ) {
+		assert.strictEqual( QUnit.config.norender, "passed,skipped" );
+	} );
+
+	QUnit.test( "Ensure that no tests were rendered", function( assert ) {
+
+		// we have to set it to 1 becuase there is currently one item being rendered, this one as it is in progress
+		assert.strictEqual( document.querySelector( "#qunit-tests" ).children.length, 1 );
+	} );
+} );


### PR DESCRIPTION
What? 

- Adds a flag to avoid rendering tests after completed

Why?

When running large test suites, rendering test output for all passing tests will cause the page to become unresponsive.

```
> document.querySelector('#qunit-tests').children.length
> 24280
```

The above output is from:

```
81 tests completed in 97301 milliseconds, with 2 failed, 2 skipped, and 0 todo.
210 assertions of 217 passed, 7 failed.
```

While the tests are running, the page becomes more and more unresponsive while appending output items. `24280` only represents the immediate children, the full child tree contains `146780` nodes.

```
> const tests = document.querySelector('#qunit-tests');
> tests.getElementsByTagName("*").length
> 146780
```

Solution?

- Add a `norender` option to not render test output given the filter criteria. 

![norender-example](https://user-images.githubusercontent.com/1854811/45665232-c36f2e80-bac4-11e8-94b7-50116166beff.gif)
