### PR TITLE
CLI: Update node-watch to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "commander": "2.12.2",
     "js-reporters": "1.2.1",
     "resolve": "1.5.0",
-    "node-watch": "0.5.9",
+    "node-watch": "0.6.0",
     "minimatch": "3.0.4"
   },
   "devDependencies": {

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -159,6 +159,10 @@ run.watch = function watch() {
 		run.restart( args );
 	} );
 
+	watcher.on( "ready", () => {
+		run.apply( null, args );
+	} );
+
 	function stop() {
 		console.log( "Stopping QUnit..." );
 
@@ -170,12 +174,6 @@ run.watch = function watch() {
 
 	process.on( "SIGTERM", stop );
 	process.on( "SIGINT", stop );
-
-	// initial run must be delayed by at least 200ms
-	// https://github.com/yuanchuan/node-watch/issues/71
-	setTimeout( () => {
-		run.apply( null, args );
-	}, 210 );
 };
 
 module.exports = run;


### PR DESCRIPTION
* Added `ready` event.
* Improved Linux support for recursive watching (changes that happen during the debounce from new directories are now reported as well).

The above two points were effectively temporary regressions in qunit master from 94fa19f899, which are now restored.

When collaborating with upstream and improving the unit tests, I found various bugs with Node.js itself (or actually its upstream, libuv), which couldn't be easily worked around. These were only bugs about there being extra events in addition to the correct ones, which is fine from our perspective; it just means we potentially re-run the tests more often (in practice, not even that, given we debounce).

* https://github.com/nodejs/node/issues/25301
* https://github.com/nodejs/node/issues/25290