### PR TITLE
Assert: Report RegExp/Error as strings from rejects()/throws()

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -286,11 +286,13 @@ class Assert {
 			// We don't want to validate thrown error
 			if ( !expected ) {
 				result = true;
-				expected = null;
 
 			// Expected is a regexp
 			} else if ( expectedType === "regexp" ) {
 				result = expected.test( errorString( actual ) );
+
+				// Log the string form of the regexp
+				expected = String( expected );
 
 			// Expected is a constructor, maybe an Error constructor
 			} else if ( expectedType === "function" && actual instanceof expected ) {
@@ -302,6 +304,9 @@ class Assert {
 					actual.name === expected.name &&
 					actual.message === expected.message;
 
+				// Log the string form of the Error object
+				expected = errorString( expected );
+
 			// Expected is a validation function which returns true if validation passed
 			} else if ( expectedType === "function" && expected.call( {}, actual ) === true ) {
 				expected = null;
@@ -311,7 +316,9 @@ class Assert {
 
 		currentTest.assert.pushResult( {
 			result,
-			actual,
+
+			// undefined if it didn't throw
+			actual: actual && errorString( actual ),
 			expected,
 			message
 		} );
@@ -378,11 +385,13 @@ class Assert {
 				// We don't want to validate
 				if ( expected === undefined ) {
 					result = true;
-					expected = actual;
 
 					// Expected is a regexp
 				} else if ( expectedType === "regexp" ) {
 					result = expected.test( errorString( actual ) );
+
+					// Log the string form of the regexp
+					expected = String( expected );
 
 					// Expected is a constructor, maybe an Error constructor
 				} else if ( expectedType === "function" && actual instanceof expected ) {
@@ -393,6 +402,9 @@ class Assert {
 					result = actual instanceof expected.constructor &&
 						actual.name === expected.name &&
 						actual.message === expected.message;
+
+					// Log the string form of the Error object
+					expected = errorString( expected );
 
 					// Expected is a validation function which returns true if validation passed
 				} else {
@@ -412,7 +424,9 @@ class Assert {
 
 				currentTest.assert.pushResult( {
 					result,
-					actual,
+
+					// leave rejection value of undefined as-is
+					actual: actual && errorString( actual ),
 					expected,
 					message
 				} );
@@ -431,12 +445,14 @@ Assert.prototype.raises = Assert.prototype[ "throws" ];
 /**
  * Converts an error into a simple string for comparisons.
  *
- * @param {Error} error
+ * @param {Error|Object} error
  * @return {String}
  */
 function errorString( error ) {
 	const resultErrorString = error.toString();
 
+	// If the error wasn't a subclass of Error but something like
+	// an object literal with name and message properties...
 	if ( resultErrorString.substring( 0, 7 ) === "[object" ) {
 		const name = error.name ? error.name.toString() : "Error";
 		const message = error.message ? error.message.toString() : "";

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -54,12 +54,12 @@ ok 2 Second > 1
 
 	"qunit fail/throws-match.js":
 `TAP version 13
-not ok 1 global failure
+not ok 1 Throws match > bad
   ---
   message: "match error"
   severity: failed
-  actual: {}
-  expected: {}
+  actual: "Error: Match me with a pattern"
+  expected: "/incorrect pattern/"
   stack: .*
   ...
 1..1

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -52,7 +52,7 @@ ok 2 Second > 1
 # todo 0
 # fail 0`,
 
-	"qunit 'fail/throws-match.js'":
+	"qunit fail/throws-match.js":
 `TAP version 13
 not ok 1 global failure
   ---

--- a/test/main/assert.js
+++ b/test/main/assert.js
@@ -252,7 +252,7 @@ QUnit.test( "throws", function( assert ) {
 			};
 		},
 		{ name: "SomeName", message: "some message" },
-		"thrown error object is similar to the expected plain object"
+		"thrown object is similar to the expected plain object"
 	);
 
 	assert.throws(
@@ -378,7 +378,7 @@ QUnit.test( "rejects", function( assert ) {
 			message: "some message"
 		} ),
 		{ name: "SomeName", message: "some message" },
-		"thrown error object is similar to the expected plain object"
+		"thrown object is similar to the expected plain object"
 	);
 
 	assert.rejects(


### PR DESCRIPTION
Report the `actual` (Error object) as a string. And report an `expected` RegExp or Error object also in its string form.

Currently, they were reported as their objects, which in the generic js-reporters module was just printed as an empty object without any properties because instances of RegExp and instances of Error both have no own properties that are enumerable.

Fixes #1333.