### PR TITLE
HTML Reporter: Hide skipped tests when hidepassed is set

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -164,6 +164,7 @@ module.exports = function( grunt ) {
 						"test/reporter-html/xhtml-escape-details-source.xhtml",
 						"test/reporter-html/xhtml-single-testid.xhtml",
 						"test/reporter-urlparams.html",
+						"test/reporter-urlparams-hidepassed.html",
 						"test/moduleId.html",
 						"test/onerror/inside-test.html",
 						"test/onerror/outside-test.html",

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -217,8 +217,11 @@ export function escapeText( s ) {
 				if ( field.checked ) {
 					for ( var i = 0; i < length; i++ ) {
 						var test = children[ i ];
+						var className = test ? test.className : "";
+						var classNameHasPass = className.indexOf( "pass" ) > -1;
+						var classNameHasSkipped = className.indexOf( "skipped" ) > -1;
 
-						if ( test && test.className.indexOf( "pass" ) > -1 ) {
+						if ( classNameHasPass || classNameHasSkipped ) {
 							hiddenTests.push( test );
 						}
 					}
@@ -1005,7 +1008,7 @@ export function escapeText( s ) {
 			testItem.appendChild( sourceName );
 		}
 
-		if ( config.hidepassed && status === "passed" ) {
+		if ( config.hidepassed && ( status === "passed" || details.skipped ) ) {
 
 			// use removeChild instead of remove because of support
 			hiddenTests.push( testItem );

--- a/test/reporter-urlparams-hidepassed.js
+++ b/test/reporter-urlparams-hidepassed.js
@@ -21,6 +21,9 @@ QUnit.module( "urlParams hidepassed module", function() {
 	QUnit.test( "passed", function( assert ) {
 		assert.ok( true );
 	} );
+	QUnit.skip( "skipped", function( assert ) {
+		assert.true( false, "can't seem to get this working" );
+	} );
 
 	QUnit.test( "passed", function( assert ) {
 


### PR DESCRIPTION
Fixes #1208

Also adds the test file with the for hidepassed to the list of tests to be run.

I don't think there is test coverage on my changes to the `toolbarChanged` method.