### PR TITLE
Build: Prepare 2.9.0 release, including authors and history update

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -91,3 +91,7 @@ Dave K. Smith <dave.k.smith@gmail.com>
 David Vollbracht <david.vollbracht@gmail.com>
 Jochen Ulrich <jochenulrich@t-online.de>
 Michał Gołębiowski-Owczarek <m.goleb@gmail.com>
+Leonardo Balter <leonardo.balter@gmail.com>
+Kevin Partington <kevin.partington@kernelpanicstudios.com>
+Kevin Partington <kevin.partington@kernelpanicstudios.com> <platinum.azure@kernelpanicstudios.com>
+Manoj Kumar <manoj@kumarmj.me> <nithmanoj@gmail.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -128,8 +128,8 @@ Daniel De Jager <danielmiester@gmail.com>
 Brahim Arkni <brahim.arkni@gmail.com>
 Cory Forsyth <cory.forsyth@gmail.com>
 Ed <proteenx11@gmail.com>
-yagni <yagni@users.noreply.github.com>
 Manoj Kumar <manoj@kumarmj.me>
+yagni <yagni@users.noreply.github.com>
 Tobias Oetzel <tobias.oetzel@sap.com>
 Ray Tiley <raytiley@gmail.com>
 Dustin Specker <dustinspecker@dustinspecker.com>

--- a/History.md
+++ b/History.md
@@ -1,3 +1,13 @@
+2.9.0 / 2019-01-06
+==================
+
+  * Assert: Report RegExp/Error as strings from `rejects()`/`throws()` (#1333)
+  * Build: Add macOS and Windows to the Travis CI test matrix
+  * Build: Update engine requirement package.json to Node 6
+  * CLI: Reduce size of the dependencies tree (#1342)
+  * CLI: Re-implement run.watch() with 'node-watch' instead of 'sane' (#1342)
+  * HTML Reporter: Fix an unescaped details.source (#1341)
+
 2.8.0 / 2018-11-02
 ==================
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "qunit",
   "title": "QUnit",
   "description": "An easy-to-use JavaScript Unit Testing framework.",
-  "version": "2.8.1-pre",
+  "version": "2.9.0-pre",
   "homepage": "https://qunitjs.com",
   "author": {
     "name": "jQuery Foundation and other contributors",


### PR DESCRIPTION
Add various names to mailmap so that they don't result in
duplicate entries from grunt-authors, using the existing entries
as canonical to make only the smallest change to AUTHORS.txt.