### PR TITLE
Add testsNotRan to keep count of testsNotRan to ensure moduleDone is called

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -151,6 +151,7 @@ module.exports = function( grunt ) {
 						"test/reorderError2.html",
 						"test/callbacks.html",
 						"test/callbacks-promises.html",
+						"test/callbacks-filters.html",
 						"test/events.html",
 						"test/events-in-test.html",
 						"test/logs.html",

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -46,7 +46,7 @@ const config = {
 		tests: [],
 		childModules: [],
 		testsRun: 0,
-		unskippedTestsRun: 0,
+		testsIgnored: 0,
 		hooks: {
 			before: [],
 			beforeEach: [],

--- a/src/module.js
+++ b/src/module.js
@@ -23,7 +23,7 @@ function createModule( name, testEnvironment, modifiers ) {
 		tests: [],
 		moduleId: generateHash( moduleName ),
 		testsRun: 0,
-		unskippedTestsRun: 0,
+		testsIgnored: 0,
 		childModules: [],
 		suiteReport: new SuiteReport( name, parentSuite ),
 

--- a/test/callbacks-filters.html
+++ b/test/callbacks-filters.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<title>QUnit Callbacks Filters Test Suite</title>
+	<link rel="stylesheet" href="../dist/qunit.css">
+	<script src="../dist/qunit.js"></script>
+	<script src="callbacks-filters.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+	<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/test/callbacks-filters.js
+++ b/test/callbacks-filters.js
@@ -1,0 +1,171 @@
+var invokedHooks = [];
+var done = false;
+
+function callback( name ) {
+	return function() {
+		if ( done ) {
+			return;
+		}
+
+		invokedHooks.push( name );
+	};
+}
+
+QUnit.begin( callback( "begin" ) );
+QUnit.moduleStart( callback( "moduleStart" ) );
+QUnit.testStart( callback( "testStart" ) );
+QUnit.testDone( callback( "testDone" ) );
+QUnit.moduleDone( callback( "moduleDone" ) );
+QUnit.done( callback( "done" ) );
+
+QUnit.done( function() {
+	if ( done ) {
+		return;
+	}
+
+	done = true;
+
+	QUnit.test( "verify callback order", function( assert ) {
+		assert.deepEqual( invokedHooks, [
+			"begin",
+			"moduleStart",
+			"testStart",
+			"testDone",
+			"testStart",
+			"testDone",
+			"moduleDone",
+			"moduleStart",
+			"testStart",
+			"testDone",
+			"moduleDone",
+			"moduleStart",
+			"testStart",
+			"testDone",
+			"moduleDone",
+			"moduleStart",
+			"testStart",
+			"testDone",
+			"moduleStart",
+			"testStart",
+			"testDone",
+			"moduleDone",
+			"moduleDone",
+			"moduleStart",
+			"testStart",
+			"testDone",
+			"moduleStart",
+			"testStart",
+			"testDone",
+			"testStart",
+			"after",
+			"testDone",
+			"moduleDone",
+			"testStart",
+			"after",
+			"testDone",
+			"moduleDone",
+			"done"
+		] );
+	} );
+} );
+
+QUnit.config.moduleId = [ "1cf055b9" ];
+
+// match for module Id
+QUnit.module( "module1", function() {
+	QUnit.test( "test should run 1.1", function( assert ) {
+		assert.ok( true );
+	} );
+
+	QUnit.test( "test should run 1.2", function( assert ) {
+		assert.ok( true );
+	} );
+} );
+
+// no match module Id
+QUnit.module( "module2", function() {
+	QUnit.test( "test should NOT run 2.1", function( assert ) {
+		assert.ok( false );
+	} );
+
+	QUnit.test( "test should NOT run 2.2", function( assert ) {
+		assert.ok( false );
+	} );
+} );
+
+QUnit.config.moduleId = [];
+QUnit.config.testId = [ "3b3c4e75" ];
+
+QUnit.module( "module3", function() {
+
+	// match test Id
+	QUnit.test( "ABCtest should run 3.1", function( assert ) {
+		assert.ok( true );
+	} );
+
+	QUnit.test( "test should NOT run 3.2", function( assert ) {
+		assert.ok( false );
+	} );
+} );
+
+QUnit.config.testId = [];
+QUnit.config.filter = "!.2";
+
+QUnit.module( "module4", function() {
+
+	// match string filter
+	QUnit.test( "test should run 4.1", function( assert ) {
+		assert.ok( true );
+	} );
+
+	QUnit.test( "test should NOT run 4.2", function( assert ) {
+		assert.ok( false );
+	} );
+} );
+
+// Make sure nested module scenarios are correct
+QUnit.module( "module5", function() {
+	QUnit.test( "test should run 5", function( assert ) {
+		assert.ok( true );
+	} );
+
+	QUnit.module( "nestedModule5A", function() {
+		QUnit.test( "test should run 5.A.1", function( assert ) {
+			assert.ok( true );
+		} );
+	} );
+} );
+
+QUnit.module( "module6", {
+	after: function( ) {
+		invokedHooks.push( "after" );
+	}
+}, function() {
+	QUnit.test( "test should run 6.1", function( assert ) {
+		assert.ok( true );
+	} );
+
+	QUnit.test( "test should NOT run 6.2", function( assert ) {
+		assert.ok( true );
+	} );
+
+	QUnit.module( "nestedModule6A", {
+		after: function( ) {
+			invokedHooks.push( "after" );
+		}
+	}, function() {
+		QUnit.test( "test should run 6.A.1", function( assert ) {
+			assert.ok( true );
+		} );
+		QUnit.test( "test should run 6.A.2", function( assert ) {
+			assert.ok( true );
+		} );
+		QUnit.test( "test should run 6.A.3", function( assert ) {
+			assert.ok( true );
+		} );
+	} );
+
+	QUnit.test( "test should run 6.3", function( assert ) {
+		assert.ok( true );
+	} );
+} );

--- a/test/main/modules.js
+++ b/test/main/modules.js
@@ -81,12 +81,8 @@ QUnit.module( "after (skip)", {
 	}
 } );
 
-QUnit.test( "does not run after initial tests", function( assert ) {
+QUnit.test( "does not run after final non-skipped tests", function( assert ) {
 	assert.expect( 0 );
-} );
-
-QUnit.test( "runs after final unskipped test", function( assert ) {
-	assert.expect( 1 );
 } );
 
 QUnit.skip( "last test in module is skipped" );


### PR DESCRIPTION
Fixes #1416 

This PR adds `testsNotRan` to a module. This is used to keep track of any tests where `isValid()` returns false.
This attribute will be used in this condition: 
```
if ( ( module.testsRun + module.testsNotRan ) === numberOfTests( module ) ) {
```
checking for whether the module has completed running its tests. 