### PR TITLE
Proc Queue/Test: add "started", "ended" to stats from tests/modules

### DIFF
--- a/src/core/processing-queue.js
+++ b/src/core/processing-queue.js
@@ -162,7 +162,8 @@ function done() {
 
 	ProcessingQueue.finished = true;
 
-	const runtime = now() - config.started;
+	const ended = now();
+	const runtime = ended - config.started;
 	const passed = config.stats.all - config.stats.bad;
 
 	if ( config.stats.all === 0 ) {
@@ -192,6 +193,8 @@ function done() {
 		passed,
 		failed: config.stats.bad,
 		total: config.stats.all,
+		started: config.started,
+		ended,
 		runtime
 	} ).then( () => {
 

--- a/src/reports/test.js
+++ b/src/reports/test.js
@@ -66,6 +66,14 @@ export default class TestReport {
 		return this._endTime - this._startTime;
 	}
 
+	getStartTime() {
+		return this._startTime;
+	}
+
+	getEndTime() {
+		return this._endTime;
+	}
+
 	getStatus() {
 		if ( this.skipped ) {
 			return "skipped";

--- a/src/test.js
+++ b/src/test.js
@@ -296,7 +296,8 @@ Test.prototype = {
 			bad = 0,
 			storage = config.storage;
 
-		this.runtime = now() - this.started;
+		this.ended = now();
+		this.runtime = this.ended - this.started;
 
 		config.stats.all += this.assertions.length;
 		module.stats.all += this.assertions.length;
@@ -334,6 +335,8 @@ Test.prototype = {
 			failed: bad,
 			passed: this.assertions.length - bad,
 			total: this.assertions.length,
+			started: skipped ? 0 : this.started,
+			ended: skipped ? 0 : this.ended,
 			runtime: skipped ? 0 : this.runtime,
 
 			// HTML Reporter use
@@ -372,13 +375,18 @@ Test.prototype = {
 			module.hooks = {};
 
 			emit( "suiteEnd", module.suiteReport.end( true ) );
+
+			const ended = now();
+
 			return runLoggingCallbacks( "moduleDone", {
 				name: module.name,
 				tests: module.tests,
 				failed: module.stats.bad,
 				passed: module.stats.all - module.stats.bad,
 				total: module.stats.all,
-				runtime: now() - module.stats.started
+				started: module.stats.started,
+				ended: ended,
+				runtime: ended - module.stats.started
 			} );
 		}
 	},
@@ -450,6 +458,8 @@ Test.prototype = {
 		}
 
 		// Destructure of resultInfo = { result, actual, expected, message, negative }
+		const ended = now();
+
 		var source,
 			details = {
 				module: this.module.name,
@@ -459,7 +469,9 @@ Test.prototype = {
 				actual: resultInfo.actual,
 				testId: this.testId,
 				negative: resultInfo.negative || false,
-				runtime: now() - this.started,
+				ended,
+				started: this.started,
+				runtime: ended - this.started,
 				todo: !!this.todo
 			};
 


### PR DESCRIPTION
Added 'started' and 'ended' fields in the stats information alongside 'runtime'. Both values were already available in internal code, just not returned in the test and module statistics information. They're very useful for diagnosing the precise timing of individual tests.