### PR TITLE
HTML Reporter: Add showskipped option

### DIFF
--- a/docs/config/QUnit.config.md
+++ b/docs/config/QUnit.config.md
@@ -43,6 +43,10 @@ By default QUnit will use whatever the starting content of `#qunit-fixture` is a
 
 By default, the HTML Reporter will show all the tests results. Enabling this option will make it show only the failing tests, hiding all that pass. This can also be managed by the HTML interface.
 
+### `QUnit.config.showskipped` (boolean) | default: `false`
+
+By default, the HTML Reporter will hide all skipped tests. Enabling this option will show the skipped tests. This can also be managed by the HTML interface.
+
 ### `QUnit.config.maxDepth` (number) | default: `5`
 
 Specifies the depth up-to which an object will be dumped during a diff. To run without a max depth, use a value of `-1`.

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -212,6 +212,19 @@ export function escapeText( s ) {
 		} else {
 			window.location = updatedUrl;
 		}
+
+		// Check if we can apply the change without a page refresh
+		if ( "showskipped" === field.name && "replaceState" in window.history ) {
+			QUnit.urlParams[ field.name ] = value;
+			config[ field.name ] = value || false;
+			tests = id( "qunit-tests" );
+			if ( tests ) {
+				toggleClass( tests, "showskipped", value || false );
+			}
+			window.history.replaceState( null, "", updatedUrl );
+		} else {
+			window.location = updatedUrl;
+		}
 	}
 
 	function setUrl( params ) {
@@ -625,6 +638,9 @@ export function escapeText( s ) {
 		tests = id( "qunit-tests" );
 		if ( tests && config.hidepassed ) {
 			addClass( tests, "hidepass" );
+		}
+		if ( tests && config.showskipped ) {
+			addClass( tests, "showskipped" );
 		}
 	} );
 

--- a/reporter/urlparams.js
+++ b/reporter/urlparams.js
@@ -40,6 +40,11 @@ import { window } from "../src/globals";
 			tooltip: "Only show tests and assertions that fail. Stored as query-strings."
 		},
 		{
+			id: "showskipped",
+			label: "Show skipped tests",
+			tooltip: "Reveal skipped tests. Stored as query-strings."
+		},
+		{
 			id: "noglobals",
 			label: "Check for Globals",
 			tooltip: "Enabling this will test if any test introduces new properties on the " +

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -236,7 +236,8 @@
 }
 
 #qunit-tests.hidepass li.running,
-#qunit-tests.hidepass li.pass:not(.todo) {
+#qunit-tests.hidepass li.pass:not(.todo),
+#qunit-tests:not(.showskipped) li.skipped {
 	visibility: hidden;
 	position: absolute;
 	width:   0;


### PR DESCRIPTION
Hi, I felt that the default option to show skipped tests should be false. So I added an option to show the skipped tests to the HTML reporter.