### PR TITLE
HTML Reporter: Fix an unescaped details.source.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,6 +162,7 @@ module.exports = function( grunt ) {
 						"test/reporter-html/single-testid.html",
 						"test/reporter-html/window-onerror.html",
 						"test/reporter-html/window-onerror-preexisting-handler.html",
+						"test/reporter-html/xhtml-escape-details-source.xhtml",
 						"test/reporter-html/xhtml-single-testid.xhtml",
 						"test/reporter-urlparams.html",
 						"test/moduleId.html",

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -936,7 +936,7 @@ export function escapeText( s ) {
 		// Show the source of the test when showing assertions
 		if ( details.source ) {
 			sourceName = document.createElement( "p" );
-			sourceName.innerHTML = "<strong>Source: </strong>" + details.source;
+			sourceName.innerHTML = "<strong>Source: </strong>" + escapeText( details.source );
 			addClass( sourceName, "qunit-source" );
 			if ( testPassed ) {
 				addClass( sourceName, "qunit-collapsed" );

--- a/test/reporter-html/test-escape-details-source.js
+++ b/test/reporter-html/test-escape-details-source.js
@@ -1,0 +1,8 @@
+QUnit.module( "outer module", function() {
+	QUnit.module( "inner module", function() {
+		QUnit.test( "test name with a special char > after char", function( assert ) {
+			assert.expect( 1 );
+			assert.ok( true, "dummy test" );
+		} );
+	} );
+} );

--- a/test/reporter-html/xhtml-escape-details-source.xhtml
+++ b/test/reporter-html/xhtml-escape-details-source.xhtml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xml:lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<meta charset="UTF-8" />
+	<title>QUnit Main Test Suite</title>
+	<link rel="stylesheet" href="../../dist/qunit.css" />
+	<script src="../../dist/qunit.js"></script>
+	<script src="test-escape-details-source.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+</body>
+</html>


### PR DESCRIPTION
Fix an unescaped details.source  in innerHTML.

It became apparent when using .xhtml (application/xml+xhtml) but may
have other XSS issues (see
https://en.wikipedia.org/wiki/Cross-site_scripting ) in plain HTML.

The new test gets stuck before the production code fix and completes
successfully and promptly after applying it.