### PR TITLE
CSS: Tweak CSS to address dropdown and button styles

### DIFF
--- a/src/qunit.css
+++ b/src/qunit.css
@@ -11,6 +11,13 @@
 
 /** Font Family and Sizes */
 
+
+[id^=qunit] button {
+	font-size: initial;
+	border: initial;
+	background-color: buttonface;
+}
+
 #qunit-tests, #qunit-header, #qunit-banner, #qunit-testrunner-toolbar, #qunit-filteredTest, #qunit-userAgent, #qunit-testresult {
 	font-family: "Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial, sans-serif;
 }
@@ -118,7 +125,7 @@
 
 #qunit-modulefilter-search {
 	box-sizing: border-box;
-	width: 400px;
+	min-width: 400px;
 }
 
 #qunit-modulefilter-search-container:after {
@@ -131,7 +138,7 @@
 #qunit-modulefilter-dropdown {
 	/* align with #qunit-modulefilter-search */
 	box-sizing: border-box;
-	width: 400px;
+	min-width: 400px;
 	position: absolute;
 	right: 0;
 	top: 50%;
@@ -204,6 +211,7 @@
 #qunit-modulefilter-dropdown-list .clickable {
 	display: block;
 	padding-left: 0.15em;
+	padding-right: 0.5em;
 }
 
 


### PR DESCRIPTION
The tested site can override the styling of buttons, which causes the
displayed content to 'jump' around while tests are running, so ensure
that all buttons in qunit elements are set to inital font size, border
and background.

With modules that have long names, the filter list becomes un-useable,
so allow them to grow using min-width rather than fixed width