### PR TITLE
HTML Reporter: remove test item when hidepassed is set to true

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -582,20 +582,6 @@ export function escapeText( s ) {
 		appendToolbar();
 	}
 
-	function appendTestsList( modules ) {
-		var i, l, x, z, test, moduleObj;
-
-		for ( i = 0, l = modules.length; i < l; i++ ) {
-			moduleObj = modules[ i ];
-
-			for ( x = 0, z = moduleObj.tests.length; x < z; x++ ) {
-				test = moduleObj.tests[ x ];
-
-				appendTest( test.name, test.testId, moduleObj.name );
-			}
-		}
-	}
-
 	function appendTest( name, testId, moduleName ) {
 		var title, rerunTrigger, testBlock, assertList,
 			tests = id( "qunit-tests" );
@@ -641,7 +627,6 @@ export function escapeText( s ) {
 
 		// Initialize QUnit elements
 		appendInterface();
-		appendTestsList( details.modules );
 	} );
 
 	QUnit.done( function( details ) {
@@ -734,16 +719,9 @@ export function escapeText( s ) {
 	}
 
 	QUnit.testStart( function( details ) {
-		var running, testBlock, bad;
+		var running, bad;
 
-		testBlock = id( "qunit-test-output-" + details.testId );
-		if ( testBlock ) {
-			testBlock.className = "running";
-		} else {
-
-			// Report later registered tests
-			appendTest( details.name, details.testId, details.module );
-		}
+		appendTest( details.name, details.testId, details.module );
 
 		running = id( "qunit-testresult-display" );
 		if ( running ) {

--- a/test/reporter-urlparams-hidepassed.html
+++ b/test/reporter-urlparams-hidepassed.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>QUnit URL Parameters Test Suite</title>
+		<link rel="stylesheet" href="../dist/qunit.css">
+		<script src="../dist/qunit.js"></script>
+		<script src="reporter-urlparams-hidepassed.js"></script>
+	</head>
+	<body>
+		<div id="qunit"></div>
+	</body>
+</html>

--- a/test/reporter-urlparams-hidepassed.js
+++ b/test/reporter-urlparams-hidepassed.js
@@ -1,0 +1,30 @@
+if ( !location.search ) {
+	location.replace( "?hidepassed=true" );
+}
+
+QUnit.module( "urlParams hidepassed module", function() {
+	QUnit.test( "passed", function( assert ) {
+		assert.ok( true );
+	} );
+	QUnit.test( "passed", function( assert ) {
+		assert.ok( true );
+	} );
+	QUnit.test( "passed", function( assert ) {
+		assert.ok( true );
+	} );
+	QUnit.test( "passed", function( assert ) {
+		assert.ok( true );
+	} );
+	QUnit.test( "passed", function( assert ) {
+		assert.ok( true );
+	} );
+	QUnit.test( "passed", function( assert ) {
+		assert.ok( true );
+	} );
+
+	QUnit.test( "passed", function( assert ) {
+
+		// we have to set it to 1 becuase there is currently one item being rendered, this one as it is in progress
+		assert.strictEqual( document.getElementById( "qunit-tests" ).children.length, 1 );
+	} );
+} );


### PR DESCRIPTION
What? 

- make hidepassed remove item from div rather than just hiding it

Why?

When running large test suites, rendering test output for all passing tests will cause the page to become unresponsive.

```
> document.querySelector('#qunit-tests').children.length
> 24280
```

The above output is from:

```
81 tests completed in 97301 milliseconds, with 2 failed, 2 skipped, and 0 todo.
210 assertions of 217 passed, 7 failed.
```

While the tests are running, the page becomes more and more unresponsive while appending output items. `24280` only represents the immediate children, the full child tree contains `146780` nodes.

```
> const tests = document.querySelector('#qunit-tests');
> tests.getElementsByTagName("*").length
> 146780
```

Solution?

- actually remove child item when it passes

![norender-example](https://user-images.githubusercontent.com/1854811/45665232-c36f2e80-bac4-11e8-94b7-50116166beff.gif)
