### PR TITLE
Tests: Unbreak test:cli due to unknown 'qunit' command

### DIFF
--- a/test/cli/helpers/execute.js
+++ b/test/cli/helpers/execute.js
@@ -4,11 +4,14 @@ const path = require( "path" );
 const exec = require( "execa" ).shell;
 
 // Executes the provided command from within the fixtures directory
-module.exports = function execute( command ) {
+// The execaOptions parameter is used by test/cli/watch.js to
+// control the stdio stream.
+module.exports = function execute( command, execaOptions ) {
 	const cwd = process.cwd();
 	process.chdir( path.join( __dirname, "..", "fixtures" ) );
 
-	const execution = exec( command );
+	command = command.replace( /^qunit\b/, "../../../bin/qunit" );
+	const execution = exec( command, execaOptions );
 
 	process.chdir( cwd );
 

--- a/test/cli/watch.js
+++ b/test/cli/watch.js
@@ -2,22 +2,15 @@
 
 const fs = require( "fs-extra" );
 const path = require( "path" );
-const exec = require( "execa" ).shell;
 const co = require( "co" );
 const fixturify = require( "fixturify" );
 
 const expectedWatchOutput = require( "./fixtures/expected/watch-tap-outputs" );
+const executeHelper = require( "./helpers/execute" );
 
 // Executes the provided command from within the fixtures directory
 function execute( command ) {
-	const cwd = process.cwd();
-	process.chdir( path.join( __dirname, "fixtures" ) );
-
-	const execution = exec( command, { stdio: [ null, null, null, "ipc" ] } );
-
-	process.chdir( cwd );
-
-	return execution;
+	return executeHelper( command, { stdio: [ null, null, null, "ipc" ] } );
 }
 
 const fixturePath = path.join( __dirname, "fixtures", "watching" );


### PR DESCRIPTION
Follows-up 362e2416669, which removed 'npm link' from the 'test:cli'
script command.

Initially, I thought the reason the child processes can't find qunit is due to our use of `execa.shell` instead of regular `execa`. Specifically, `execa.shell()` spawns a process that starts with a new shell and no inherited environment variables. `execa()` on the other hand inherits environment variables like PATH by default, and it also has a `preferLocal` option that ensures node_modules/.bin is in the`PATH` even if you're running the tests without `npm run ..` (e.g. if you'd use `bin/qunit test/cli/*.js` directly).

Switching to `execa()` is non-trivial because it requires an array as input and there aren't built-in or trust-worthy modules that parse a command string into an array. Trying it with brute-force I realised the problem is actually that `qunit` isn't visible at all even in the original environment created by npm-run.

While npm-run does add node_modules/.bin, and bins from (dev)dependencies are indeed linked from there, the bins from the current package itself (qunit) are never linked in .bin.

So... keeping it simple and just string-replacing 'qunit' with 'bin/qunit', which also matches the way we invoke the cli from other commands in package.json already.