### PR TITLE
Build: Bumps package.lock verstion to 2.9.4-pre

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qunit",
-  "version": "2.9.3-pre",
+  "version": "2.9.4-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This happens automatically when `npm install` runs.