### PR TITLE
Tests: Add case for errors while console is mocked

### DIFF
--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -69,6 +69,16 @@ not ok 1 global failure
 # fail 1
 `,
 
+	"qunit 'fail/mocked-console.js'":
+`TAP version 13
+ok 2 Uncaught error > good
+1..2
+# pass 1
+# skip 0
+# todo 0
+# fail 1
+`,
+
 	"qunit test single.js 'glob/**/*-test.js'":
 `TAP version 13
 ok 1 A-Test > derp

--- a/test/cli/fixtures/fail/mocked-console.js
+++ b/test/cli/fixtures/fail/mocked-console.js
@@ -1,0 +1,24 @@
+QUnit.module( "Error with mocked console", function( hooks ) {
+	var orgLog, orgError;
+
+	// Stub
+	hooks.before( function() {
+		orgLog = console.log;
+		orgError = console.error;
+		console.log = console.error = function() {};
+	} );
+
+	// Restore
+	hooks.after( function() {
+		console.log = orgLog;
+		console.error = orgError;
+	} );
+
+	QUnit.test( "bad", function( assert ) {
+		assert.ok( this.aint() );
+	} );
+
+	QUnit.test( "good", function( assert ) {
+		assert.ok( 1 );
+	} );
+} );

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -79,8 +79,22 @@ QUnit.module( "CLI Main", function() {
 		}
 	} ) );
 
+	// Test case for https://github.com/qunitjs/qunit/issues/1333
 	QUnit.test( "report assert.throws() failures properly", co.wrap( function* ( assert ) {
 		const command = "qunit fail/throws-match.js";
+		try {
+			yield execute( command );
+		} catch ( e ) {
+			assert.equal( e.code, 1 );
+			assert.equal( e.stderr, "" );
+			const re = new RegExp( expectedOutput[ command ] );
+			assert.equal( re.test( e.stdout ), true );
+		}
+	} ) );
+
+	// Test case for https://github.com/qunitjs/qunit/issues/1340
+	QUnit.test( "report errors with mocked console", co.wrap( function* ( assert ) {
+		const command = "qunit fail/mocked-console.js";
 		try {
 			yield execute( command );
 		} catch ( e ) {


### PR DESCRIPTION
The asserted output is not what we'd like it to be.
This is just to document what happens today.

Ref https://github.com/qunitjs/qunit/issues/1340.