### PR TITLE
Docs: Repair old url for QUnit.log with redirect

### DIFF
--- a/docs/callbacks/QUnit.log.md
+++ b/docs/callbacks/QUnit.log.md
@@ -4,6 +4,8 @@ title: QUnit.log
 description: Register a callback to fire whenever an assertion completes.
 categories:
   - callbacks
+redirect_from:
+  - "/QUnit.log/"
 ---
 
 ## `QUnit.log( callback )`


### PR DESCRIPTION
The link <https://api.qunitjs.com/QUnit.log/> used to work.