### PR TITLE
CSS: Scope QUnit UI button style to not affect #qunit-fixture

### DIFF
--- a/src/qunit.css
+++ b/src/qunit.css
@@ -11,8 +11,12 @@
 
 /** Font Family and Sizes */
 
-
-[id^=qunit] button {
+/* Style our buttons in a simple way, uninfluenced by the styles
+   the tested app might load. Don't affect buttons in #qunit-fixture!
+   https://github.com/qunitjs/qunit/pull/1395
+   https://github.com/qunitjs/qunit/issues/1437 */
+#qunit-testrunner-toolbar button,
+#qunit-testresult button {
 	font-size: initial;
 	border: initial;
 	background-color: buttonface;


### PR DESCRIPTION
There are currently two places where we use buttons:
* The toolbar, with the filter "Go" button and the "Apply" and "Reset"
  buttons for the module dropdown.
* The test results, with the temporal "Abort" button.

Fixes https://github.com/qunitjs/qunit/issues/1437.