### PR TITLE
Core: Connected to #1434: run all `only` tests

### DIFF
--- a/docs/QUnit/module.md
+++ b/docs/QUnit/module.md
@@ -59,7 +59,7 @@ The module's callback is invoked with the test environment as its `this` context
 
 ## Exclusive tests
 
-When you are debugging your code, you will often need to _only_ run a subset of tests. You can append `only` to `QUnit.module` to specify which module you want to run.
+When you are debugging your code, you will often need to _only_ run a subset of tests. You can append `only` to `QUnit.module` to specify which module(s) you want to run.
 
 It works the same way `QUnit.only()` does for tests.
 

--- a/docs/QUnit/module.md
+++ b/docs/QUnit/module.md
@@ -61,8 +61,6 @@ The module's callback is invoked with the test environment as its `this` context
 
 When you are debugging your code, you will often need to _only_ run a subset of tests. You can append `only` to `QUnit.module` to specify which module you want to run.
 
-Note that if more than one module was defined using `QUnit.module.only()`, only the first one will run.
-
 It works the same way `QUnit.only()` does for tests.
 
 ## Inclusive tests

--- a/docs/QUnit/only.md
+++ b/docs/QUnit/only.md
@@ -8,7 +8,7 @@ categories:
 
 ## `QUnit.only( name, callback )`
 
-Adds a test to exclusively run, preventing all other tests from running.
+Add a set of tests to exclusively run, preventing other tests from running.
 
 | parameter | description |
 |-----------|-------------|
@@ -23,9 +23,7 @@ Adds a test to exclusively run, preventing all other tests from running.
 
 ### Description
 
-Use this method to focus your test suite on a specific test. `QUnit.only` will cause any other tests in your suite to be ignored.
-
-Note that if more than one `QUnit.only` is present only the first instance will run.
+Use this method to focus your test suite on a specific set of tests. `QUnit.only` will cause any other tests in your suite to be ignored.
 
 This is an alternative to filtering tests to run in the HTML reporter. It is especially useful when you use a console reporter or in a codebase with a large set of long running tests.
 
@@ -48,9 +46,13 @@ QUnit.test( "stomp", function( assert ) {
   assert.ok( false, "I'm not quite ready yet" );
 });
 
-// You're currently working on the laser feature, so we run only this test
+// You're currently working on the laser feature, so we run only these tests
 QUnit.only( "laser", function( assert ) {
   assert.ok( this.robot.laser() );
+});
+
+QUnit.only( "other laser", function( assert ) {
+  assert.ok( this.robot.otherLaser() );
 });
 ```
 
@@ -73,8 +75,12 @@ test( "stomp", t => {
   t.ok( false, "I'm not quite ready yet" );
 });
 
-// You're currently working on the laser feature, so we run only this test
+// You're currently working on the laser feature, so we run only these tests
 only( "laser", function( t ) {
   t.ok( this.robot.laser() );
+});
+
+only( "other laser", function( t ) {
+  t.ok( this.robot.otherLaser() );
 });
 ```

--- a/docs/QUnit/only.md
+++ b/docs/QUnit/only.md
@@ -1,14 +1,14 @@
 ---
 layout: default
 title: only
-description: Adds a test to exclusively run, preventing all other tests from running.
+description: Adds a test to exclusively run, preventing any other tests not defined with `QUnit.only()` from running.
 categories:
   - main
 ---
 
 ## `QUnit.only( name, callback )`
 
-Add a set of tests to exclusively run, preventing other tests from running.
+Adds a test to exclusively run, preventing any other tests not defined with `QUnit.only()` from running.
 
 | parameter | description |
 |-----------|-------------|
@@ -23,7 +23,7 @@ Add a set of tests to exclusively run, preventing other tests from running.
 
 ### Description
 
-Use this method to focus your test suite on a specific set of tests. `QUnit.only` will cause any other tests in your suite to be ignored.
+Use this method to focus your test suite on specific tests. `QUnit.only` will cause any other tests in your suite to be ignored.
 
 This is an alternative to filtering tests to run in the HTML reporter. It is especially useful when you use a console reporter or in a codebase with a large set of long running tests.
 

--- a/src/module.js
+++ b/src/module.js
@@ -9,6 +9,11 @@ let focused = false;
 
 const moduleStack = [];
 
+function isParentModuleInQueue() {
+	const modulesInQueue = config.modules.map( module => module.moduleId );
+	return moduleStack.some( module => modulesInQueue.includes( module.moduleId ) );
+}
+
 function createModule( name, testEnvironment, modifiers ) {
 	const parentModule = moduleStack.length ? moduleStack.slice( -1 )[ 0 ] : null;
 	const moduleName = parentModule !== null ? [ parentModule.name, name ].join( " > " ) : name;
@@ -96,7 +101,7 @@ function processModule( name, options, executeNow, modifiers = {} ) {
 }
 
 export default function module( name, options, executeNow ) {
-	if ( focused ) {
+	if ( focused && !isParentModuleInQueue() ) {
 		return;
 	}
 

--- a/src/module.js
+++ b/src/module.js
@@ -104,14 +104,12 @@ export default function module( name, options, executeNow ) {
 }
 
 module.only = function() {
-	if ( focused ) {
-		return;
+	if ( !focused ) {
+		config.modules.length = 0;
+		config.queue.length = 0;
 	}
 
-	config.modules.length = 0;
-	config.queue.length = 0;
-
-	module( ...arguments );
+	processModule( ...arguments );
 
 	focused = true;
 };

--- a/src/test.js
+++ b/src/test.js
@@ -719,12 +719,10 @@ export function skip( testName ) {
 
 // Will be exposed as QUnit.only
 export function only( testName, callback ) {
-	if ( focused ) {
-		return;
+	if ( !focused ) {
+		config.queue.length = 0;
+		focused = true;
 	}
-
-	config.queue.length = 0;
-	focused = true;
 
 	const newTest = new Test( {
 		testName: testName,

--- a/test/module-only.js
+++ b/test/module-only.js
@@ -39,6 +39,14 @@ QUnit.done( function() {
 			"c7ae85c2": {
 				skipped: false,
 				todo: false
+			},
+			"74b800d1": {
+				skipped: false,
+				todo: false
+			},
+			"2f8fb2a2": {
+				skipped: false,
+				todo: false
 			}
 		} );
 	} );
@@ -87,5 +95,29 @@ QUnit.module( "module C", function() {
 QUnit.module.only( "module D", function() {
 	QUnit.test( "test D", function( assert ) {
 		assert.ok( true, "this test should run as well" );
+	} );
+} );
+
+QUnit.module.only( "module E", function() {
+	QUnit.module( "module F", function() {
+		QUnit.test( "test F", function( assert ) {
+			assert.ok( true, "this test should run as well" );
+		} );
+	} );
+
+	QUnit.test( "test E", function( assert ) {
+		assert.ok( true, "this test should run as well" );
+	} );
+} );
+
+QUnit.module.skip( "module G", function() {
+	QUnit.module.only( "module H", function() {
+		QUnit.test( "test H", function( assert ) {
+			assert.ok( false, "this test should not run" );
+		} );
+	} );
+
+	QUnit.test( "test G", function( assert ) {
+		assert.ok( false, "this test should not run" );
 	} );
 } );

--- a/test/module-only.js
+++ b/test/module-only.js
@@ -35,6 +35,10 @@ QUnit.done( function() {
 			"75e1bf3f": {
 				skipped: false,
 				todo: false
+			},
+			"c7ae85c2": {
+				skipped: false,
+				todo: false
 			}
 		} );
 	} );
@@ -77,5 +81,11 @@ QUnit.module( "module B", function() {
 QUnit.module( "module C", function() {
 	QUnit.test( "test C", function( assert ) {
 		assert.ok( false, "this test should not run" );
+	} );
+} );
+
+QUnit.module.only( "module D", function() {
+	QUnit.test( "test D", function( assert ) {
+		assert.ok( true, "this test should run as well" );
 	} );
 } );

--- a/test/only.js
+++ b/test/only.js
@@ -1,17 +1,25 @@
-QUnit.module( "QUnit.only" );
+QUnit.module( "QUnit.only", function( hooks ) {
+	let testsRun = 0;
 
-QUnit.test( "implicitly skipped test", function( assert ) {
-	assert.ok( false, "test should be skipped" );
-} );
+	hooks.after( function( assert ) {
+		assert.strictEqual( testsRun, 2 );
+	} );
 
-QUnit.only( "only run this test", function( assert ) {
-	assert.ok( true, "only this test should run" );
-} );
+	QUnit.test( "implicitly skipped test", function( assert ) {
+		assert.ok( false, "test should be skipped" );
+	} );
 
-QUnit.test( "another implicitly skipped test", function( assert ) {
-	assert.ok( false, "test should be skipped" );
-} );
+	QUnit.only( "run this test", function( assert ) {
+		testsRun += 1;
+		assert.ok( true, "only this test should run" );
+	} );
 
-QUnit.only( "ignore the subsequent calls to only", function( assert ) {
-	assert.ok( false, "this test should be skipped" );
+	QUnit.test( "another implicitly skipped test", function( assert ) {
+		assert.ok( false, "test should be skipped" );
+	} );
+
+	QUnit.only( "all tests with only run", function( assert ) {
+		testsRun += 1;
+		assert.ok( true, "this test should run as well" );
+	} );
 } );


### PR DESCRIPTION
WIP alternate implementation of #1434: modifying the way `only` behaves instead of adding a new method.

TODO:
- [x] docs;