### PR TITLE
CLI: Fix 'qunit' require error on Node 10 if qunit.json exists

### DIFF
--- a/src/cli/require-qunit.js
+++ b/src/cli/require-qunit.js
@@ -4,7 +4,12 @@ module.exports = function requireQUnit( resolve = require.resolve ) {
 	try {
 
 		// First we attempt to find QUnit relative to the current working directory.
-		const localQUnitPath = resolve( "qunit", { paths: [ process.cwd() ] } );
+		const localQUnitPath = resolve( "qunit", {
+
+			// Support: Node 10. Explicitly check "node_modules" to avoid a bug.
+			// Fixed in Node 12+. See https://github.com/nodejs/node/issues/35367.
+			paths: [ process.cwd() + "/node_modules", process.cwd() ]
+		} );
 		delete require.cache[ localQUnitPath ];
 		return require( localQUnitPath );
 	} catch ( e ) {


### PR DESCRIPTION
If the project using QUnit has a local qunit.json file in the
repository root, then the CLI was unable to find the 'qunit'
package. Instead, it first found a local 'qunit.json' file.

This affected an ESLint plugin with a 'qunit' preset file.

This bug was fixed in Node 12, and thus only affects Node 10 for us.

The bug is also specific to require.resolve(). Regular use of
require() was not affected and always correctly found the
local package. (A local file would only be considered if the
require started with dot-slash like `./qunit`.)

Ref https://github.com/nodejs/node/issues/35367.
Fixes https://github.com/qunitjs/qunit/issues/1484.