### PR TITLE
HTML Reporter: Add basic ES6 Map fallback for fuzzysort.js

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -19,3 +19,20 @@ export const localSessionStorage = ( function() {
 		return undefined;
 	}
 }() );
+
+// Support IE 9-10: Fallback for fuzzysort.js used by /reporter/html.js
+if ( !global.Map ) {
+	global.Map = function StringMap() {
+		var store = Object.create( null );
+		this.get = function( strKey ) {
+			return store[ strKey ];
+		};
+		this.set = function( strKey, val ) {
+			store[ strKey ] = val;
+			return this;
+		};
+		this.clear = function() {
+			store = Object.create( null );
+		};
+	};
+}

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,7 +1,8 @@
 {
 	"extends": [ "plugin:qunit/two" ],
 	"env": {
-		"browser": true
+		"browser": true,
+		"es6": false
 	},
 	"plugins": [
 		"html",
@@ -12,6 +13,7 @@
 	},
 	"globals": {
 		"QUnit": false,
+		"Promise": false,
 		"console": false
 	},
 	"rules": {

--- a/test/cli/.eslintrc.json
+++ b/test/cli/.eslintrc.json
@@ -3,6 +3,7 @@
     "ecmaVersion": 2017
   },
   "env": {
-    "node": true
+    "node": true,
+    "es6": true
   }
 }

--- a/test/main/assert.js
+++ b/test/main/assert.js
@@ -313,7 +313,7 @@ QUnit.test( "rejects", function( assert ) {
 		return this.message;
 	};
 
-	const rejectsReturnValue = assert.rejects(
+	var rejectsReturnValue = assert.rejects(
 		buildMockPromise( "my error" )
 	);
 

--- a/test/main/assert/step.js
+++ b/test/main/assert/step.js
@@ -154,7 +154,7 @@ QUnit.module( "assert.verifySteps value reference", function() {
 	} );
 
 	QUnit.test( "steps array should not be reset in logging function", function( assert ) {
-		const result = loggedAssertions[ "verification-assertion" ].actual;
+		var result = loggedAssertions[ "verification-assertion" ].actual;
 		assert.deepEqual( result, [ "step one", "step two" ] );
 	} );
 

--- a/test/main/utilities.js
+++ b/test/main/utilities.js
@@ -1,3 +1,5 @@
+/* globals Map, Set, Symbol */
+
 QUnit.module( "QUnit.objectType" );
 
 function Foo( ) { }

--- a/test/only.js
+++ b/test/only.js
@@ -1,5 +1,5 @@
 QUnit.module( "QUnit.only", function( hooks ) {
-	let testsRun = 0;
+	var testsRun = 0;
 
 	hooks.after( function( assert ) {
 		assert.strictEqual( testsRun, 2 );

--- a/test/reporter-html/unhandled-rejection.js
+++ b/test/reporter-html/unhandled-rejection.js
@@ -15,7 +15,7 @@ if ( HAS_UNHANDLED_REJECTION_HANDLER ) {
 		} );
 
 		QUnit.test( "test passes just fine, but has a rejected promise", function( assert ) {
-			const done = assert.async();
+			var done = assert.async();
 
 			Promise.resolve().then( function() {
 				throw new Error( "Error thrown in non-returned promise!" );

--- a/test/reporter-html/window-onerror.js
+++ b/test/reporter-html/window-onerror.js
@@ -22,7 +22,7 @@ QUnit.module( "window.onerror (no preexisting handler)", function( hooks ) {
 	QUnit.test( "Should extract stacktrace if it is available", function( assert ) {
 		assert.expect( 1 );
 
-		const errorObj = {
+		var errorObj = {
 			stack: "dummy.js:1 top()\ndummy.js:2 middle()\ndummy.js:3 bottom()"
 		};
 

--- a/test/webWorker-worker.js
+++ b/test/webWorker-worker.js
@@ -1,4 +1,5 @@
 /* global importScripts */
+/* eslint-env es6 */
 importScripts(
 	"../dist/qunit.js",
 	"main/test.js",


### PR DESCRIPTION
Follows-up 474a708, which added fuzzysort.js, which has an
undocumented dependency on ES6 Map (whilst publishing its code
in UMD/ES5-syntax).

Restore IE 10 compat by adding a simple inline fallback
(it only needs to work with strings).

Also:
* Restore ESLint settings on test/main/ to explicitly disable
  es6. This used to be the default (we enable es6:true on /src/
  and /test/cli), but now that ESLint enables it by default we need
  to disable it to flag its use.
* Fix the handful of syntaxes that were introduced and caused
  tests to fail as a result.

Ref https://github.com/qunitjs/qunit/pull/1440.