### PR TITLE
Core: reset testTimeout on assert.timeout if config.timeout has already been set

### DIFF
--- a/docs/assert/timeout.md
+++ b/docs/assert/timeout.md
@@ -19,6 +19,8 @@ Sets the length of time to wait for async operations before failing the test.
 
 `assert.timeout()` sets the length of time, in milliseconds, to wait for async operations in the current test. This is equivalent to setting `config.testTimeout` on a per-test basis. The timeout length only applies when performing async operations.
 
+If `assert.timeout()` is called after a timeout has already been set, the old timeout will be cleared and the new duration will be used for the new timer.
+
 If `0` is passed, then the test will be assumed to be completely synchronous. If a non-numeric value is passed as an argument, the function will throw an error.
 
 ### Examples

--- a/src/assert.js
+++ b/src/assert.js
@@ -1,11 +1,12 @@
 import dump from "./dump";
 import equiv from "./equiv";
-import { internalStop } from "./test";
+import { internalStop, resetTestTimeout } from "./test";
 import Logger from "./logger";
 
 import config from "./core/config";
 import { objectType, objectValues } from "./core/utilities";
 import { sourceFromStacktrace } from "./core/stacktrace";
+import { clearTimeout } from "./globals";
 
 class Assert {
 	constructor( testContext ) {
@@ -20,6 +21,15 @@ class Assert {
 		}
 
 		this.test.timeout = duration;
+
+		// If a timeout has been set, clear it and reset with the new duration
+		if ( config.timeout ) {
+			clearTimeout( config.timeout );
+
+			if ( config.timeoutHandler && this.test.timeout > 0 ) {
+				resetTestTimeout( this.test.timeout );
+			}
+		}
 	}
 
 	// Documents a "step", which is a string value, in a test as a passing assertion

--- a/src/test.js
+++ b/src/test.js
@@ -726,6 +726,12 @@ export function only( testName, callback ) {
 	newTest.queue();
 }
 
+// Resets config.timeout with a new timeout duration.
+export function resetTestTimeout( timeoutDuration ) {
+	clearTimeout( config.timeout );
+	config.timeout = setTimeout( config.timeoutHandler( timeoutDuration ), timeoutDuration );
+}
+
 // Put a hold on processing and return a function that will release it.
 export function internalStop( test ) {
 	let released = false;
@@ -744,16 +750,21 @@ export function internalStop( test ) {
 
 		if ( typeof timeoutDuration === "number" && timeoutDuration > 0 ) {
 			clearTimeout( config.timeout );
-			config.timeout = setTimeout( function() {
-				pushFailure(
-					`Test took longer than ${timeoutDuration}ms; test timed out.`,
-					sourceFromStacktrace( 2 )
-				);
-				released = true;
-				internalRecover( test );
-			}, timeoutDuration );
+			config.timeoutHandler = function( timeout ) {
+				return function() {
+					pushFailure(
+						`Test took longer than ${timeout}ms; test timed out.`,
+						sourceFromStacktrace( 2 )
+					);
+					released = true;
+					internalRecover( test );
+				};
+			};
+			config.timeout = setTimeout(
+				config.timeoutHandler( timeoutDuration ),
+				timeoutDuration
+			);
 		}
-
 	}
 
 	return function resume() {

--- a/test/main/assert/timeout.js
+++ b/test/main/assert/timeout.js
@@ -45,6 +45,23 @@ QUnit.module( "assert.timeout", function() {
 		}, /You must pass a number as the duration to assert.timeout/ );
 	} );
 
+	QUnit.test( "reset a timeout if an existing timeout has been set", function( assert ) {
+		assert.timeout( 50 );
+		assert.expect( 1 );
+
+		setTimeout( function() {
+			assert.timeout( 10 );
+			var originalPushFailure = QUnit.config.current.pushFailure;
+			QUnit.config.current.pushFailure = function pushFailureStub( message ) {
+				QUnit.config.current.pushFailure = originalPushFailure;
+
+				assert.equal( message, "Test took longer than 10ms; test timed out." );
+				done();
+			};
+		} );
+		var done = assert.async();
+	} );
+
 	QUnit.module( "a value of zero", function() {
 		function stubPushFailure( assert ) {
 			var originalPushFailure = QUnit.config.current.pushFailure;


### PR DESCRIPTION
This reset any current timeouts by canceling and setting up a new timer.

Usecase: https://github.com/emberjs/ember-qunit/issues/496