### PR TITLE
Docs: Restore page title of assert.false

### DIFF
--- a/docs/assert/false.md
+++ b/docs/assert/false.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: false
+title: "false"
 description: A strict boolean false comparison.
 categories:
   - assert


### PR DESCRIPTION
When visiting <https://api.qunitjs.com/assert/false>, the page
lacks the expected document title of `false | QUnit API Docs`.

This is because `false` got intepreted as a boolean value rather
than the string that it is meant to be (Thanks YAML!).

------

Follows-up https://github.com/qunitjs/qunit/commit/0a0b7b8b275e1b4ec6a2b49df7bf0db1f98b2f74.

/cc @ventuno