### PR TITLE
Use `console.group/groupEnd()` to group console messages during test runs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,9 @@
     "parserOptions": {
         "sourceType": "module"
     },
+    "globals": {
+        "console": true
+    },
     "rules": {
         "arrow-spacing": ["error", { "before": true, "after": true }],
         "brace-style": ["error", "1tbs", { "allowSingleLine": true }],

--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -7,6 +7,13 @@ export const now = Date.now || function() {
 	return new Date().getTime();
 };
 
+export const isNodeJS = detectNodeJS();
+
+function detectNodeJS() {
+	// eslint-disable-next-line no-undef
+	return typeof process !== "undefined" && process.release.name === "node";
+}
+
 export const hasPerformanceApi = detectPerformanceApi();
 export const performance = hasPerformanceApi ? window.performance : undefined;
 export const performanceNow = hasPerformanceApi ?

--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -10,8 +10,10 @@ export const now = Date.now || function() {
 export const isNodeJS = detectNodeJS();
 
 function detectNodeJS() {
-	// eslint-disable-next-line no-undef
-	return typeof process !== "undefined" && process.release.name === "node";
+	/* eslint-disable no-undef */
+	return typeof process !== "undefined" &&
+		process.release !== undefined &&
+		process.release.name === "node";
 }
 
 export const hasPerformanceApi = detectPerformanceApi();

--- a/src/reports/suite.js
+++ b/src/reports/suite.js
@@ -1,4 +1,4 @@
-import { measure, performance, performanceNow } from "../core/utilities";
+import { measure, performance, performanceNow, isNodeJS } from "../core/utilities";
 
 export default class SuiteReport {
 	constructor( name, parentSuite ) {
@@ -23,7 +23,7 @@ export default class SuiteReport {
 			}
 		}
 
-		if ( console.group ) {
+		if ( console.group && !isNodeJS ) {
 			console.group( `Test Suite: ${this.name}` );
 		}
 
@@ -56,7 +56,7 @@ export default class SuiteReport {
 			}
 		}
 
-		if ( console.groupEnd ) {
+		if ( console.groupEnd && !isNodeJS ) {
 			console.groupEnd();
 		}
 

--- a/src/reports/suite.js
+++ b/src/reports/suite.js
@@ -21,10 +21,10 @@ export default class SuiteReport {
 				const suiteLevel = this.fullName.length;
 				performance.mark( `qunit_suite_${suiteLevel}_start` );
 			}
-		}
 
-		if ( console.group && !isNodeJS ) {
-			console.group( `Test Suite: ${this.name}` );
+			if ( console.group && !isNodeJS ) {
+				console.group( `Test Suite: ${this.name}` );
+			}
 		}
 
 		return {
@@ -54,10 +54,10 @@ export default class SuiteReport {
 					`qunit_suite_${suiteLevel}_end`
 				);
 			}
-		}
 
-		if ( console.groupEnd && !isNodeJS ) {
-			console.groupEnd();
+			if ( console.groupEnd && !isNodeJS ) {
+				console.groupEnd();
+			}
 		}
 
 		return {

--- a/src/reports/suite.js
+++ b/src/reports/suite.js
@@ -23,6 +23,8 @@ export default class SuiteReport {
 			}
 		}
 
+		console.group( `Test Suite: ${this.name}` );
+
 		return {
 			name: this.name,
 			fullName: this.fullName.slice(),
@@ -51,6 +53,8 @@ export default class SuiteReport {
 				);
 			}
 		}
+
+		console.groupEnd();
 
 		return {
 			name: this.name,

--- a/src/reports/suite.js
+++ b/src/reports/suite.js
@@ -23,7 +23,9 @@ export default class SuiteReport {
 			}
 		}
 
-		console.group( `Test Suite: ${this.name}` );
+		if ( console.group ) {
+			console.group( `Test Suite: ${this.name}` );
+		}
 
 		return {
 			name: this.name,
@@ -54,7 +56,9 @@ export default class SuiteReport {
 			}
 		}
 
-		console.groupEnd();
+		if ( console.groupEnd ) {
+			console.groupEnd();
+		}
 
 		return {
 			name: this.name,

--- a/src/reports/test.js
+++ b/src/reports/test.js
@@ -27,7 +27,9 @@ export default class TestReport {
 			}
 		}
 
-		console.group( `Test: ${this.name}` );
+		if ( console.group ) {
+			console.group( `Test: ${this.name}` );
+		}
 
 		return {
 			name: this.name,
@@ -52,7 +54,9 @@ export default class TestReport {
 			}
 		}
 
-		console.groupEnd();
+		if ( console.groupEnd ) {
+			console.groupEnd();
+		}
 
 		return extend( this.start(), {
 			runtime: this.getRuntime(),

--- a/src/reports/test.js
+++ b/src/reports/test.js
@@ -27,6 +27,8 @@ export default class TestReport {
 			}
 		}
 
+		console.group( `Test: ${this.name}` );
+
 		return {
 			name: this.name,
 			suiteName: this.suiteName,
@@ -49,6 +51,8 @@ export default class TestReport {
 				);
 			}
 		}
+
+		console.groupEnd();
 
 		return extend( this.start(), {
 			runtime: this.getRuntime(),

--- a/src/reports/test.js
+++ b/src/reports/test.js
@@ -25,10 +25,10 @@ export default class TestReport {
 			if ( performance ) {
 				performance.mark( "qunit_test_start" );
 			}
-		}
 
-		if ( console.group && !isNodeJS ) {
-			console.group( `Test: ${this.name}` );
+			if ( console.group && !isNodeJS ) {
+				console.group( `Test: ${this.name}` );
+			}
 		}
 
 		return {
@@ -52,10 +52,10 @@ export default class TestReport {
 					"qunit_test_end"
 				);
 			}
-		}
 
-		if ( console.groupEnd && !isNodeJS ) {
-			console.groupEnd();
+			if ( console.groupEnd && !isNodeJS ) {
+				console.groupEnd();
+			}
 		}
 
 		return extend( this.start(), {

--- a/src/reports/test.js
+++ b/src/reports/test.js
@@ -1,4 +1,4 @@
-import { extend, measure, performance, performanceNow } from "../core/utilities";
+import { extend, measure, performance, performanceNow, isNodeJS } from "../core/utilities";
 
 export default class TestReport {
 	constructor( name, suite, options ) {
@@ -27,7 +27,7 @@ export default class TestReport {
 			}
 		}
 
-		if ( console.group ) {
+		if ( console.group && !isNodeJS ) {
 			console.group( `Test: ${this.name}` );
 		}
 
@@ -54,7 +54,7 @@ export default class TestReport {
 			}
 		}
 
-		if ( console.groupEnd ) {
+		if ( console.groupEnd && !isNodeJS ) {
 			console.groupEnd();
 		}
 


### PR DESCRIPTION
<img width="779" alt="screenshot" src="https://user-images.githubusercontent.com/141300/54199721-ec97d700-44c9-11e9-8c8e-519a601fd494.png">

When running multiple tests in the browser it can be hard to figure out what tests are causing warnings or other debug messages. The `console.group()` API allows console output to be grouped to make it easier to see what those messages belong to.

In this PR I've added `console.group/groupEnd()` calls to the test/test suite start/end handlers. This makes it a lot easier to see what console output belongs to what test.