### PR TITLE
Build: Update node-watch to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "commander": "2.12.2",
     "js-reporters": "1.2.1",
     "resolve": "1.9.0",
-    "node-watch": "0.6.0",
+    "node-watch": "0.6.1",
     "minimatch": "3.0.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2486,10 +2486,10 @@ negotiator@0.6.1:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
   integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
 
-node-watch@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/node-watch/-/node-watch-0.6.0.tgz#ab0703b60cd270783698e57a428faa0010ed8fd0"
-  integrity sha512-XAgTL05z75ptd7JSVejH1a2Dm1zmXYhuDr9l230Qk6Z7/7GPcnAs/UyJJ4ggsXSvWil8iOzwQLW0zuGUvHpG8g==
+node-watch@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/node-watch/-/node-watch-0.6.1.tgz#b9874111ce9f5841b1c7596120206c7b825be0e9"
+  integrity sha512-gwQiR7weFRV8mAtT0x0kXkZ18dfRLB45xH7q0hCOVQMLfLb2f1ZaSvR57q4/b/Vj6B0RwMNJYbvb69e1yM7qEA==
 
 nopt@3.x, nopt@~3.0.6:
   version "3.0.6"


### PR DESCRIPTION
https://github.com/yuanchuan/node-watch/releases/tag/v0.6.1

* Fixed a race condition where a short-lived file
  could cause the wrong result.

* Fixed a bug affecting Windows installations.