### PR TITLE
Correct tab order for toolbar filters

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -502,13 +502,22 @@ export function escapeText( s ) {
 		return moduleFilter;
 	}
 
+	function toolbarFilters() {
+		var toolbarFilters = document.createElement( "span" );
+
+		toolbarFilters.id = "qunit-toolbar-filters";
+		toolbarFilters.appendChild( toolbarLooseFilter() );
+		toolbarFilters.appendChild( toolbarModuleFilter() );
+
+		return toolbarFilters;
+	}
+
 	function appendToolbar() {
 		var toolbar = id( "qunit-testrunner-toolbar" );
 
 		if ( toolbar ) {
 			toolbar.appendChild( toolbarUrlConfigContainer() );
-			toolbar.appendChild( toolbarModuleFilter() );
-			toolbar.appendChild( toolbarLooseFilter() );
+			toolbar.appendChild( toolbarFilters() );
 			toolbar.appendChild( document.createElement( "div" ) ).className = "clearfix";
 		}
 	}

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -105,6 +105,10 @@
 	height: 1.6em;
 }
 
+#qunit-toolbar-filters {
+	float: right;
+}
+
 .qunit-url-config,
 .qunit-filter,
 #qunit-modulefilter {
@@ -114,7 +118,6 @@
 
 .qunit-filter,
 #qunit-modulefilter {
-	float: right;
 	position: relative;
 	margin-left: 1em;
 }


### PR DESCRIPTION
The objective of this pull request is to correct the tab order for the toolbar filters. Currently, the tab order for the **Module** and **Filter** items in the toolbar are in reverse order (right-to-left for English) as described by Issue #1428:

Issue #1428 - Tab order for "Module" and "Filter" items is reversed in toolbar

The changes applied in this pull request wrap the two toolbar filters into a single container SPAN element. This new container has a `float: right` style that acts as a substitute for the original `float` styles assigned to each of the two toolbar filters. When the individual `float` styles are removed from the toolbar filters, then the order of the corresponding DOM elements (also the tab order) for these filters will no longer be the reverse of the visual order.

