### PR TITLE
Build: Set "root: true" in eslintrc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env": {
         "es6": true
     },


### PR DESCRIPTION
Otherwise, the proposed PR for qunitjs/jquery-release (https://github.com/qunitjs/jquery-release/pull/2), is unable to get "grunt" to pass on qunitjs/qunit because it's clone will be in a subdirectory of itself, which then fails as follows:

> ~/Dev/qunit-release/__release/repo/test/reporter-html/window-onerror-preexisting-handler.html
>  9:27  error  'onerrorCallingContext' is assigned a value but never used  no-unused-vars

This is because ESLint is walking up from __release/repo and finding an unrelated `.eslintrc` file in *that* repo.