### PR TITLE
HTML Reporter: Remove unused 'moduleList' arrray

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -50,8 +50,7 @@ export function escapeText( s ) {
 		collapseNext = false,
 		hasOwn = Object.prototype.hasOwnProperty,
 		unfilteredUrl = setUrl( { filter: undefined, module: undefined,
-			moduleId: undefined, testId: undefined } ),
-		modulesList = [];
+			moduleId: undefined, testId: undefined } );
 
 	function addEvent( elem, type, fn ) {
 		elem.addEventListener( type, fn, false );
@@ -649,19 +648,7 @@ export function escapeText( s ) {
 	}
 
 	// HTML Reporter initialization and load
-	QUnit.begin( function( details ) {
-		var i, moduleObj;
-
-		// Sort modules by name for the picker
-		for ( i = 0; i < details.modules.length; i++ ) {
-			moduleObj = details.modules[ i ];
-			if ( moduleObj.name ) {
-				modulesList.push( moduleObj.name );
-			}
-		}
-		modulesList.sort( function( a, b ) {
-			return a.localeCompare( b );
-		} );
+	QUnit.begin( function() {
 
 		// Initialize QUnit elements
 		appendInterface();


### PR DESCRIPTION
Follows-up 0780127c7f64, which changed the code to use QUnit.config.modules directly. This meant the list is no longer
sorted, however. I filed https://github.com/qunitjs/qunit/issues/1487 to look into that.

Depending on the outcome of that, we can bring this back in some form after the refactoring of https://github.com/qunitjs/qunit/issues/1487.