### PR TITLE
Clean up internal access to document and performance globals

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -2,7 +2,7 @@ import QUnit from "../src/core";
 import Test from "../src/test";
 import { extractStacktrace } from "../src/core/stacktrace";
 import { now } from "../src/core/utilities";
-import { window, navigator } from "../src/globals";
+import { window, document, navigator } from "../src/globals";
 import "./urlparams";
 import fuzzysort from "fuzzysort";
 
@@ -40,13 +40,12 @@ export function escapeText( s ) {
 ( function() {
 
 	// Don't load the HTML Reporter on non-browser environments
-	if ( typeof window === "undefined" || !window.document ) {
+	if ( !window || !document ) {
 		return;
 	}
 
 	var config = QUnit.config,
 		hiddenTests = [],
-		document = window.document,
 		collapseNext = false,
 		hasOwn = Object.prototype.hasOwnProperty,
 		unfilteredUrl = setUrl( { filter: undefined, module: undefined,

--- a/runner/fixture.js
+++ b/runner/fixture.js
@@ -3,7 +3,7 @@ import { window, document } from "../src/globals";
 
 ( function() {
 
-	if ( typeof window === "undefined" || typeof document === "undefined" ) {
+	if ( !window || !document ) {
 		return;
 	}
 

--- a/src/core.js
+++ b/src/core.js
@@ -1,4 +1,4 @@
-import { window, setTimeout } from "./globals";
+import { window, document, setTimeout } from "./globals";
 
 import equiv from "./equiv";
 import dump from "./dump";
@@ -8,7 +8,7 @@ import Test, { test, skip, only, todo, pushFailure } from "./test";
 import exportQUnit from "./export";
 
 import config from "./core/config";
-import { defined, extend, objectType, is, now } from "./core/utilities";
+import { extend, objectType, is, now } from "./core/utilities";
 import { registerLoggingCallbacks, runLoggingCallbacks } from "./core/logging";
 import { sourceFromStacktrace } from "./core/stacktrace";
 import ProcessingQueue from "./core/processing-queue";
@@ -31,7 +31,7 @@ var globalStartCalled = false;
 var runStarted = false;
 
 // Figure out if we're running the tests from a server or not
-QUnit.isLocal = !( defined.document && window.location.protocol !== "file:" );
+QUnit.isLocal = ( window && window.location && window.location.protocol === "file:" );
 
 // Expose the current QUnit version
 QUnit.version = "@VERSION";
@@ -70,7 +70,7 @@ extend( QUnit, {
 
 				// Starts from Node even if .load was not previously called. We still return
 				// early otherwise we'll wind up "beginning" twice.
-				if ( !defined.document ) {
+				if ( !document ) {
 					QUnit.load();
 				}
 
@@ -134,7 +134,7 @@ function scheduleBegin() {
 	runStarted = true;
 
 	// Add a slight delay to allow definition of more modules and tests.
-	if ( defined.setTimeout ) {
+	if ( setTimeout ) {
 		setTimeout( function() {
 			begin();
 		} );

--- a/src/core/processing-queue.js
+++ b/src/core/processing-queue.js
@@ -1,6 +1,5 @@
 import config from "./config";
 import {
-	defined,
 	generateHash,
 	now
 } from "./utilities";
@@ -59,7 +58,7 @@ function processTaskQueue( start ) {
 	if ( taskQueue.length && !config.blocking ) {
 		const elapsedTime = now() - start;
 
-		if ( !defined.setTimeout || config.updateRate <= 0 || elapsedTime < config.updateRate ) {
+		if ( !setTimeout || config.updateRate <= 0 || elapsedTime < config.updateRate ) {
 			const task = taskQueue.shift();
 			Promise.resolve( task() ).then( function() {
 				if ( !taskQueue.length ) {

--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -1,4 +1,4 @@
-import { window, setTimeout } from "../globals";
+import { window } from "../globals";
 import Logger from "../logger";
 
 export const toString = Object.prototype.toString;
@@ -36,11 +36,6 @@ export const performance = {
 		}
 	} : function() {},
 	mark: nativePerf ? nativePerf.mark.bind( nativePerf ) : function() {}
-};
-
-export const defined = {
-	document: window && window.document !== undefined,
-	setTimeout: setTimeout !== undefined
 };
 
 // Returns a new Array with the elements that are in a but not in b

--- a/src/export.js
+++ b/src/export.js
@@ -1,10 +1,9 @@
 /* global module, exports, define */
-import { defined } from "./core/utilities";
-import { window, self } from "./globals";
+import { window, document, self } from "./globals";
 
 export default function exportQUnit( QUnit ) {
 
-	if ( defined.document ) {
+	if ( window && document ) {
 
 		// QUnit may be defined when it is preconfigured but then only QUnit and QUnit.config may be defined.
 		if ( window.QUnit && window.QUnit.version ) {

--- a/src/reports/suite.js
+++ b/src/reports/suite.js
@@ -1,4 +1,4 @@
-import { measure, performance, performanceNow } from "../core/utilities";
+import { performance } from "../core/utilities";
 
 export default class SuiteReport {
 	constructor( name, parentSuite ) {
@@ -15,12 +15,10 @@ export default class SuiteReport {
 
 	start( recordTime ) {
 		if ( recordTime ) {
-			this._startTime = performanceNow();
+			this._startTime = performance.now();
 
-			if ( performance ) {
-				const suiteLevel = this.fullName.length;
-				performance.mark( `qunit_suite_${suiteLevel}_start` );
-			}
+			const suiteLevel = this.fullName.length;
+			performance.mark( `qunit_suite_${suiteLevel}_start` );
 		}
 
 		return {
@@ -36,20 +34,17 @@ export default class SuiteReport {
 
 	end( recordTime ) {
 		if ( recordTime ) {
-			this._endTime = performanceNow();
+			this._endTime = performance.now();
 
-			if ( performance ) {
-				const suiteLevel = this.fullName.length;
-				performance.mark( `qunit_suite_${suiteLevel}_end` );
+			const suiteLevel = this.fullName.length;
+			const suiteName = this.fullName.join( " – " );
 
-				const suiteName = this.fullName.join( " – " );
-
-				measure(
-					suiteLevel === 0 ? "QUnit Test Run" : `QUnit Test Suite: ${suiteName}`,
-					`qunit_suite_${suiteLevel}_start`,
-					`qunit_suite_${suiteLevel}_end`
-				);
-			}
+			performance.mark( `qunit_suite_${suiteLevel}_end` );
+			performance.measure(
+				suiteLevel === 0 ? "QUnit Test Run" : `QUnit Test Suite: ${suiteName}`,
+				`qunit_suite_${suiteLevel}_start`,
+				`qunit_suite_${suiteLevel}_end`
+			);
 		}
 
 		return {

--- a/src/reports/test.js
+++ b/src/reports/test.js
@@ -1,4 +1,4 @@
-import { extend, measure, performance, performanceNow } from "../core/utilities";
+import { extend, performance } from "../core/utilities";
 
 export default class TestReport {
 	constructor( name, suite, options ) {
@@ -21,10 +21,8 @@ export default class TestReport {
 
 	start( recordTime ) {
 		if ( recordTime ) {
-			this._startTime = performanceNow();
-			if ( performance ) {
-				performance.mark( "qunit_test_start" );
-			}
+			this._startTime = performance.now();
+			performance.mark( "qunit_test_start" );
 		}
 
 		return {
@@ -36,13 +34,13 @@ export default class TestReport {
 
 	end( recordTime ) {
 		if ( recordTime ) {
-			this._endTime = performanceNow();
+			this._endTime = performance.now();
 			if ( performance ) {
 				performance.mark( "qunit_test_end" );
 
 				const testName = this.fullName.join( " – " );
 
-				measure(
+				performance.measure(
 					`QUnit Test: ${testName}`,
 					"qunit_test_start",
 					"qunit_test_end"

--- a/src/test.js
+++ b/src/test.js
@@ -8,7 +8,6 @@ import Promise from "./promise";
 
 import config from "./core/config";
 import {
-	defined,
 	diff,
 	extend,
 	generateHash,
@@ -746,7 +745,7 @@ export function internalStop( test ) {
 	config.blocking = true;
 
 	// Set a recovery timeout, if so configured.
-	if ( defined.setTimeout ) {
+	if ( setTimeout ) {
 		let timeoutDuration;
 
 		if ( typeof test.timeout === "number" ) {
@@ -822,7 +821,7 @@ function internalStart( test ) {
 	}
 
 	// Add a slight delay to allow more assertions etc.
-	if ( defined.setTimeout ) {
+	if ( setTimeout ) {
 		if ( config.timeout ) {
 			clearTimeout( config.timeout );
 		}


### PR DESCRIPTION
The pattern of checking `A` to decide whether `B` is safe to use is imho an anti-pattern and reduces confidence in the code. This was previously the case for `setTimeout`, `performance` and `document`.