### PR TITLE
Core: Drop support for Node 6 and Node 8, require Node 10+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-dist
-node_modules
-build/report
-browserstack-run.pid
-temp/
-docs/_site/
+/dist
+/node_modules
+/build/report
+/browserstack-run.pid
+/temp/
+/docs/_site/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ node_js:
   - "14"
   - "12"
   - "10"
-  - "8"
-  - "6"
 env:
   - NPM_SCRIPT=test
 matrix:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3443,7 +3443,8 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-type": {
       "version": "1.1.0",
@@ -3842,6 +3843,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
       "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }

--- a/package.json
+++ b/package.json
@@ -33,12 +33,11 @@
   ],
   "main": "qunit/qunit.js",
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   },
   "dependencies": {
     "commander": "2.12.2",
     "js-reporters": "1.2.1",
-    "resolve": "1.9.0",
     "node-watch": "0.6.4",
     "minimatch": "3.0.4"
   },

--- a/src/cli/require-from-cwd.js
+++ b/src/cli/require-from-cwd.js
@@ -1,8 +1,4 @@
-const resolve = require( "resolve" );
-
 module.exports = function requireFromCWD( mod ) {
-
-	// TODO: Once Node 8+ is required, consider using native require.resolve().
-	const resolvedPath = resolve.sync( mod, { basedir: process.cwd() } );
+	const resolvedPath = require.resolve( mod, { paths: [ process.cwd() ] } );
 	return require( resolvedPath );
 };

--- a/src/cli/require-qunit.js
+++ b/src/cli/require-qunit.js
@@ -1,26 +1,24 @@
-const resolve = require( "resolve" );
-
 // Depending on the exact usage, QUnit could be in one of several places, this
 // function handles finding it.
-module.exports = function requireQUnit() {
+module.exports = function requireQUnit( resolve = require.resolve ) {
 	try {
 
 		// First we attempt to find QUnit relative to the current working directory.
-		const localQUnitPath = resolve.sync( "qunit", { basedir: process.cwd() } );
+		const localQUnitPath = resolve( "qunit", { paths: [ process.cwd() ] } );
 		delete require.cache[ localQUnitPath ];
 		return require( localQUnitPath );
 	} catch ( e ) {
 		try {
 
 			// Second, we use the globally installed QUnit
-			delete require.cache[ resolve.sync( "../../qunit/qunit" ) ];
+			delete require.cache[ resolve( "../../qunit/qunit" ) ];
 			// eslint-disable-next-line node/no-missing-require, node/no-unpublished-require
 			return require( "../../qunit/qunit" );
 		} catch ( e ) {
 			if ( e.code === "MODULE_NOT_FOUND" ) {
 
 				// Finally, we use the local development version of QUnit
-				delete require.cache[ resolve.sync( "../../dist/qunit" ) ];
+				delete require.cache[ resolve( "../../dist/qunit" ) ];
 				// eslint-disable-next-line node/no-missing-require, node/no-unpublished-require
 				return require( "../../dist/qunit" );
 			}

--- a/test/cli/fixtures/require-from-cwd/node_modules/qunit/index.js
+++ b/test/cli/fixtures/require-from-cwd/node_modules/qunit/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+	version: "from-cwd"
+};

--- a/test/cli/require-qunit-test.js
+++ b/test/cli/require-qunit-test.js
@@ -1,53 +1,53 @@
-const proxyquire = require( "proxyquire" );
-const resolveStub = {
-	sync( path ) {
-		return path;
-	}
+const proxyquire = require( "proxyquire" ).noCallThru();
+const path = require( "path" );
+const resolveStub = ( path ) => {
+	return path;
 };
 
-QUnit.module( "requireQUnit", function() {
-	QUnit.test( "finds QUnit in the current working directory", function( assert ) {
-		const localQUnit = {
-			"@noCallThru": true
-		};
-		const requireQUnit = proxyquire( "../../src/cli/require-qunit", {
-			"resolve": resolveStub,
-			"qunit": localQUnit
-		} );
+QUnit.module( "requireQUnit", function( hooks ) {
+	const cwd = process.cwd();
 
-		assert.strictEqual( requireQUnit(), localQUnit );
+	hooks.before( () => {
+		process.chdir( cwd );
+	} );
+	hooks.afterEach( () => {
+		process.chdir( cwd );
+	} );
+
+	QUnit.test( "finds QUnit in the current working directory", function( assert ) {
+		const requireQUnit = require( "../../src/cli/require-qunit" );
+		process.chdir( path.join( __dirname, "./fixtures/require-from-cwd" ) );
+
+		assert.propEqual( requireQUnit(), { version: "from-cwd" } );
 	} );
 
 	QUnit.test( "finds globally installed QUnit", function( assert ) {
 		const globalQUnit = {
-			"@noCallThru": true
+			"version": "from-global"
 		};
 		const requireQUnit = proxyquire( "../../src/cli/require-qunit", {
-			"resolve": resolveStub,
 			"qunit": null,
+			"../../dist/qunit": null,
 			"../../qunit/qunit": globalQUnit
 		} );
-
-		assert.strictEqual( requireQUnit(), globalQUnit );
+		assert.strictEqual( requireQUnit( resolveStub ), globalQUnit );
 	} );
 
 	QUnit.test( "finds development mode QUnit", function( assert ) {
 		const devQUnit = {
-			"@noCallThru": true
+			"version": "from-dist"
 		};
 		const requireQUnit = proxyquire( "../../src/cli/require-qunit", {
-			"resolve": resolveStub,
 			"qunit": null,
 			"../../qunit/qunit": null,
 			"../../dist/qunit": devQUnit
 		} );
 
-		assert.strictEqual( requireQUnit(), devQUnit );
+		assert.strictEqual( requireQUnit( resolveStub ), devQUnit );
 	} );
 
 	QUnit.test( "throws error if none of the modules are found", function( assert ) {
 		const requireQUnit = proxyquire( "../../src/cli/require-qunit", {
-			"resolve": resolveStub,
 			"qunit": null,
 			"../../qunit/qunit": null,
 			"../../dist/qunit": null


### PR DESCRIPTION
Per <https://github.com/nodejs/Release>, Node 6 and 8 have
reached EOL in 2019.

This allows us to drop the 'resolve' package as dependency,
which is no longer needed as of Node 8.