### PR TITLE
Test: Clean up usages of assert.ok/notOk where possible

### DIFF
--- a/docs/QUnit/module.md
+++ b/docs/QUnit/module.md
@@ -41,19 +41,19 @@ If `QUnit.module` is defined without a `nested` callback argument, all subsequen
 QUnit.module( "Group A" );
 
 QUnit.test( "basic test example 1", function( assert ) {
-  assert.ok( true, "this is fine" );
+  assert.true( true, "this is fine" );
 });
 QUnit.test( "basic test example 2", function( assert ) {
-  assert.ok( true, "this is also fine" );
+  assert.true( true, "this is also fine" );
 });
 
 QUnit.module( "Group B" );
 
 QUnit.test( "basic test example 3", function( assert ) {
-  assert.ok( true, "this is fine" );
+  assert.true( true, "this is fine" );
 });
 QUnit.test( "basic test example 4", function( assert ) {
-  assert.ok( true, "this is also fine" );
+  assert.true( true, "this is also fine" );
 });
 ```
 
@@ -65,19 +65,19 @@ const { module, test } = QUnit;
 module( "Group A" );
 
 test( "basic test example", assert => {
-  assert.ok( true, "this is fine" );
+  assert.true( true, "this is fine" );
 });
 test( "basic test example 2", assert => {
-  assert.ok( true, "this is also fine" );
+  assert.true( true, "this is also fine" );
 });
 
 module( "Group B" );
 
 test( "basic test example 3", assert => {
-  assert.ok( true, "this is fine" );
+  assert.true( true, "this is fine" );
 });
 test( "basic test example 4", assert => {
-  assert.ok( true, "this is also fine" );
+  assert.true( true, "this is also fine" );
 });
 ```
 
@@ -148,22 +148,22 @@ const { module, test } = QUnit;
 module( "Group A", hooks => {
 
   test( "basic test example", assert => {
-    assert.ok( true, "this is fine" );
+    assert.true( true, "this is fine" );
   });
 
   test( "basic test example 2", assert => {
-    assert.ok( true, "this is also fine" );
+    assert.true( true, "this is also fine" );
   });
 });
 
 module( "Group B", hooks => {
 
   test( "basic test example 3", assert => {
-    assert.ok( true, "this is fine" );
+    assert.true( true, "this is fine" );
   });
 
   test( "basic test example 4", assert => {
-    assert.ok( true, "this is also fine" );
+    assert.true( true, "this is also fine" );
   });
 });
 ```

--- a/docs/QUnit/only.md
+++ b/docs/QUnit/only.md
@@ -44,16 +44,16 @@ QUnit.module( "robot", {
 });
 
 QUnit.test( "say()", function( assert ) {
-  assert.ok( false, "I'm not quite ready yet" );
+  assert.true( false, "I'm not quite ready yet" );
 });
 
 // You're currently working on the laser methiod, so run only this test
 QUnit.only( "laser()", function( assert ) {
-  assert.ok( this.robot.laser() );
+  assert.true( this.robot.laser() );
 });
 
 QUnit.test( "stomp()", function( assert ) {
-  assert.ok( false, "I'm not quite ready yet" );
+  assert.true( false, "I'm not quite ready yet" );
 });
 
 ```
@@ -72,16 +72,16 @@ module( "robot", hooks => {
   });
 
   test( "say()", assert => {
-    assert.ok( false, "I'm not quite ready yet" );
+    assert.true( false, "I'm not quite ready yet" );
   });
 
   // You're currently working on the laser methiod, so run only this test
   only( "laser()", assert => {
-    assert.ok( robot.laser() );
+    assert.true( robot.laser() );
   });
 
   test( "stomp()", assert => {
-    assert.ok( false, "I'm not quite ready yet" );
+    assert.true( false, "I'm not quite ready yet" );
   });
 });
 ```

--- a/docs/QUnit/skip.md
+++ b/docs/QUnit/skip.md
@@ -41,7 +41,7 @@ QUnit.test( "say", function( assert ) {
 // Robot doesn't have a laser method, yet, skip this test
 // Will show up as skipped in the results
 QUnit.skip( "laser", function( assert ) {
-  assert.ok( this.robot.laser() );
+  assert.true( this.robot.laser() );
 });
 ```
 

--- a/docs/QUnit/test.md
+++ b/docs/QUnit/test.md
@@ -79,7 +79,7 @@ QUnit.test( "a Promise-returning test", function( assert ) {
 
   var thenable = new Promise(function( resolve, reject ) {
     setTimeout(function() {
-      assert.ok( true );
+      assert.true( true );
       resolve( "result" );
     }, 500 );
   });

--- a/docs/assert/async.md
+++ b/docs/assert/async.md
@@ -50,11 +50,11 @@ QUnit.test( "two async calls", function( assert ) {
   var done1 = assert.async();
   var done2 = assert.async();
   setTimeout(function() {
-    assert.ok( true, "test resumed from async operation 1" );
+    assert.true( true, "test resumed from async operation 1" );
     done1();
   }, 500 );
   setTimeout(function() {
-    assert.ok( true, "test resumed from async operation 2" );
+    assert.true( true, "test resumed from async operation 2" );
     done2();
   }, 150);
 });
@@ -68,17 +68,17 @@ QUnit.test( "multiple call done()", function( assert ) {
   var done = assert.async( 3 );
 
   setTimeout(function() {
-    assert.ok( true, "first call done." );
+    assert.true( true, "first call done." );
     done();
   }, 500 );
 
   setTimeout(function() {
-    assert.ok( true, "second call done." );
+    assert.true( true, "second call done." );
     done();
   }, 500 );
 
   setTimeout(function() {
-    assert.ok( true, "third call done." );
+    assert.true( true, "third call done." );
     done();
   }, 500 );
 });

--- a/docs/assert/expect.md
+++ b/docs/assert/expect.md
@@ -34,10 +34,10 @@ QUnit.test( "a test", function( assert ) {
   }
 
   var result = calc( 2, function( x ) {
-    assert.ok( true, "calc() calls operation function" );
+    assert.true( true, "calc() calls operation function" );
     return x * x;
   });
 
-  assert.equal( result, 4, "2 squared equals 4" );
+  assert.strictEqual( result, 4, "2 squared equals 4" );
 });
 ```

--- a/docs/assert/timeout.md
+++ b/docs/assert/timeout.md
@@ -43,7 +43,7 @@ QUnit.test( "Waiting for async function", function( assert ) {
   assert.timeout( 500 ); // Timeout of .5 seconds
   var promise = asyncFunction();
   return promise.then( function( result ) {
-    assert.ok( result );
+    assert.true( result );
   } );
 });
 ```
@@ -53,6 +53,6 @@ QUnit.test( "Waiting in an async test", async assert => {
   assert.timeout( 500 ); // Timeout of .5 seconds
 
   let result = await asyncFunction();
-  assert.ok( result );
+  assert.true( result );
 });
 ```

--- a/docs/config/QUnit.assert.md
+++ b/docs/config/QUnit.assert.md
@@ -15,10 +15,10 @@ This object has properties for each of [QUnit's built-in assertion methods](../a
 
 ### Example
 
-Use the `ok` assertion through the test callback parameter:
+Use the `true` assertion through the test callback parameter:
 
 ```js
-QUnit.test( "`ok` assertion defined in the callback parameter", function( assert ) {
-  assert.ok( true, "on the object passed to the `test` function" );
+QUnit.test( "`true` assertion defined in the callback parameter", function( assert ) {
+  assert.true( true, "on the object passed to the `test` function" );
 });
 ```

--- a/docs/config/QUnit.extend.md
+++ b/docs/config/QUnit.extend.md
@@ -37,6 +37,6 @@ QUnit.test( "QUnit.extend", function( assert ) {
   assert.strictEqual( base.a, 1, "Unspecified values are not modified" );
   assert.strictEqual( base.b, 2.5, "Existing values are updated" );
   assert.strictEqual( base.c, 3, "New values are defined" );
-  assert.strictEqual( base.z, undefined, "Values specified as `undefined` are removed" );
+  assert.false( "z" in base, "Values specified as `undefined` are removed" );
 });
 ```

--- a/docs/config/QUnit.extend.md
+++ b/docs/config/QUnit.extend.md
@@ -34,9 +34,9 @@ QUnit.test( "QUnit.extend", function( assert ) {
     z: undefined
   } );
 
-  assert.equal( base.a, 1, "Unspecified values are not modified" );
-  assert.equal( base.b, 2.5, "Existing values are updated" );
-  assert.equal( base.c, 3, "New values are defined" );
-  assert.ok( !( "z" in base ), "Values specified as `undefined` are removed" );
+  assert.strictEqual( base.a, 1, "Unspecified values are not modified" );
+  assert.strictEqual( base.b, 2.5, "Existing values are updated" );
+  assert.strictEqual( base.c, 3, "New values are defined" );
+  assert.strictEqual( base.z, undefined, "Values specified as `undefined` are removed" );
 });
 ```

--- a/docs/config/QUnit.stack.md
+++ b/docs/config/QUnit.stack.md
@@ -38,6 +38,6 @@ QUnit.log( function( details ) {
 QUnit.test( "foo", function( assert ) {
 
   // the log callback will report the position of the following line.
-  assert.ok( true );
+  assert.true( true );
 } );
 ```

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -59,7 +59,7 @@ function run( args, options ) {
 			QUnit.module( files[ i ], function() {
 				const loadFailureMessage = `Failed to load the test file with error:\n${e.stack}`;
 				QUnit.test( loadFailureMessage, function( assert ) {
-					assert.ok( false, "should be able to load file" );
+					assert.true( false, "should be able to load file" );
 				} );
 			} );
 		}

--- a/test/amd.js
+++ b/test/amd.js
@@ -4,7 +4,7 @@ define( [ "qunit" ], function( QUnit ) {
 	return function() {
 		QUnit.module( "AMD autostart", {
 			after: function( assert ) {
-				assert.ok( true, "after hook ran" );
+				assert.true( true, "after hook ran" );
 			}
 		} );
 

--- a/test/autostart.js
+++ b/test/autostart.js
@@ -4,6 +4,6 @@ QUnit.module( "autostart" );
 
 QUnit.test( "Prove the test run started as expected", function( assert ) {
 	assert.expect( 2 );
-	assert.ok( window.times.autostartOff <= window.times.runStarted );
+	assert.true( window.times.autostartOff <= window.times.runStarted );
 	assert.strictEqual( window.beginData.totalTests, 1, "Should have expected 1 test" );
 } );

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -128,7 +128,7 @@ QUnit.module( "module1", {
 }, function() {
 	QUnit.test( "test1", function( assert ) {
 		invokedHooks.push( "module1 > test1" );
-		assert.ok( true );
+		assert.true( true );
 	} );
 
 	QUnit.module( "module2", {
@@ -139,7 +139,7 @@ QUnit.module( "module1", {
 	}, function() {
 		QUnit.test( "test1", function( assert ) {
 			invokedHooks.push( "module2 > test1" );
-			assert.ok( true );
+			assert.true( true );
 		} );
 	} );
 
@@ -151,13 +151,13 @@ QUnit.module( "module1", {
 	}, function() {
 		QUnit.test( "test1", function( assert ) {
 			invokedHooks.push( "module3 > test1" );
-			assert.ok( true );
+			assert.true( true );
 		} );
 	} );
 
 	QUnit.test( "test2", function( assert ) {
 		invokedHooks.push( "module1 > test2" );
-		assert.ok( true );
+		assert.true( true );
 	} );
 
 	QUnit.module( "module4", {
@@ -168,7 +168,7 @@ QUnit.module( "module1", {
 	}, function() {
 		QUnit.test( "test1", function( assert ) {
 			invokedHooks.push( "module4 > test1" );
-			assert.ok( true );
+			assert.true( true );
 		} );
 	} );
 } );

--- a/test/cli/fixtures/double.js
+++ b/test/cli/fixtures/double.js
@@ -1,9 +1,9 @@
 QUnit.module( "Double", function() {
 	QUnit.test( "has a test", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 
 	QUnit.test( "has another test", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 } );

--- a/test/cli/fixtures/fail/failure.js
+++ b/test/cli/fixtures/fail/failure.js
@@ -1,9 +1,9 @@
 QUnit.module( "Failure", function() {
 	QUnit.test( "bad", function( assert ) {
-		assert.ok( false );
+		assert.true( false );
 	} );
 
 	QUnit.test( "bad again", function( assert ) {
-		assert.ok( false );
+		assert.true( false );
 	} );
 } );

--- a/test/cli/fixtures/glob/a-test.js
+++ b/test/cli/fixtures/glob/a-test.js
@@ -1,5 +1,5 @@
 QUnit.module( "A-Test", function() {
 	QUnit.test( "derp", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 } );

--- a/test/cli/fixtures/glob/not-a.js
+++ b/test/cli/fixtures/glob/not-a.js
@@ -1,5 +1,5 @@
 QUnit.module( "Not-A", function() {
 	QUnit.test( "1", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 } );

--- a/test/cli/fixtures/glob/sub/nested-test.js
+++ b/test/cli/fixtures/glob/sub/nested-test.js
@@ -1,5 +1,5 @@
 QUnit.module( "Nested-Test", function() {
 	QUnit.test( "herp", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 } );

--- a/test/cli/fixtures/memory-leak/index.js
+++ b/test/cli/fixtures/memory-leak/index.js
@@ -56,7 +56,7 @@ QUnit.module( "later thing", function() {
 
 		let snapshot = await streamToString( v8.getHeapSnapshot() );
 		let matches = snapshot.match( reHeap );
-		assert.true( matches && matches.length, "found local Foo in heap" );
+		assert.strictEqual( matches.length, 2, "found local Foo in heap" );
 
 		snapshot = matches = null;
 		foo2.destroy();

--- a/test/cli/fixtures/memory-leak/index.js
+++ b/test/cli/fixtures/memory-leak/index.js
@@ -56,7 +56,7 @@ QUnit.module( "later thing", function() {
 
 		let snapshot = await streamToString( v8.getHeapSnapshot() );
 		let matches = snapshot.match( reHeap );
-		assert.ok( matches && matches.length, "found local Foo in heap" );
+		assert.true( matches && matches.length, "found local Foo in heap" );
 
 		snapshot = matches = null;
 		foo2.destroy();

--- a/test/cli/fixtures/single.js
+++ b/test/cli/fixtures/single.js
@@ -1,5 +1,5 @@
 QUnit.module( "Single", function() {
 	QUnit.test( "has a test", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 } );

--- a/test/cli/fixtures/test/first.js
+++ b/test/cli/fixtures/test/first.js
@@ -1,5 +1,5 @@
 QUnit.module( "First", function() {
 	QUnit.test( "1", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 } );

--- a/test/cli/fixtures/test/nested/second.js
+++ b/test/cli/fixtures/test/nested/second.js
@@ -1,5 +1,5 @@
 QUnit.module( "Second", function() {
 	QUnit.test( "1", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 } );

--- a/test/cli/fixtures/timeout/index.js
+++ b/test/cli/fixtures/timeout/index.js
@@ -8,7 +8,7 @@ QUnit.module( "timeout", function() {
 	QUnit.test( "second", function( assert ) {
 		return new Promise( resolve => setTimeout( resolve, 20 ) )
 			.then( () => {
-				assert.ok( true, "This promise resolved" );
+				assert.true( true, "This promise resolved" );
 			} );
 	} );
 } );

--- a/test/cli/fixtures/unhandled-rejection.js
+++ b/test/cli/fixtures/unhandled-rejection.js
@@ -2,7 +2,7 @@
 
 QUnit.module( "Unhandled Rejections", function() {
 	QUnit.test( "test passes just fine, but has a rejected promise", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 
 		const done = assert.async();
 

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -209,7 +209,7 @@ QUnit.module( "CLI Main", function() {
 				await execute( command );
 			} catch ( e ) {
 				assert.equal( e.code, 1 );
-				assert.ok( e.stderr.includes( "Error: Cannot find module 'does-not-exist-at-all'" ) );
+				assert.true( e.stderr.includes( "Error: Cannot find module 'does-not-exist-at-all'" ) );
 				assert.equal( e.stdout, "" );
 			}
 		} );

--- a/test/cli/watch.js
+++ b/test/cli/watch.js
@@ -40,7 +40,7 @@ QUnit.module( "CLI Watch", function( hooks ) {
 
 	QUnit.test( "runs tests and waits until SIGTERM", async function( assert ) {
 		fixturify.writeSync( fixturePath, {
-			"foo.js": "QUnit.test('foo', function(assert) { assert.ok(true); });"
+			"foo.js": "QUnit.test('foo', function(assert) { assert.true(true); });"
 		} );
 
 		const command = "qunit watching";
@@ -61,7 +61,7 @@ QUnit.module( "CLI Watch", function( hooks ) {
 
 	QUnit.test( "runs tests and waits until SIGINT", async function( assert ) {
 		fixturify.writeSync( fixturePath, {
-			"foo.js": "QUnit.test('foo', function(assert) { assert.ok(true); });"
+			"foo.js": "QUnit.test('foo', function(assert) { assert.true(true); });"
 		} );
 
 		const command = "qunit watching";
@@ -82,7 +82,7 @@ QUnit.module( "CLI Watch", function( hooks ) {
 
 	QUnit.test( "re-runs tests on file changed", async function( assert ) {
 		fixturify.writeSync( fixturePath, {
-			"foo.js": "QUnit.test('foo', function(assert) { assert.ok(true); });"
+			"foo.js": "QUnit.test('foo', function(assert) { assert.true(true); });"
 		} );
 
 		const command = "qunit watching";
@@ -91,7 +91,7 @@ QUnit.module( "CLI Watch", function( hooks ) {
 		execution.once( "message", function( data ) {
 			assert.step( data );
 			fixturify.writeSync( fixturePath, {
-				"foo.js": "QUnit.test('bar', function(assert) { assert.ok(true); });"
+				"foo.js": "QUnit.test('bar', function(assert) { assert.true(true); });"
 			} );
 
 			execution.once( "message", function( data ) {
@@ -110,7 +110,7 @@ QUnit.module( "CLI Watch", function( hooks ) {
 
 	QUnit.test( "re-runs tests on file added", async function( assert ) {
 		fixturify.writeSync( fixturePath, {
-			"foo.js": "QUnit.test('foo', function(assert) { assert.ok(true); });"
+			"foo.js": "QUnit.test('foo', function(assert) { assert.true(true); });"
 		} );
 
 		const command = "qunit watching";
@@ -119,7 +119,7 @@ QUnit.module( "CLI Watch", function( hooks ) {
 		execution.once( "message", function( data ) {
 			assert.step( data );
 			fixturify.writeSync( fixturePath, {
-				"bar.js": "QUnit.test('bar', function(assert) { assert.ok(true); });"
+				"bar.js": "QUnit.test('bar', function(assert) { assert.true(true); });"
 			} );
 
 			execution.once( "message", function( data ) {
@@ -138,8 +138,8 @@ QUnit.module( "CLI Watch", function( hooks ) {
 
 	QUnit.test( "re-runs tests on file removed", async function( assert ) {
 		fixturify.writeSync( fixturePath, {
-			"foo.js": "QUnit.test('foo', function(assert) { assert.ok(true); });",
-			"bar.js": "QUnit.test('bar', function(assert) { assert.ok(true); });"
+			"foo.js": "QUnit.test('foo', function(assert) { assert.true(true); });",
+			"bar.js": "QUnit.test('bar', function(assert) { assert.true(true); });"
 		} );
 
 		const command = "qunit watching";
@@ -185,11 +185,11 @@ QUnit.module( "CLI Watch", function( hooks ) {
 						process.send('testRunning');
 						var done = assert.async();
 						setTimeout(function() {
-							assert.ok(true);
+							assert.true(true);
 							done();
 						}, 500);
 					});
-					QUnit.test('two', function(assert) { assert.ok(true); });`
+					QUnit.test('two', function(assert) { assert.true(true); });`
 			},
 			"bar.js": "module.exports = 'bar export first';"
 		} );
@@ -253,7 +253,7 @@ QUnit.module( "CLI Watch", function( hooks ) {
 				"foo.js": `
 					QUnit.module('Module');
 					QUnit.test('Test', function(assert) {
-						assert.ok(true);
+						assert.true(true);
 					});`
 			}
 		} );
@@ -275,7 +275,7 @@ QUnit.module( "CLI Watch", function( hooks ) {
 								process.send(require('../bar.js'));
 								QUnit.module('Module');
 								QUnit.test('Test', function(assert) {
-									assert.ok(true);
+									assert.true(true);
 								});`
 						},
 						"bar.js": "module.exports = 'bar export first';"

--- a/test/events-in-test.js
+++ b/test/events-in-test.js
@@ -47,6 +47,6 @@ QUnit.on( "assertion", function( data ) {
 QUnit.module( "Events During Test", function() {
 	QUnit.test( "test1", function( assert ) {
 		assert.expect( 2 );
-		assert.ok( true, "assertion1" );
+		assert.true( true, "assertion1" );
 	} );
 } );

--- a/test/events.js
+++ b/test/events.js
@@ -277,12 +277,12 @@ QUnit.done( function() {
 QUnit.module( "Events", function() {
 	QUnit.module( "Nested", function() {
 		QUnit.todo( "test1", function( assert ) {
-			assert.ok( false, "failing assertion" );
+			assert.true( false, "failing assertion" );
 		} );
 	} );
 
 	QUnit.test( "test2", function( assert ) {
-		assert.ok( true, "passing assertion" );
+		assert.true( true, "passing assertion" );
 	} );
 
 	QUnit.skip( "test3" );

--- a/test/logs.js
+++ b/test/logs.js
@@ -196,7 +196,7 @@ QUnit.test( module1Test2.name, function( assert ) {
 		"test runtime was a reasonable number"
 	);
 
-	assert.ok( testDoneContext.assertions instanceof Array, "testDone context: assertions" );
+	assert.true( testDoneContext.assertions instanceof Array, "testDone context: assertions" );
 
 	// TODO: more tests for testDoneContext.assertions
 
@@ -307,8 +307,8 @@ QUnit.test( module2Test4.name, function( assert ) {
 } );
 
 QUnit.todo( module2Test5.name, function( assert ) {
-	assert.ok( false );
-	assert.ok( true );
+	assert.true( false );
+	assert.true( true );
 } );
 
 QUnit.test( module2Test6.name, function( assert ) {

--- a/test/main/assert/step.js
+++ b/test/main/assert/step.js
@@ -7,7 +7,7 @@ QUnit.test( "pushes a failing assertion if no message is given", function( asser
 	assert.pushResult = function pushResultStub( resultInfo ) {
 		assert.pushResult = originalPushResult;
 
-		assert.notOk( resultInfo.result );
+		assert.false( resultInfo.result );
 		assert.equal( resultInfo.message, "You must provide a message to assert.step" );
 	};
 
@@ -23,7 +23,7 @@ QUnit.test( "pushes a failing assertion if empty message is given", function( as
 	assert.pushResult = function pushResultStub( resultInfo ) {
 		assert.pushResult = originalPushResult;
 
-		assert.notOk( resultInfo.result );
+		assert.false( resultInfo.result );
 		assert.equal( resultInfo.message, "You must provide a message to assert.step" );
 	};
 
@@ -43,7 +43,7 @@ QUnit.test( "pushes a failing assertion if a non string message is given", funct
 
 		count += 1;
 
-		assert.notOk( resultInfo.result );
+		assert.false( resultInfo.result );
 		assert.equal( resultInfo.message, "You must provide a string value to assert.step" );
 
 		if ( count < 3 ) {
@@ -88,7 +88,7 @@ QUnit.test( "verifies the order and value of steps", function( assert ) {
 	assert.pushResult = function pushResultStub( resultInfo ) {
 		assert.pushResult = originalPushResult;
 
-		assert.notOk( resultInfo.result );
+		assert.false( resultInfo.result );
 	};
 
 	assert.verifySteps( [ "One step", "Red step", "Two step", "Blue step" ] );

--- a/test/main/assert/timeout.js
+++ b/test/main/assert/timeout.js
@@ -36,7 +36,7 @@ QUnit.module( "assert.timeout", function() {
 		var wait = Date.now() + 10;
 		while ( Date.now() < wait ) {} // eslint-disable-line no-empty
 
-		assert.ok( true );
+		assert.true( true );
 	} );
 
 	QUnit.test( "throws an error if a non-numeric value is passed as duration", function( assert ) {
@@ -78,7 +78,7 @@ QUnit.module( "assert.timeout", function() {
 		QUnit.test( "does not fail a synchronous test using assert.async", function( assert ) {
 			assert.timeout( 0 );
 			var done = assert.async();
-			assert.ok( true );
+			assert.true( true );
 			done();
 		} );
 

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -1,7 +1,7 @@
 function asyncCallback( assert ) {
 	var done = assert.async();
 	setTimeout( function() {
-		assert.ok( true );
+		assert.true( true );
 		done();
 	} );
 }
@@ -13,7 +13,7 @@ QUnit.test( "single call", function( assert ) {
 
 	assert.expect( 1 );
 	setTimeout( function() {
-		assert.ok( true );
+		assert.true( true );
 		done();
 	} );
 } );
@@ -23,19 +23,19 @@ QUnit.test( "multiple call", function( assert ) {
 
 	assert.expect( 4 );
 	setTimeout( function() {
-		assert.ok( true );
+		assert.true( true );
 		done();
 	} );
 	setTimeout( function() {
-		assert.ok( true );
+		assert.true( true );
 		done();
 	} );
 	setTimeout( function() {
-		assert.ok( true );
+		assert.true( true );
 		done();
 	} );
 	setTimeout( function() {
-		assert.ok( true );
+		assert.true( true );
 		done();
 	} );
 
@@ -47,11 +47,11 @@ QUnit.test( "parallel calls", function( assert ) {
 
 	assert.expect( 2 );
 	setTimeout( function() {
-		assert.ok( true );
+		assert.true( true );
 		done1();
 	} );
 	setTimeout( function() {
-		assert.ok( true );
+		assert.true( true );
 		done2();
 	} );
 } );
@@ -62,11 +62,11 @@ QUnit.test( "parallel calls of differing speeds", function( assert ) {
 
 	assert.expect( 2 );
 	setTimeout( function() {
-		assert.ok( true );
+		assert.true( true );
 		done1();
 	} );
 	setTimeout( function() {
-		assert.ok( true );
+		assert.true( true );
 		done2();
 	}, 100 );
 } );
@@ -77,11 +77,11 @@ QUnit.test( "waterfall calls", function( assert ) {
 
 	assert.expect( 2 );
 	setTimeout( function() {
-		assert.ok( true, "first" );
+		assert.true( true, "first" );
 		done1();
 		done2 = assert.async();
 		setTimeout( function() {
-			assert.ok( true, "second" );
+			assert.true( true, "second" );
 			done2();
 		} );
 	} );
@@ -93,11 +93,11 @@ QUnit.test( "waterfall calls of differing speeds", function( assert ) {
 
 	assert.expect( 2 );
 	setTimeout( function() {
-		assert.ok( true, "first" );
+		assert.true( true, "first" );
 		done1();
 		done2 = assert.async();
 		setTimeout( function() {
-			assert.ok( true, "second" );
+			assert.true( true, "second" );
 			done2();
 		}, 100 );
 	} );
@@ -340,7 +340,7 @@ QUnit.module( "assert.async in afterEach", {
 	afterEach: function( assert ) {
 		var done = assert.async();
 		setTimeout( function() {
-			assert.ok( true, "afterEach synchronized before test was finished" );
+			assert.true( true, "afterEach synchronized before test was finished" );
 			done();
 		} );
 	}
@@ -371,7 +371,7 @@ QUnit.module( "assert.async in after", {
 	after: function( assert ) {
 		var done = assert.async();
 		setTimeout( function() {
-			assert.ok( true, "after synchronized before test was finished" );
+			assert.true( true, "after synchronized before test was finished" );
 			done();
 		} );
 	}
@@ -389,7 +389,7 @@ QUnit.test( "`done` can be called synchronously", function( assert ) {
 	assert.expect( 1 );
 	done = assert.async();
 
-	assert.ok( true );
+	assert.true( true );
 	done();
 } );
 
@@ -399,7 +399,7 @@ QUnit.test( "sole `done` is called last", function( assert ) {
 	assert.expect( 1 );
 	done = assert.async();
 	setTimeout( function() {
-		assert.ok( true, "should pass if called before `done`" );
+		assert.true( true, "should pass if called before `done`" );
 		done();
 	} );
 } );
@@ -412,10 +412,10 @@ QUnit.test( "multiple `done` calls, no assertions after final `done`", function(
 	done2 = assert.async();
 	setTimeout( function() {
 		done1();
-		assert.ok( true, "should pass if called after this `done` but before final `done`" );
+		assert.true( true, "should pass if called after this `done` but before final `done`" );
 	} );
 	setTimeout( function() {
-		assert.ok( true, "should pass if called before final `done`" );
+		assert.true( true, "should pass if called before final `done`" );
 		done2();
 	} );
 } );
@@ -423,26 +423,26 @@ QUnit.test( "multiple `done` calls, no assertions after final `done`", function(
 QUnit.module( "assertions after final assert.async callback", {
 	before: function( assert ) {
 		assert.async()();
-		assert.ok( true, "before" );
+		assert.true( true, "before" );
 	},
 
 	beforeEach: function( assert ) {
 		assert.async()();
-		assert.ok( true, "beforeEach" );
+		assert.true( true, "beforeEach" );
 	},
 
 	afterEach: function( assert ) {
 		assert.async()();
-		assert.ok( true, "afterEach" );
+		assert.true( true, "afterEach" );
 	},
 
 	after: function( assert ) {
 		assert.async()();
-		assert.ok( true, "after" );
+		assert.true( true, "after" );
 	}
 } );
 
 QUnit.test( "in any hook still pass", function( assert ) {
 	assert.expect( 5 );
-	assert.ok( true, "test callback" );
+	assert.true( true, "test callback" );
 } );

--- a/test/main/deepEqual.js
+++ b/test/main/deepEqual.js
@@ -212,8 +212,8 @@ QUnit[ typeof Object.create === "function" ? "test" : "skip" ](
 		a.foo = 1;
 		var b = { foo: 1 };
 
-		assert.ok( QUnit.equiv( a, b ) );
-		assert.ok( QUnit.equiv( b, a ) );
+		assert.true( QUnit.equiv( a, b ) );
+		assert.true( QUnit.equiv( b, a ) );
 	} );
 
 QUnit.test( "Arrays basics", function( assert ) {
@@ -1693,23 +1693,23 @@ QUnit.module( "equiv Object-wrapped primitives" );
 QUnit.test( "Number", function( assert ) {
 	var SafeNumber = Number;
 
-	assert.ok( QUnit.equiv( new SafeNumber( 1 ), new SafeNumber( 1 ) ),
+	assert.true( QUnit.equiv( new SafeNumber( 1 ), new SafeNumber( 1 ) ),
 		"Number objects with same values are equivalent."
 	);
-	assert.ok( QUnit.equiv( new SafeNumber( 0 / 0 ), new SafeNumber( 0 / 0 ) ),
+	assert.true( QUnit.equiv( new SafeNumber( 0 / 0 ), new SafeNumber( 0 / 0 ) ),
 		"NaN Number objects are equivalent."
 	);
-	assert.ok( QUnit.equiv( new SafeNumber( 1 / 0 ), new SafeNumber( 2 / 0 ) ),
+	assert.true( QUnit.equiv( new SafeNumber( 1 / 0 ), new SafeNumber( 2 / 0 ) ),
 		"Infinite Number objects are equivalent."
 	);
 
-	assert.notOk( QUnit.equiv( new SafeNumber( 1 ), new SafeNumber( 2 ) ),
+	assert.false( QUnit.equiv( new SafeNumber( 1 ), new SafeNumber( 2 ) ),
 		"Number objects with different values are not equivalent."
 	);
-	assert.notOk( QUnit.equiv( new SafeNumber( 0 / 0 ), new SafeNumber( 1 / 0 ) ),
+	assert.false( QUnit.equiv( new SafeNumber( 0 / 0 ), new SafeNumber( 1 / 0 ) ),
 		"NaN Number objects and infinite Number objects are not equivalent."
 	);
-	assert.notOk( QUnit.equiv( new SafeNumber( 1 / 0 ), new SafeNumber( -1 / 0 ) ),
+	assert.false( QUnit.equiv( new SafeNumber( 1 / 0 ), new SafeNumber( -1 / 0 ) ),
 		"Positive and negative infinite Number objects are not equivalent."
 	);
 } );
@@ -1717,17 +1717,17 @@ QUnit.test( "Number", function( assert ) {
 QUnit.test( "String", function( assert ) {
 	var SafeString = String;
 
-	assert.ok( QUnit.equiv( new SafeString( "foo" ), new SafeString( "foo" ) ),
+	assert.true( QUnit.equiv( new SafeString( "foo" ), new SafeString( "foo" ) ),
 		"String objects with same values are equivalent."
 	);
-	assert.ok( QUnit.equiv( new SafeString( "" ), new SafeString( "" ) ),
+	assert.true( QUnit.equiv( new SafeString( "" ), new SafeString( "" ) ),
 		"Empty String objects are equivalent."
 	);
 
-	assert.notOk( QUnit.equiv( new SafeString( "foo" ), new SafeString( "bar" ) ),
+	assert.false( QUnit.equiv( new SafeString( "foo" ), new SafeString( "bar" ) ),
 		"String objects with different values are not equivalent."
 	);
-	assert.notOk( QUnit.equiv( new SafeString( "" ), new SafeString( "foo" ) ),
+	assert.false( QUnit.equiv( new SafeString( "" ), new SafeString( "foo" ) ),
 		"Empty and nonempty String objects are not equivalent."
 	);
 } );
@@ -1735,14 +1735,14 @@ QUnit.test( "String", function( assert ) {
 QUnit.test( "Boolean", function( assert ) {
 	var SafeBoolean = Boolean;
 
-	assert.ok( QUnit.equiv( new SafeBoolean( true ), new SafeBoolean( true ) ),
+	assert.true( QUnit.equiv( new SafeBoolean( true ), new SafeBoolean( true ) ),
 		"True Boolean objects are equivalent."
 	);
-	assert.ok( QUnit.equiv( new SafeBoolean( false ), new SafeBoolean( false ) ),
+	assert.true( QUnit.equiv( new SafeBoolean( false ), new SafeBoolean( false ) ),
 		"False Boolean objects are equivalent."
 	);
 
-	assert.notOk( QUnit.equiv( new SafeBoolean( true ), new SafeBoolean( false ) ),
+	assert.false( QUnit.equiv( new SafeBoolean( true ), new SafeBoolean( false ) ),
 		"Boolean objects with different values are not equivalent."
 	);
 } );

--- a/test/main/dump.js
+++ b/test/main/dump.js
@@ -152,7 +152,7 @@ QUnit.test( "Check dump recursion", function( assert ) {
 
 	circref = this.chainwrap( 10 );
 	circdump = QUnit.dump.parse( circref );
-	assert.ok( new RegExp( "recursion\\(-10\\)" ).test( circdump ),
+	assert.true( new RegExp( "recursion\\(-10\\)" ).test( circdump ),
 		"(" + circdump + ") should show -10 recursion level"
 	);
 } );

--- a/test/main/modules.js
+++ b/test/main/modules.js
@@ -29,7 +29,7 @@ QUnit.test( "hooks order", function( assert ) {
 
 QUnit.module( "before", {
 	before: function( assert ) {
-		assert.ok( true, "before hook ran" );
+		assert.true( true, "before hook ran" );
 
 		if ( typeof this.beforeCount === "undefined" ) {
 			this.beforeCount = 0;
@@ -51,7 +51,7 @@ QUnit.test( "does not run before subsequent tests", function( assert ) {
 
 QUnit.module( "before (skip)", {
 	before: function( assert ) {
-		assert.ok( true, "before hook ran" );
+		assert.true( true, "before hook ran" );
 	}
 } );
 
@@ -63,7 +63,7 @@ QUnit.test( "runs before first unskipped test", function( assert ) {
 
 QUnit.module( "after", {
 	after: function( assert ) {
-		assert.ok( true, "after hook ran" );
+		assert.true( true, "after hook ran" );
 	}
 } );
 
@@ -77,7 +77,7 @@ QUnit.test( "runs after final test", function( assert ) {
 
 QUnit.module( "after (skip)", {
 	after: function( assert ) {
-		assert.ok( true, "after hook ran" );
+		assert.true( true, "after hook ran" );
 	}
 } );
 
@@ -93,10 +93,10 @@ QUnit.skip( "last test in module is skipped" );
 
 QUnit.module( "before/after with all tests skipped", {
 	before: function( assert ) {
-		assert.ok( false, "should not occur" );
+		assert.true( false, "should not occur" );
 	},
 	after: function( assert ) {
-		assert.ok( false, "should not occur" );
+		assert.true( false, "should not occur" );
 	}
 } );
 
@@ -144,7 +144,7 @@ QUnit.module( "async beforeEach test", {
 	beforeEach: function( assert ) {
 		var done = assert.async();
 		setTimeout( function() {
-			assert.ok( true );
+			assert.true( true );
 			done();
 		} );
 	}
@@ -152,14 +152,14 @@ QUnit.module( "async beforeEach test", {
 
 QUnit.test( "module with async beforeEach", function( assert ) {
 	assert.expect( 2 );
-	assert.ok( true );
+	assert.true( true );
 } );
 
 QUnit.module( "async afterEach test", {
 	afterEach: function( assert ) {
 		var done = assert.async();
 		setTimeout( function() {
-			assert.ok( true );
+			assert.true( true );
 			done();
 		} );
 	}
@@ -167,7 +167,7 @@ QUnit.module( "async afterEach test", {
 
 QUnit.test( "module with async afterEach", function( assert ) {
 	assert.expect( 2 );
-	assert.ok( true );
+	assert.true( true );
 } );
 
 QUnit.module( "save scope", {
@@ -192,18 +192,18 @@ QUnit.module( "pre-nested modules" );
 QUnit.module( "nested modules", function() {
 	QUnit.module( "first outer", {
 		afterEach: function( assert ) {
-			assert.ok( true, "first outer module afterEach called" );
+			assert.true( true, "first outer module afterEach called" );
 		},
 		beforeEach: function( assert ) {
-			assert.ok( true, "first outer beforeEach called" );
+			assert.true( true, "first outer beforeEach called" );
 		}
 	}, function() {
 		QUnit.module( "first inner", {
 			afterEach: function( assert ) {
-				assert.ok( true, "first inner module afterEach called" );
+				assert.true( true, "first inner module afterEach called" );
 			},
 			beforeEach: function( assert ) {
-				assert.ok( true, "first inner module beforeEach called" );
+				assert.true( true, "first inner module beforeEach called" );
 			}
 		}, function() {
 			QUnit.test( "in module, before-/afterEach called in out-in-out order", function( assert ) {
@@ -252,11 +252,11 @@ QUnit.module( "contained suite arguments", function( hooks ) {
 		var afterEach = hooks.afterEach;
 
 		beforeEach( function( assert ) {
-			assert.ok( true, "beforeEach called" );
+			assert.true( true, "beforeEach called" );
 		} );
 
 		afterEach( function( assert ) {
-			assert.ok( true, "afterEach called" );
+			assert.true( true, "afterEach called" );
 		} );
 
 		QUnit.test( "call hooks", function( assert ) {
@@ -268,11 +268,11 @@ QUnit.module( "contained suite arguments", function( hooks ) {
 			var afterEach = hooks.afterEach;
 
 			beforeEach( function( assert ) {
-				assert.ok( true, "nested beforeEach called" );
+				assert.true( true, "nested beforeEach called" );
 			} );
 
 			afterEach( function( assert ) {
-				assert.ok( true, "nested afterEach called" );
+				assert.true( true, "nested afterEach called" );
 			} );
 
 			QUnit.test( "call hooks", function( assert ) {
@@ -310,21 +310,21 @@ QUnit.module( "contained suite `this`", function( hooks ) {
 		this.inner = true;
 
 		hooks.beforeEach( function( assert ) {
-			assert.ok( this.outer );
-			assert.ok( this.inner );
+			assert.strictEqual( this.outer, 2 );
+			assert.true( this.inner );
 		} );
 
 		hooks.afterEach( function( assert ) {
-			assert.ok( this.outer );
-			assert.ok( this.inner );
+			assert.strictEqual( this.outer, 2 );
+			assert.true( this.inner );
 
 			// This change affects the outermodule afterEach assertion.
 			this.outer = 42;
 		} );
 
 		QUnit.test( "inner modules share outer environments", function( assert ) {
-			assert.ok( this.outer );
-			assert.ok( this.inner );
+			assert.strictEqual( this.outer, 2 );
+			assert.true( this.inner );
 		} );
 	} );
 
@@ -336,7 +336,7 @@ QUnit.module( "contained suite `this`", function( hooks ) {
 
 QUnit.module( "nested modules before/after", {
 	before: function( assert ) {
-		assert.ok( true, "before hook ran" );
+		assert.true( true, "before hook ran" );
 		this.lastHook = "before";
 	},
 	after: function( assert ) {
@@ -350,7 +350,7 @@ QUnit.module( "nested modules before/after", {
 
 	QUnit.module( "outer", {
 		before: function( assert ) {
-			assert.ok( true, "outer before hook ran" );
+			assert.true( true, "outer before hook ran" );
 			this.lastHook = "outer-before";
 		},
 		after: function( assert ) {

--- a/test/main/promise.js
+++ b/test/main/promise.js
@@ -21,7 +21,7 @@ function createMockPromise( assert, reject, value ) {
 
 QUnit.module( "Module with Promise-aware before", {
 	before: function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 		return {};
 	}
 } );
@@ -44,7 +44,7 @@ QUnit.test( "fulfilled Promise", function( assert ) {
 
 QUnit.module( "Module with Promise-aware beforeEach", {
 	beforeEach: function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 		return {};
 	}
 } );
@@ -67,7 +67,7 @@ QUnit.test( "fulfilled Promise", function( assert ) {
 
 QUnit.module( "Module with Promise-aware afterEach", {
 	afterEach: function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 		return {};
 	}
 } );
@@ -90,7 +90,7 @@ QUnit.test( "fulfilled Promise", function( assert ) {
 
 QUnit.module( "Module with Promise-aware after", {
 	after: function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 		return {};
 	}
 } );
@@ -150,7 +150,7 @@ QUnit.test( "fulfilled Promise with non-Promise async assertion", function( asse
 
 	var done = assert.async();
 	setTimeout( function() {
-		assert.ok( true );
+		assert.true( true );
 		done();
 	}, 100 );
 

--- a/test/main/stack.js
+++ b/test/main/stack.js
@@ -5,10 +5,10 @@
 
 	// Flag this test as skipped on browsers that doesn't support stack trace
 	QUnit[ stack ? "test" : "skip" ]( "returns the proper stack line", function( assert ) {
-		assert.ok( /(\/|\\)test(\/|\\)main(\/|\\)stack\.js/.test( stack ) );
+		assert.true( /(\/|\\)test(\/|\\)main(\/|\\)stack\.js/.test( stack ) );
 
 		stack = QUnit.stack( 2 );
-		assert.ok( stack, "can use offset argument to return a different stacktrace line" );
-		assert.notOk( /\/test\/main\/stack\.js/.test( stack ), "stack with offset argument" );
+		assert.true( /(\/|\\)dist(\/|\\)qunit\.js/.test( stack ), "can use offset argument to return a different stacktrace line" );
+		assert.false( /\/test\/main\/stack\.js/.test( stack ), "stack with offset argument" );
 	} );
 }() );

--- a/test/main/test.js
+++ b/test/main/test.js
@@ -1,10 +1,10 @@
 QUnit.test( "expect query and multiple issue", function( assert ) {
 	assert.expect( 2 );
-	assert.ok( true );
+	assert.true( true );
 	var expected = assert.expect();
 	assert.equal( expected, 2 );
 	assert.expect( expected + 1 );
-	assert.ok( true );
+	assert.true( true );
 } );
 
 if ( typeof document !== "undefined" ) {
@@ -72,7 +72,7 @@ if ( typeof document !== "undefined" ) {
 		hooks.afterEach( function( assert ) {
 			failure = failure || assert.hasFailingAssertions();
 			if ( failure ) {
-				assert.ok( false, "prior failure" );
+				assert.true( false, "prior failure" );
 				QUnit.config.fixture = originalValue;
 			} else {
 				QUnit.config.fixture = values.shift();
@@ -197,11 +197,11 @@ QUnit.module( "QUnit.skip", {
 	beforeEach: function( assert ) {
 
 		// Skip test hooks for skipped tests
-		assert.ok( false, "skipped function" );
+		assert.true( false, "skipped function" );
 		throw "Error";
 	},
 	afterEach: function( assert ) {
-		assert.ok( false, "skipped function" );
+		assert.true( false, "skipped function" );
 		throw "Error";
 	}
 } );

--- a/test/module-filter.js
+++ b/test/module-filter.js
@@ -3,37 +3,37 @@ QUnit.config.module = "Foo";
 QUnit.module( "Foo" );
 
 QUnit.test( "Foo test should be run", function( assert ) {
-	assert.ok( true, "Foo test should be run" );
+	assert.true( true, "Foo test should be run" );
 } );
 
 QUnit.module( "foo" );
 
 QUnit.test( "foo test should be run", function( assert ) {
-	assert.ok( true, "foo test should be run" );
+	assert.true( true, "foo test should be run" );
 } );
 
 QUnit.module( "Bar" );
 
 QUnit.test( "Bar test should not be run", function( assert ) {
-	assert.ok( false, "Bar test should not be run" );
+	assert.true( false, "Bar test should not be run" );
 } );
 
 QUnit.module( "Foo Bar" );
 
 QUnit.test( "Foo Bar test should not be run", function( assert ) {
-	assert.ok( false, "Foo Bar test should not be run" );
+	assert.true( false, "Foo Bar test should not be run" );
 } );
 
 QUnit.module( "Foo", function() {
 	QUnit.module( "Bar", function() {
 		QUnit.test( "Bar submodule test should run", function( assert ) {
-			assert.ok( true, "Bar submodule test should run" );
+			assert.true( true, "Bar submodule test should run" );
 		} );
 	} );
 
 	QUnit.module( "Boo", function() {
 		QUnit.test( "Boo submodule test should run", function( assert ) {
-			assert.ok( true, "Boo submodule test should run" );
+			assert.true( true, "Boo submodule test should run" );
 		} );
 	} );
 } );
@@ -41,13 +41,13 @@ QUnit.module( "Foo", function() {
 QUnit.module( "Bar", function() {
 	QUnit.module( "Foo", function() {
 		QUnit.test( "Foo submodule test should not run", function( assert ) {
-			assert.ok( false, "Foo submodule test should not run" );
+			assert.true( false, "Foo submodule test should not run" );
 		} );
 	} );
 
 	QUnit.module( "Boo", function() {
 		QUnit.test( "Boo submodule test should not run", function( assert ) {
-			assert.ok( false, "Boo submodule test should not run" );
+			assert.true( false, "Boo submodule test should not run" );
 		} );
 	} );
 } );

--- a/test/module-only.js
+++ b/test/module-only.js
@@ -54,70 +54,70 @@ QUnit.done( function() {
 
 QUnit.module( "module A", function() {
 	QUnit.test( "test A", function( assert ) {
-		assert.ok( false, "this test should not run" );
+		assert.true( false, "this test should not run" );
 	} );
 } );
 
 QUnit.module( "module B", function() {
 	QUnit.module( "This module should not run", function() {
 		QUnit.test( "normal test", function( assert ) {
-			assert.ok( false, "this test should not run" );
+			assert.true( false, "this test should not run" );
 		} );
 	} );
 
 	QUnit.module.only( "Only this module should run", function() {
 		QUnit.todo( "a todo test", function( assert ) {
-			assert.ok( false, "not implemented yet" );
+			assert.true( false, "not implemented yet" );
 		} );
 
 		QUnit.skip( "implicitly skipped test", function( assert ) {
-			assert.ok( false, "test should be skipped" );
+			assert.true( false, "test should be skipped" );
 		} );
 
 		QUnit.test( "normal test", function( assert ) {
-			assert.ok( true, "this test should run" );
+			assert.true( true, "this test should run" );
 		} );
 	} );
 
 	QUnit.module( "This also should not run", function() {
 		QUnit.test( "normal test", function( assert ) {
-			assert.ok( false, "this test should not run" );
+			assert.true( false, "this test should not run" );
 		} );
 	} );
 } );
 
 QUnit.module( "module C", function() {
 	QUnit.test( "test C", function( assert ) {
-		assert.ok( false, "this test should not run" );
+		assert.true( false, "this test should not run" );
 	} );
 } );
 
 QUnit.module.only( "module D", function() {
 	QUnit.test( "test D", function( assert ) {
-		assert.ok( true, "this test should run as well" );
+		assert.true( true, "this test should run as well" );
 	} );
 } );
 
 QUnit.module.only( "module E", function() {
 	QUnit.module( "module F", function() {
 		QUnit.test( "test F", function( assert ) {
-			assert.ok( true, "this test should run as well" );
+			assert.true( true, "this test should run as well" );
 		} );
 	} );
 
 	QUnit.test( "test E", function( assert ) {
-		assert.ok( true, "this test should run as well" );
+		assert.true( true, "this test should run as well" );
 	} );
 } );
 
 QUnit.module.skip( "module G", function() {
 	QUnit.module.only( "module H", function() {
 		QUnit.test( "test H", function( assert ) {
-			assert.ok( false, "this test should not run" );
+			assert.true( false, "this test should not run" );
 		} );
 	} );
 
 	QUnit.test( "test G", function( assert ) {
-		assert.ok( false, "this test should not run" );
+		assert.true( false, "this test should not run" );
 	} );
 } );

--- a/test/module-skip.js
+++ b/test/module-skip.js
@@ -47,21 +47,21 @@ QUnit.done( function() {
 QUnit.module( "Parent module", function() {
 	QUnit.module( "A normal module", function() {
 		QUnit.test( "normal test", function( assert ) {
-			assert.ok( true, "this test should run" );
+			assert.true( true, "this test should run" );
 		} );
 	} );
 
 	QUnit.module.skip( "This module will be skipped", function() {
 		QUnit.test( "test will be treated as a skipped test", function( assert ) {
-			assert.ok( false, "this test should not run" );
+			assert.true( false, "this test should not run" );
 		} );
 
 		QUnit.todo( "a todo test that should be skipped", function( assert ) {
-			assert.ok( false, "this test should not run" );
+			assert.true( false, "this test should not run" );
 		} );
 
 		QUnit.skip( "a normal skipped test", function( assert ) {
-			assert.ok( false, "this test should not run" );
+			assert.true( false, "this test should not run" );
 		} );
 	} );
 } );

--- a/test/module-todo.js
+++ b/test/module-todo.js
@@ -47,21 +47,21 @@ QUnit.done( function() {
 QUnit.module( "parent module", function() {
 	QUnit.module( "a normal module", function() {
 		QUnit.test( "normal test", function( assert ) {
-			assert.ok( true, "this test should run" );
+			assert.true( true, "this test should run" );
 		} );
 	} );
 
 	QUnit.module.todo( "a todo module", function() {
 		QUnit.todo( "a todo test", function( assert ) {
-			assert.ok( false, "not implemented yet" );
+			assert.true( false, "not implemented yet" );
 		} );
 
 		QUnit.skip( "a skipped test that will be left intact", function( assert ) {
-			assert.ok( false, "not implemented yet" );
+			assert.true( false, "not implemented yet" );
 		} );
 
 		QUnit.test( "a normal test that will be treated as a todo", function( assert ) {
-			assert.ok( false, "not implemented yet" );
+			assert.true( false, "not implemented yet" );
 		} );
 	} );
 } );

--- a/test/moduleId.js
+++ b/test/moduleId.js
@@ -3,30 +3,30 @@ QUnit.config.moduleId = [ "720ab266", "0af5a573", "64f7439b", "8fdbddfe" ];
 QUnit.module( "QUnit.config.moduleId.foo" );
 
 QUnit.test( "foo test should be run", function( assert ) {
-	assert.ok( true, "foo test should be run" );
+	assert.true( true, "foo test should be run" );
 } );
 
 QUnit.module( "QUnit.config.moduleId.bar" );
 
 QUnit.test( "bar test should be run", function( assert ) {
-	assert.ok( true, "bar test should be run" );
+	assert.true( true, "bar test should be run" );
 } );
 
 QUnit.module( "QUnit.config.moduleId.foobar" );
 
 QUnit.test( "foobar test should not be run", function( assert ) {
-	assert.ok( false, "foobar test should not be run" );
+	assert.true( false, "foobar test should not be run" );
 } );
 
 QUnit.module( "QUnit.config.moduleId.parentModule1", function() {
 	QUnit.module( "Qunit.config.module.parentModule1.module1", function() {
 		QUnit.test( "submodule should run", function( assert ) {
-			assert.ok( true, "submodule test should run" );
+			assert.true( true, "submodule test should run" );
 		} );
 	} );
 	QUnit.module( "Qunit.config.module.parentModule.module2", function() {
 		QUnit.test( "submodule should run", function( assert ) {
-			assert.ok( true, "submodule test should run" );
+			assert.true( true, "submodule test should run" );
 		} );
 	} );
 } );
@@ -34,12 +34,12 @@ QUnit.module( "QUnit.config.moduleId.parentModule1", function() {
 QUnit.module( "QUnit.config.moduleId.parentModule2", function() {
 	QUnit.module( "Qunit.config.module.parentModule2.module1", function() {
 		QUnit.test( "submodule should run", function( assert ) {
-			assert.ok( true, "submodule test should run" );
+			assert.true( true, "submodule test should run" );
 		} );
 	} );
 	QUnit.module( "Qunit.config.module.parentModule.module1", function() {
 		QUnit.test( "submodule should not run", function( assert ) {
-			assert.ok( false, "submodule test should not run" );
+			assert.true( false, "submodule test should not run" );
 		} );
 	} );
 } );

--- a/test/onerror/inside-test.js
+++ b/test/onerror/inside-test.js
@@ -43,7 +43,7 @@ QUnit.module( "QUnit.onError", function() {
 		assert.expect( 1 );
 
 		QUnit.config.current.pushFailure = function() {
-			assert.ok( false, "No error should be pushed" );
+			assert.true( false, "No error should be pushed" );
 		};
 
 		QUnit.config.current.ignoreGlobalErrors = true;

--- a/test/only.js
+++ b/test/only.js
@@ -6,20 +6,20 @@ QUnit.module( "QUnit.only", function( hooks ) {
 	} );
 
 	QUnit.test( "implicitly skipped test", function( assert ) {
-		assert.ok( false, "test should be skipped" );
+		assert.true( false, "test should be skipped" );
 	} );
 
 	QUnit.only( "run this test", function( assert ) {
 		testsRun += 1;
-		assert.ok( true, "only this test should run" );
+		assert.true( true, "only this test should run" );
 	} );
 
 	QUnit.test( "another implicitly skipped test", function( assert ) {
-		assert.ok( false, "test should be skipped" );
+		assert.true( false, "test should be skipped" );
 	} );
 
 	QUnit.only( "all tests with only run", function( assert ) {
 		testsRun += 1;
-		assert.ok( true, "this test should run as well" );
+		assert.true( true, "this test should run as well" );
 	} );
 } );

--- a/test/overload.html
+++ b/test/overload.html
@@ -9,7 +9,7 @@
 			window.onerror = function( error ) {
 				QUnit.module( "Overload", function() {
 					QUnit.test( "error is thrown when overloading QUnit global", function( assert ) {
-						assert.ok( error.indexOf( "QUnit has already been defined." ) !== -1 );
+						assert.true( error.indexOf( "QUnit has already been defined." ) !== -1 );
 					} );
 				} );
 

--- a/test/performance-mark.js
+++ b/test/performance-mark.js
@@ -2,6 +2,6 @@ QUnit.module( "urlParams performance mark module", function() {
 	QUnit.test( "shouldn't fail if performance marks are cleared ", function( assert ) {
 		performance.clearMarks();
 
-		assert.ok( true );
+		assert.true( true );
 	} );
 } );

--- a/test/preconfigured.js
+++ b/test/preconfigured.js
@@ -4,11 +4,11 @@ window.addEventListener( "load", function() {
 	setTimeout( function() {
 		QUnit.module( "QUnit.preconfigured.asyncTests" );
 		QUnit.test( "QUnit.config should have an expected default", function( assert ) {
-			assert.ok( QUnit.config.scrolltop, "The scrolltop default is true" );
+			assert.true( QUnit.config.scrolltop, "The scrolltop default is true" );
 		} );
 
 		QUnit.test( "Qunit.config.reorder default was overwritten", function( assert ) {
-			assert.notOk( QUnit.config.reorder, "reorder was overwritten" );
+			assert.false( QUnit.config.reorder, "reorder was overwritten" );
 		} );
 
 		QUnit.start();
@@ -17,5 +17,5 @@ window.addEventListener( "load", function() {
 
 QUnit.module( "QUnit.preconfigured" );
 QUnit.test( "Autostart is false", function( assert ) {
-	assert.notOk( QUnit.config.autostart, "The global autostart setting is applied" );
+	assert.false( QUnit.config.autostart, "The global autostart setting is applied" );
 } );

--- a/test/regex-exclude-filter.js
+++ b/test/regex-exclude-filter.js
@@ -3,17 +3,17 @@ QUnit.config.filter = "!/Foo|bar/";
 QUnit.module( "QUnit.config.filter with excluding, case-sensitive regular expression" );
 
 QUnit.test( "foo test should be run", function( assert ) {
-	assert.ok( true, "foo test should be run" );
+	assert.true( true, "foo test should be run" );
 } );
 
 QUnit.test( "Foo test should not be run", function( assert ) {
-	assert.ok( false, "Foo test should not be run" );
+	assert.true( false, "Foo test should not be run" );
 } );
 
 QUnit.test( "Bar test should be run", function( assert ) {
-	assert.ok( true, "Bar test should be run" );
+	assert.true( true, "Bar test should be run" );
 } );
 
 QUnit.test( "bar test should not be run", function( assert ) {
-	assert.ok( false, "bar test should not be run" );
+	assert.true( false, "bar test should not be run" );
 } );

--- a/test/regex-filter.js
+++ b/test/regex-filter.js
@@ -3,17 +3,17 @@ QUnit.config.filter = "/foo|bar/i";
 QUnit.module( "QUnit.config.filter with case-insensitive regular expression" );
 
 QUnit.test( "foo test should be run", function( assert ) {
-	assert.ok( true, "foo test should be run" );
+	assert.true( true, "foo test should be run" );
 } );
 
 QUnit.test( "boo test should not be run", function( assert ) {
-	assert.ok( false, "boo test should not be run" );
+	assert.true( false, "boo test should not be run" );
 } );
 
 QUnit.test( "bar test should be run", function( assert ) {
-	assert.ok( true, "bar test should be run" );
+	assert.true( true, "bar test should be run" );
 } );
 
 QUnit.test( "baz test should not be run", function( assert ) {
-	assert.ok( false, "baz test should not be run" );
+	assert.true( false, "baz test should not be run" );
 } );

--- a/test/reorderError1.html
+++ b/test/reorderError1.html
@@ -24,15 +24,15 @@
 
 		QUnit.module( "First fail module-1" );
 		QUnit.test( "should pass", function( assert ) {
-			assert.ok( true );
+			assert.true( true );
 		} );
 		QUnit.test( "should be fail", function( assert ) {
-			assert.ok( false );
+			assert.true( false );
 		} );
 
 		QUnit.module( "Second fail module-1" );
 		QUnit.test( "should be fail", function( assert ) {
-			assert.ok( false );
+			assert.true( false );
 		} );
 	}
 

--- a/test/reorderError2.html
+++ b/test/reorderError2.html
@@ -24,12 +24,12 @@
 
 		QUnit.module( "First fail module-2" );
 		QUnit.test( "should be fail", function( assert ) {
-			assert.ok( false );
+			assert.true( false );
 		} );
 
 		QUnit.module( "Second fail module-2" );
 		QUnit.test( "should be fail", function( assert ) {
-			assert.ok( false );
+			assert.true( false );
 		} );
 	}
 

--- a/test/reporter-html/no-qunit-element.html
+++ b/test/reporter-html/no-qunit-element.html
@@ -14,7 +14,7 @@
 
 		QUnit.test( "no qunit markup", function( assert ) {
 			assert.expect( 1 );
-			assert.ok( true );
+			assert.true( true );
 		} );
 
 		QUnit.done( function() {

--- a/test/reporter-html/reporter-html.js
+++ b/test/reporter-html/reporter-html.js
@@ -13,20 +13,20 @@ QUnit.module( "<script id='qunit-unescaped-module'>'module';</script>", {
 		if ( document.getElementById( "qunit-unescaped-module" ) ) {
 
 			// This can either be from in #qunit-modulefilter or #qunit-testresult
-			assert.ok( false, "Unescaped module name" );
+			assert.true( false, "Unescaped module name" );
 		}
 		if ( document.getElementById( "qunit-unescaped-test" ) ) {
-			assert.ok( false, "Unescaped test name" );
+			assert.true( false, "Unescaped test name" );
 		}
 		if ( document.getElementById( "qunit-unescaped-assertion" ) ) {
-			assert.ok( false, "Unescaped test name" );
+			assert.true( false, "Unescaped test name" );
 		}
 	}
 } );
 
 QUnit.test( "<script id='qunit-unescaped-test'>'test';</script>", function( assert ) {
 	assert.expect( 1 );
-	assert.ok( true, "<script id='qunit-unescaped-asassertionsert'>'assertion';</script>" );
+	assert.true( true, "<script id='qunit-unescaped-asassertionsert'>'assertion';</script>" );
 } );
 
 QUnit.module( "display test info" );
@@ -42,10 +42,10 @@ QUnit.test( "running test name displayed", function( assert ) {
 
 	var displaying = document.getElementById( "qunit-testresult" );
 
-	assert.ok( /running test name displayed/.test( displaying.innerHTML ),
+	assert.true( /running test name displayed/.test( displaying.innerHTML ),
 		"Expect test name to be found in displayed text"
 	);
-	assert.ok( /display test info/.test( displaying.innerHTML ),
+	assert.true( /display test info/.test( displaying.innerHTML ),
 		"Expect module name to be found in displayed text"
 	);
 } );
@@ -56,7 +56,7 @@ QUnit.test( "running test suite progress displayed", function( assert ) {
 	var displaying = document.getElementById( "qunit-testresult" );
 
 	var expected = /\d+ \/ \d+ tests completed in \d+ milliseconds, with \d+ failed, \d+ skipped, and \d+ todo./;
-	assert.ok(
+	assert.true(
 		expected.test( displaying.innerHTML ),
 		"Expect test suite progress to be found in displayed text"
 	);
@@ -97,7 +97,7 @@ QUnit.test( "basics", function( assert ) {
 	var previous = this.getPreviousTest( assert ),
 		runtime = this.filterClass( previous.getElementsByTagName( "span" ) );
 
-	assert.ok( /^\d+ ms$/.test( runtime.innerHTML ), "Runtime reported in ms" );
+	assert.true( /^\d+ ms$/.test( runtime.innerHTML ), "Runtime reported in ms" );
 } );
 
 QUnit.test( "values", function( assert ) {
@@ -109,10 +109,10 @@ QUnit.test( "values", function( assert ) {
 	basics = this.filterClass( basics.getElementsByTagName( "span" ) );
 	setup = this.filterClass( setup.getElementsByTagName( "span" ) );
 
-	assert.ok( parseInt( basics.innerHTML, 10 ) < 100,
+	assert.true( parseInt( basics.innerHTML, 10 ) < 100,
 		"Fast runtime for trivial test"
 	);
-	assert.ok( parseInt( setup.innerHTML, 10 ) > 100,
+	assert.true( parseInt( setup.innerHTML, 10 ) > 100,
 		"Runtime includes beforeEach"
 	);
 } );
@@ -139,11 +139,11 @@ QUnit.test( "logs location", function( assert ) {
 		return;
 	}
 
-	assert.ok( /(^| )qunit-source( |$)/.test( source.className ), "Source element exists" );
+	assert.true( /(^| )qunit-source( |$)/.test( source.className ), "Source element exists" );
 	assert.equal( source.firstChild.innerHTML, "Source: " );
 
 	// The file test/reporter-html/reporter-html.js is a direct reference to this test file
-	assert.ok( /\/test\/reporter-html\/reporter-html\.js:\d+/.test( source.innerHTML ),
+	assert.true( /\/test\/reporter-html\/reporter-html\.js:\d+/.test( source.innerHTML ),
 		"Source references to the current file and line number"
 	);
 } );

--- a/test/reporter-html/single-testid.js
+++ b/test/reporter-html/single-testid.js
@@ -2,11 +2,11 @@ QUnit.config.testId = [ "2e48c6fa", "9ccf6855" ];
 
 QUnit.test( "Check for changed header after running filtered test", function( assert ) {
 	var html = document.getElementById( "qunit-filteredTest" ).innerHTML;
-	var result = html.match( /Rerunning selected tests: 2e48c6fa, 9ccf6855/ );
-	assert.ok( result );
+	var result = /Rerunning selected tests: 2e48c6fa, 9ccf6855/.test( html );
+	assert.true( result );
 } );
 
 QUnit.test( "Check for link to clear filter", function( assert ) {
 	var html = document.getElementById( "qunit-clearFilter" ).innerHTML;
-	assert.equal( html, "Run all tests" );
+	assert.strictEqual( html, "Run all tests" );
 } );

--- a/test/reporter-html/test-escape-details-source.js
+++ b/test/reporter-html/test-escape-details-source.js
@@ -2,7 +2,7 @@ QUnit.module( "outer module", function() {
 	QUnit.module( "inner module", function() {
 		QUnit.test( "test name with a special char > after char", function( assert ) {
 			assert.expect( 1 );
-			assert.ok( true, "dummy test" );
+			assert.true( true, "dummy test" );
 		} );
 	} );
 } );

--- a/test/reporter-html/window-onerror-preexisting-handler.js
+++ b/test/reporter-html/window-onerror-preexisting-handler.js
@@ -21,7 +21,7 @@ QUnit.module( "window.onerror (with preexisting handler)", function( hooks ) {
 		onerrorReturnValue = false;
 
 		QUnit.onError = function() {
-			assert.ok( true, "QUnit.onError was called" );
+			assert.true( true, "QUnit.onError was called" );
 		};
 
 		window.onerror( "An error message", "filename.js", 1 );
@@ -33,7 +33,7 @@ QUnit.module( "window.onerror (with preexisting handler)", function( hooks ) {
 		onerrorReturnValue = void 0;
 
 		QUnit.onError = function() {
-			assert.ok( true, "QUnit.onError was called" );
+			assert.true( true, "QUnit.onError was called" );
 		};
 
 		window.onerror( "An error message", "filename.js", 1 );
@@ -45,7 +45,7 @@ QUnit.module( "window.onerror (with preexisting handler)", function( hooks ) {
 		onerrorReturnValue = "truthy value";
 
 		QUnit.onError = function() {
-			assert.ok( true, "QUnit.onError was called" );
+			assert.true( true, "QUnit.onError was called" );
 		};
 
 		window.onerror( "An error message", "filename.js", 1 );
@@ -57,7 +57,7 @@ QUnit.module( "window.onerror (with preexisting handler)", function( hooks ) {
 		onerrorReturnValue = true;
 
 		QUnit.onError = function() {
-			assert.ok( false, "QUnit.onError should not have been called" );
+			assert.true( false, "QUnit.onError should not have been called" );
 		};
 
 		var result = window.onerror( "An error message", "filename.js", 1 );

--- a/test/reporter-html/window-onerror.js
+++ b/test/reporter-html/window-onerror.js
@@ -13,7 +13,7 @@ QUnit.module( "window.onerror (no preexisting handler)", function( hooks ) {
 		assert.expect( 1 );
 
 		QUnit.onError = function() {
-			assert.ok( true, "QUnit.onError was called" );
+			assert.true( true, "QUnit.onError was called" );
 		};
 
 		window.onerror( "An error message", "filename.js", 1 );

--- a/test/reporter-urlparams-hidepassed.js
+++ b/test/reporter-urlparams-hidepassed.js
@@ -4,22 +4,22 @@ if ( !location.search ) {
 
 QUnit.module( "urlParams hidepassed module", function() {
 	QUnit.test( "passed", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 	QUnit.test( "passed", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 	QUnit.test( "passed", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 	QUnit.test( "passed", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 	QUnit.test( "passed", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 	QUnit.test( "passed", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 	QUnit.skip( "skipped", function( assert ) {
 		assert.true( false, "can't seem to get this working" );

--- a/test/reporter-urlparams.js
+++ b/test/reporter-urlparams.js
@@ -9,11 +9,10 @@ QUnit.config.urlConfig.push( "custom", "customArray" );
 // Don't change this module name without also changing the module parameter when loading this suite
 QUnit.module( "urlParams module", function() {
 	QUnit.test( "parsing", function( assert ) {
-		assert.ok( QUnit.urlParams, "urlParams property exists" );
 		assert.strictEqual( QUnit.urlParams.implicit, true, "implicit true value" );
 		assert.strictEqual( QUnit.urlParams.explicit, "yes", "explicit value" );
 		assert.deepEqual( QUnit.urlParams.array, [ "A", "B" ], "multiple values" );
-		assert.ok( QUnit.urlParams[ "escaped name" ], "escape sequences in name" );
+		assert.true( QUnit.urlParams[ "escaped name" ], "escape sequences in name" );
 		assert.strictEqual( QUnit.urlParams.toString, "string", "Object.prototype property" );
 		assert.strictEqual( QUnit.urlParams.module, "urlParams module", "escaped space as +" );
 		assert.strictEqual( QUnit.urlParams.filter, "urlParams module", "escaped space as %20" );

--- a/test/setTimeout.js
+++ b/test/setTimeout.js
@@ -12,11 +12,11 @@
 	} );
 
 	QUnit.test( "just a test", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 
 	QUnit.test( "just a test", function( assert ) {
-		assert.ok( true );
+		assert.true( true );
 	} );
 
 }( ( function() {

--- a/test/string-filter.js
+++ b/test/string-filter.js
@@ -3,13 +3,13 @@ QUnit.config.filter = "!foo|bar";
 QUnit.module( "QUnit.config.filter" );
 
 QUnit.test( "foo test should be run", function( assert ) {
-	assert.ok( true, "foo test should be run" );
+	assert.true( true, "foo test should be run" );
 } );
 
 QUnit.test( "bar test should be run", function( assert ) {
-	assert.ok( true, "bar test should be run" );
+	assert.true( true, "bar test should be run" );
 } );
 
 QUnit.test( "foo|bar test should not be run", function( assert ) {
-	assert.ok( false, "baz test should not be run" );
+	assert.true( false, "baz test should not be run" );
 } );


### PR DESCRIPTION

Implements: https://github.com/qunitjs/qunit/issues/1450.

@Krinkle / @trentmwillis: I'm leaving a few usages of `assert.ok`/`assert.notOk` as their usage seems legitimate as they are actually testing something related to the assertions themselves.
Remaining legitimate usages of `assert.ok`:
- [`test/stack-errors.js`](https://github.com/qunitjs/qunit/blob/ae78fa04351306f213b73518ff9b186b41a1a4cf/test/stack-errors.js#L49);
- [`test/logs.js`](https://github.com/qunitjs/qunit/blob/master/test/logs.js#L156);
- [`test/main/assert.js`](https://github.com/qunitjs/qunit/blob/master/test/main/assert.js#L23)


Remaining legitimate usages of `assert.notOk`:
- [`test/main/assert.js`](https://github.com/qunitjs/qunit/blob/master/test/main/assert.js#L32)

TODO:
- [x] Docs.