### PR TITLE
Allow test runs with zero assertions to pass

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -96,7 +96,7 @@ extend( QUnit, {
 
 		// Initialize the configuration options
 		extend( config, {
-			stats: { all: 0, bad: 0 },
+			stats: { all: 0, bad: 0, testCount: 0 },
 			started: 0,
 			updateRate: 1000,
 			autostart: true,

--- a/src/core/processing-queue.js
+++ b/src/core/processing-queue.js
@@ -165,7 +165,7 @@ function done() {
 	const runtime = now() - config.started;
 	const passed = config.stats.all - config.stats.bad;
 
-	if ( config.stats.all === 0 ) {
+	if ( config.stats.testCount === 0 ) {
 
 		if ( config.filter && config.filter.length ) {
 			throw new Error( `No tests matched the filter "${config.filter}".` );

--- a/src/test.js
+++ b/src/test.js
@@ -299,6 +299,7 @@ Test.prototype = {
 		this.runtime = now() - this.started;
 
 		config.stats.all += this.assertions.length;
+		config.stats.testCount += 1;
 		module.stats.all += this.assertions.length;
 
 		for ( i = 0; i < this.assertions.length; i++ ) {

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -186,6 +186,15 @@ ok 2 timeout > second
 # fail 1
 `,
 
+	"qunit zero-assertions.js":
+`TAP version 13
+ok 1 Zero assertions > has a test
+1..1
+# pass 1
+# skip 0
+# todo 0
+# fail 0`,
+
 	// in node 8, the stack trace includes 'at <anonymous>. But not in node 6 or 10.
 	"qunit qunit --filter 'no matches' test":
 `TAP version 13

--- a/test/cli/fixtures/zero-assertions.js
+++ b/test/cli/fixtures/zero-assertions.js
@@ -1,0 +1,9 @@
+QUnit.module( "Zero assertions", function() {
+	QUnit.test( "has a test", function( assert ) {
+		assert.expect( 0 );
+
+		/* A zero assertion test run
+		that might be written when using another assertion library other than the QUnit built-ins
+		to verify tested behaviour */
+	} );
+} );

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -149,6 +149,15 @@ QUnit.module( "CLI Main", function() {
 		}
 	} ) );
 
+	QUnit.test( "allows running zero-assertion tests", co.wrap( function* ( assert ) {
+		const command = "qunit zero-assertions.js";
+		const execution = yield execute( command );
+
+		assert.equal( execution.code, 0 );
+		assert.equal( execution.stderr, "" );
+		assert.equal( execution.stdout, expectedOutput[ command ] );
+	} ) );
+
 	if ( semver.gte( process.versions.node, "9.0.0" ) ) {
 		QUnit.test( "callbacks and hooks from modules are properly released for garbage collection", co.wrap( function* ( assert ) {
 			const command = "node --expose-gc --allow-natives-syntax ../../../bin/qunit.js memory-leak/*.js";


### PR DESCRIPTION
Fixes https://github.com/qunitjs/qunit/issues/1405

### Previous Behaviour

Before this change, test runs that included tests which had in total zero assertions, would fail with a global error. This made it, f.e. not possible to run test cases leveraging other means of assertions than the QUnit built-ins (`assert.ok`, `assert.equals`, etc.)
For a reproduction example, see also the description of the original issue: https://github.com/qunitjs/qunit/issues/1405

### New Behaviour

With this change, QUnit will decide if the current test run is "empty" and should therefore fail based on the number of tests included in the run rather than the number of included assertions. This should allow users to run test sets containing zero assertions, as long as respective test cases are marked as such using the `assert.expect(0)` declaration.

### How to Test

Run the new example test case containing no assertions to verify the new behaviourL

```bash
bin/qunit.js test/cli/fixtures/zero-assertions.js
```

| before | after |
|---|---|
| ![image](https://user-images.githubusercontent.com/8811742/85222557-63559c80-b3bc-11ea-9128-7f8894c7a16b.png) | ![image](https://user-images.githubusercontent.com/8811742/85223352-d95d0200-b3c2-11ea-8ddf-bf0122cae17c.png) |

