### PR TITLE
All: Update node-watch dependency and test fixtures for Node 12+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 os: linux
 language: node_js
 node_js:
+  - "14"
+  - "12"
   - "10"
   - "8"
   - "6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qunit",
-  "version": "2.10.0-pre",
+  "version": "2.10.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3265,9 +3265,9 @@
       "dev": true
     },
     "node-watch": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.6.1.tgz",
-      "integrity": "sha512-gwQiR7weFRV8mAtT0x0kXkZ18dfRLB45xH7q0hCOVQMLfLb2f1ZaSvR57q4/b/Vj6B0RwMNJYbvb69e1yM7qEA=="
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.6.4.tgz",
+      "integrity": "sha512-cI6CHzivIFESe8djiK3Wh90CtWQBxLwMem8x8S+2GSvCvFgoMuOKVlfJtQ/2v3Afg3wOnHl/+tXotEs8z5vOrg=="
     },
     "nopt": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "commander": "2.12.2",
     "js-reporters": "1.2.1",
     "resolve": "1.9.0",
-    "node-watch": "0.6.1",
+    "node-watch": "0.6.4",
     "minimatch": "3.0.4"
   },
   "devDependencies": {

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -143,7 +143,7 @@ not ok 2 global failure
 # fail 2
 `,
 
-	// in node 8, the stack trace includes 'at <anonymous>. But not in node 6 or 10.
+	// Ignore the last frame about Node processing ticks (differs between Node 10 ad 12+)
 	"qunit no-tests":
 `TAP version 13
 not ok 1 global failure
@@ -157,7 +157,7 @@ not ok 1 global failure
     at advanceTestQueue (.*)
     at Object.advance (.*)
     at unblockAndAdvanceQueue (.*)(\n    at <anonymous>)?
-    at process._tickCallback (.*)
+    at .*
   ...
 1..1
 # pass 0
@@ -174,9 +174,8 @@ not ok 1 timeout > first
   severity: failed
   actual: null
   expected: undefined
-  stack:     at ontimeout (.*)
-    at tryOnTimeout (.*)
-    (.*)\\s*(.*)?
+  stack:     at .* (.*timers.js.*)
+    at .*(\n    at .*)?(\n    at .*)?
   ...
 ok 2 timeout > second
 1..2
@@ -186,7 +185,7 @@ ok 2 timeout > second
 # fail 1
 `,
 
-	// in node 8, the stack trace includes 'at <anonymous>. But not in node 6 or 10.
+	// Ignore the last frame about Node processing ticks (differs between Node 10 ad 12+)
 	"qunit qunit --filter 'no matches' test":
 `TAP version 13
 not ok 1 global failure
@@ -200,7 +199,7 @@ not ok 1 global failure
     at advanceTestQueue (.*)
     at Object.advance (.*)
     at unblockAndAdvanceQueue (.*)(\n    at <anonymous>)?
-    at process._tickCallback (.*)
+    at .*
   ...
 1..1
 # pass 0
@@ -220,7 +219,7 @@ ok 1 Single > has a test
 # todo 0
 # fail 0`,
 
-	"node --expose-gc --allow-natives-syntax ../../../bin/qunit.js memory-leak/*.js":
+	"node --expose-gc ../../../bin/qunit.js memory-leak/*.js":
 `TAP version 13
 ok 1 some nested module > can call method on foo
 ok 2 later thing > has released all foos

--- a/test/cli/fixtures/memory-leak/.eslintrc.json
+++ b/test/cli/fixtures/memory-leak/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+	"parserOptions": {
+		"ecmaVersion": 2017
+	}
+}

--- a/test/cli/fixtures/memory-leak/index.js
+++ b/test/cli/fixtures/memory-leak/index.js
@@ -1,5 +1,7 @@
 /* globals gc */
 
+const v8 = require( "v8" );
+
 const foos = new WeakSet();
 class Foo {
 	constructor() {
@@ -13,48 +15,60 @@ class Foo {
 	destroy() { }
 }
 
+function streamToString( stream ) {
+	const chunks = [];
+	return new Promise( ( resolve, reject ) => {
+		stream.on( "data", chunk => chunks.push( chunk ) );
+		stream.on( "error", reject );
+		stream.on( "end", () => resolve( Buffer.concat( chunks ).toString( "utf8" ) ) );
+	} );
+}
+
 QUnit.module( "some nested module", function( hooks ) {
-	let foo;
+	let foo1;
 
 	hooks.beforeEach( function() {
-		foo = new Foo();
+		foo1 = new Foo();
 	} );
 
 	hooks.afterEach( function() {
-		foo.destroy();
+		foo1.destroy();
 	} );
 
 	QUnit.test( "can call method on foo", function( assert ) {
-		assert.equal( foo.sayHello(), "Hi!" );
+		assert.equal( foo1.sayHello(), "Hi!" );
 	} );
 
 } );
 
 QUnit.module( "later thing", function() {
-	QUnit.test( "has released all foos", function( assert ) {
+	QUnit.test( "has released all foos", async function( assert ) {
 
-		// Without async here, the test runner is recursive, and therefore the `foo`
-		// instance is still retained.
-		return Promise.resolve()
-			.then( () => {
+		// Create another one to ensure our heap match logic is working.
+		let foo2 = new Foo();
 
-				// Requires `--expose-gc` flag to function properly.
-				gc();
+		// The snapshot is expected to contain something like this:
+		// > "part of key (Foo @…) -> value (…) pair in WeakMap (…)"
+		// It is important that the regex uses \d and that the above
+		// comment doesn't include a number after "@", as otherwise
+		// it will match the memory relating to this function's code.
+		const reHeap = /^[^\n]+Foo @\d[^\n]+/gm;
 
-				// Using `new Function` here to avoid a syntax error.
-				const retainedFoos = new Function(
-					"foos",
-					"return %GetWeakSetValues(foos, 0)"
-				)( foos );
+		let snapshot = await streamToString( v8.getHeapSnapshot() );
+		let matches = snapshot.match( reHeap );
+		assert.ok( matches && matches.length, "found local Foo in heap" );
 
-				assert.equal( retainedFoos.length, 0 );
-			} )
-			.catch( error => {
-				if ( error instanceof SyntaxError ) {
-					console.log( "Must launch Node 9 with `--expose-gc --allow-natives-syntax`" );
-				} else {
-					throw error;
-				}
-			} );
+		snapshot = matches = null;
+		foo2.destroy();
+
+		// Comment out the below to test the failure mode
+		foo2 = null;
+
+		// Requires `--expose-gc` flag to function properly.
+		gc();
+
+		snapshot = await streamToString( v8.getHeapSnapshot() );
+		matches = snapshot.match( reHeap );
+		assert.strictEqual( null, matches, "the after heap" );
 	} );
 } );

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -149,9 +149,11 @@ QUnit.module( "CLI Main", function() {
 		}
 	} ) );
 
-	if ( semver.gte( process.versions.node, "9.0.0" ) ) {
+	// https://nodejs.org/docs/v14.0.0/api/v8.html#v8_v8_getheapsnapshot
+	// Created in Node 11.x, but starts working the way we need from Node 14.
+	if ( semver.gte( process.versions.node, "14.0.0" ) ) {
 		QUnit.test( "callbacks and hooks from modules are properly released for garbage collection", co.wrap( function* ( assert ) {
-			const command = "node --expose-gc --allow-natives-syntax ../../../bin/qunit.js memory-leak/*.js";
+			const command = "node --expose-gc ../../../bin/qunit.js memory-leak/*.js";
 			const execution = yield execute( command );
 
 			assert.equal( execution.code, 0 );


### PR DESCRIPTION
### Test fixtures

Node 6-10:
> at process._tickCallback (internal/process/next_tick.js…)
> at ontimeout (timers.js…)

Node 12-14:
> at processTicksAndRejections (internal/process/task_queues.js…)
> at listOnTimeout (internal/timers.js…)

### Test memory

Also update the memory-leak test to use a different strategy
because the V8 native `%GetWeakSetValues` function no longer
exists as of V8 7.1 (or 8.1, not sure) per
<https://chromium.googlesource.com/v8/v8/+/0cf4a0f82f8f810519ba0d4b3b01adef0a0a6c1d>
<https://chromium-review.googlesource.com/c/v8/v8/+/1238574>.

Instead, inspect a heap snapshot and validate it that way.
Also expand the test so that we first verify our logic actually
works, for easier debugging in the future.

### Recursive watch

As of Node 14, `fs.watch` can throw ERR_FEATURE_UNAVAILABLE_ON_PLATFORM,
which is handled by node-watch 0.6.4 per
<https://github.com/yuanchuan/node-watch/commit/fd5d4655ca47db56>.

Without this, Node 14 fails as follows:

> CLI Watch > runs tests and waits until SIGTERM
>
> TypeError [ERR_FEATURE_UNAVAILABLE_ON_PLATFORM]:
> The feature watch recursively is unavailable on the current platform, …
> at Object.watch (fs.js)
> at hasNativeRecursive (…/node_modules/node-watch/lib/has-native-recursive.js)
> at Watcher.watchDirectory (…/node_modules/node-watch/lib/watch.js)
> at watch (…/node_modules/node-watch/lib/watch.js)
> at Function.watch (qunitjs/qunit/src/cli/run.js)

Fixes https://github.com/qunitjs/qunit/issues/1430.