### PR TITLE
Docs: rename "Main assertions" page to "Main Methods"

### DIFF
--- a/docs/QUnit/index.md
+++ b/docs/QUnit/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Main assertions
+title: Main Methods
 category: main
 categories:
   - topics

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -3,7 +3,7 @@ layout: wrapper
 ---
 
 <section class="sidebar">
-    <h2>Main methods:</h2>
+    <h2>Main Methods</h2>
     <ul class="sidebar-list">
     {% assign methods = site.pages | where:'categories', 'main' %}
     {% for page in methods %}
@@ -13,7 +13,7 @@ layout: wrapper
     {% endfor %}
     </ul>
 
-    <h2>Assertions:</h2>
+    <h2>Assertions</h2>
     <ul class="sidebar-list">
     {% assign assertions = site.pages | where:'categories', 'assert' %}
     {% for page in assertions %}
@@ -23,7 +23,7 @@ layout: wrapper
     {% endfor %}
     </ul>
 
-    <h2>Config:</h2>
+    <h2>Configuration Tools</h2>
 
     <ul class="sidebar-list">
     {% assign config = site.pages | where:'categories', 'config' %}
@@ -34,7 +34,7 @@ layout: wrapper
     {% endfor %}
     </ul>
 
-    <h2>Callbacks:</h2>
+    <h2>Callback Handlers</h2>
 
     <ul class="sidebar-list">
     {% assign callbacks = site.pages | where:'categories', 'callbacks' %}
@@ -45,7 +45,7 @@ layout: wrapper
     {% endfor %}
     </ul>
 
-    <h2>Async control:</h2>
+    <h2>Async Control</h2>
 
     <ul class="sidebar-list">
     {% assign async = site.pages | where:'categories', 'async' %}

--- a/docs/_layouts/wrapper.html
+++ b/docs/_layouts/wrapper.html
@@ -23,14 +23,35 @@
                 </div>
                 <nav role="navigation" class="site-nav">
                     <ul class="site-nav-list">
-                        {% assign topics = site.pages | where:'categories', 'topics' %}
-                        {% for topic in topics %}
                         <li class="site-nav-list-item">
-                            <a class="site-nav-list-link" href="{{ topic.url }}">
-                                {{ topic.title }}
+                            <a class="site-nav-list-link" href="/QUnit/">
+                                Main Methods
                             </a>
                         </li>
-                        {% endfor %}
+
+                        <li class="site-nav-list-item">
+                            <a class="site-nav-list-link" href="/assert/">
+                                Assertions
+                            </a>
+                        </li>
+
+                        <li class="site-nav-list-item">
+                            <a class="site-nav-list-link" href="/config/">
+                                Configuration Tools
+                            </a>
+                        </li>
+
+                        <li class="site-nav-list-item">
+                            <a class="site-nav-list-link" href="/callbacks/">
+                                Callback Handlers
+                            </a>
+                        </li>
+
+                        <li class="site-nav-list-item">
+                            <a class="site-nav-list-link" href="/async">
+                                Async Control
+                            </a>
+                        </li>
                     </ul>
                 </nav>
             </div>

--- a/docs/callbacks/index.md
+++ b/docs/callbacks/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Callback handlers
+title: Callback Handlers
 category: callbacks
 categories:
   - topics

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Configuration tools
+title: Configuration Tools
 category: config
 categories:
   - topics


### PR DESCRIPTION
Fixes #1396

Also fixes some discrepancies between the sidebar and the top navigation.