### PR TITLE
Build: Remove Node 4 from AppVeyor test matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@
 # Test against this version of Node.js
 environment:
   matrix:
-    - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "7"
     - nodejs_version: "8"


### PR DESCRIPTION
The AppVeyor build is currently failing due to Node 4 not
being supported anymore, whih is intentional and removed from
the Travi CI config already, but in reviewing #1288, I forgot
about AppVeyor :)