### PR TITLE
CLI: Further improve startup performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1616,7 +1616,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -1658,6 +1659,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1826,7 +1828,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -3897,6 +3900,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -4229,8 +4233,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pify": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2849,6 +2849,16 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "globalyzer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.4.tgz",
+      "integrity": "sha512-LeguVWaxgHN0MNbWC6YljNMzHkrCny9fzjmEUdnF1kQ7wATFD1RHFRqA1qxaX2tgxGENlcxjOflopBwj3YZiXA=="
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
+    },
     "globule": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
@@ -4233,7 +4243,8 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
@@ -4989,6 +5000,15 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "tiny-glob": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.6.tgz",
+      "integrity": "sha512-A7ewMqPu1B5PWwC3m7KVgAu96Ch5LA0w4SnEN/LbDREj/gAD0nPWboRbn8YoP9ISZXqeNAlMvKSKoEuhcfK3Pw==",
+      "requires": {
+        "globalyzer": "^0.1.0",
+        "globrex": "^0.1.1"
+      }
     },
     "tiny-lr": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "commander": "2.12.2",
     "js-reporters": "1.2.1",
     "node-watch": "0.6.4",
-    "picomatch": "2.2.2"
+    "tiny-glob": "0.2.6"
   },
   "devDependencies": {
     "@babel/core": "7.11.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "commander": "2.12.2",
     "js-reporters": "1.2.1",
     "node-watch": "0.6.4",
-    "minimatch": "3.0.4"
+    "picomatch": "2.2.2"
   },
   "devDependencies": {
     "@babel/core": "7.11.1",

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -2,7 +2,7 @@
 
 const fs = require( "fs" );
 const path = require( "path" );
-const { Minimatch } = require( "minimatch" );
+const picomatch = require( "picomatch" );
 
 function existsStat() {
 	try {
@@ -30,14 +30,15 @@ function findFilesInternal( dir, options, result = [], prefix = "" ) {
 			return;
 		}
 		const prefixedName = prefix + name;
-		const isIgnore = options.ignores.some( ( mm ) => mm.match( prefixedName ) );
+		const isIgnore = options.ignores( prefixedName );
+
 		if ( isIgnore ) {
 			return;
 		}
 		if ( stat.isDirectory() ) {
 			findFilesInternal( fullName, options, result, prefixedName + "/" );
 		} else {
-			const isMatch = options.matchers.some( ( mm ) => mm.match( prefixedName ) );
+			const isMatch = options.matchers( prefixedName );
 			if ( isMatch ) {
 				result.push( prefixedName );
 			}
@@ -48,8 +49,8 @@ function findFilesInternal( dir, options, result = [], prefix = "" ) {
 
 function findFiles( baseDir, options ) {
 	return findFilesInternal( baseDir, {
-		matchers: ( options.match || [] ).map( ( pattern ) => new Minimatch( pattern ) ),
-		ignores: ( options.ignore || [] ).map( ( pattern ) => new Minimatch( pattern ) )
+		matchers: picomatch( options.match || [] ),
+		ignores: picomatch( options.ignore || [] )
 	} );
 }
 

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -33,9 +33,9 @@ ok 1 Single > has a test
 
 	"qunit single.js double.js":
 `TAP version 13
-ok 1 Single > has a test
-ok 2 Double > has a test
-ok 3 Double > has another test
+ok 1 Double > has a test
+ok 2 Double > has another test
+ok 3 Single > has a test
 1..3
 # pass 3
 # skip 0
@@ -71,9 +71,9 @@ not ok 1 Throws match > bad
 
 	"qunit test single.js 'glob/**/*-test.js'":
 `TAP version 13
-ok 1 Single > has a test
-ok 2 A-Test > derp
-ok 3 Nested-Test > herp
+ok 1 A-Test > derp
+ok 2 Nested-Test > herp
+ok 3 Single > has a test
 ok 4 First > 1
 ok 5 Second > 1
 1..5
@@ -85,10 +85,10 @@ ok 5 Second > 1
 	"qunit --seed 's33d' test single.js 'glob/**/*-test.js'": `Running tests with seed: s33d
 TAP version 13
 ok 1 Second > 1
-ok 2 Nested-Test > herp
+ok 2 Single > has a test
 ok 3 First > 1
-ok 4 A-Test > derp
-ok 5 Single > has a test
+ok 4 Nested-Test > herp
+ok 5 A-Test > derp
 1..5
 # pass 5
 # skip 0


### PR DESCRIPTION
When using a glob or directory argument, we currently recursively traverse the entire working directory (except for `.git` and `node_modules`) and then filter out results later with Minimatch. This is inefficient to say the least, and is especially noticable on large repositories.

I looked into a bunch of glob libraries but couldn't find any that uphold our security and simplicity principles, in so far that most of them bring in far too many dependencies that I can't feasibly audit or keep up with and (unfortunately) most likely the library author hasn't audited or trusts deeply either to e.g. not get compromised or taken over in subtle ways.

Except for one, `tiny-glob`, this seems to fit the bill nicely and would be a great library to boost through the QUnit community. I instrumented it with some checks and confirmed that it isn't just very fast (which some globbers achieve by spawning processes rather than being efficient), but indeed it is also efficient in not traversing directories that it knows cannot match any part of the pattern. e.g. `src/` will be entered for `**/*.js` but will not be entered for `test/**/*.js`.

@SparshithNR @rwjblue I tried this out on a few small code basis and an artificially bloated directory tree and it seems to work fine. I'd be great if you could give this a try and let me know if you find any issues and/or could measure improvements. Thanks!