### PR TITLE
Deprecate QUnit.extend

### DIFF
--- a/docs/config/QUnit.extend.md
+++ b/docs/config/QUnit.extend.md
@@ -1,9 +1,13 @@
 ---
 layout: default
-categories: [config]
+categories:
+- config
+- deprecated
 title: QUnit.extend()
+status: deprecated
 description: Copy the properties defined by the <code>mixin</code> object into the <code>target</code> object.
 version_added: "1.0"
+version_deprecated: "2.12"
 ---
 
 `QUnit.extend( target, mixin )`
@@ -14,6 +18,8 @@ Copy the properties defined by the `mixin` object into the `target` object
 |--------------------|--------------------------------------|
 | `target`           | An object whose properties are to be modified |
 | `mixin`            | An object describing which properties should be modified |
+
+<p class="note note--warning" markdown="1">This method is __deprecated__ and it's recommended to use `Object.assign` instead.</p>
 
 This method will modify the `target` object to contain the "own" properties defined by the `mixin`. If the `mixin` object specifies the value of any attribute as `undefined`, this property will instead be removed from the `target` object.
 

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -1,7 +1,7 @@
 import QUnit from "../src/core";
 import Test from "../src/test";
 import { extractStacktrace } from "../src/core/stacktrace";
-import { now } from "../src/core/utilities";
+import { now, extend } from "../src/core/utilities";
 import { window, document, navigator } from "../src/globals";
 import "./urlparams";
 import fuzzysort from "fuzzysort";
@@ -244,7 +244,7 @@ export function escapeText( s ) {
 			querystring = "?",
 			location = window.location;
 
-		params = QUnit.extend( QUnit.extend( {}, QUnit.urlParams ), params );
+		params = extend( extend( {}, QUnit.urlParams ), params );
 
 		for ( key in params ) {
 

--- a/src/core.js
+++ b/src/core.js
@@ -4,6 +4,7 @@ import equiv from "./equiv";
 import dump from "./dump";
 import module from "./module";
 import Assert from "./assert";
+import Logger from "./logger";
 import Test, { test, skip, only, todo, pushFailure } from "./test";
 import exportQUnit from "./export";
 
@@ -89,7 +90,13 @@ extend( QUnit, {
 
 	objectType: objectType,
 
-	extend: extend,
+	extend: function( ...args ) {
+		Logger.warn( "QUnit.extend is deprecated and will be removed in QUnit 3.0." +
+			" Please use Object.assign instead." );
+
+		// delegate to utility implementation, which does not warn and can be used elsewhere internally
+		return extend.apply( this, args );
+	},
 
 	load: function() {
 		config.pageLoaded = true;

--- a/test/main/utilities.js
+++ b/test/main/utilities.js
@@ -62,3 +62,29 @@ maybeValidateObjectType( "async function() { }", "function" );
 maybeValidateObjectType( "async () => { }", "function" );
 maybeValidateObjectType( "() => { }", "function" );
 maybeValidateObjectType( "function* { }", "function" );
+
+QUnit.module( "extend" );
+
+QUnit.test( "appends to object", function( assert ) {
+	var base = { foo: 1 };
+	var copy = QUnit.extend( base, { bar: 2 } );
+
+	assert.deepEqual( base, { foo: 1, bar: 2 } );
+	assert.equal( copy, base, "returns mutated object" );
+} );
+
+QUnit.test( "overwrites duplicate fields", function( assert ) {
+	var base = { foo: 1 };
+	var copy = QUnit.extend( base, { foo: 2 } );
+
+	assert.deepEqual( base, { foo: 2 } );
+	assert.equal( copy, base, "returns mutated object" );
+} );
+
+QUnit.test( "removes undefined fields", function( assert ) {
+	var base = { foo: 1, bar: 2 };
+	var copy = QUnit.extend( base, { bar: undefined } );
+
+	assert.false( "bar" in base, "Values specified as `undefined` are removed" );
+	assert.equal( copy, base, "returns mutated object" );
+} );


### PR DESCRIPTION
Fixes #1491 

Backfilled a few unittests for sanity-checks and coverage
QUnit.extend issues a warning that it is to be deprecated in QUnit 3.0, and recommends `Object.assign`. (do we want an MDN hyperlink?)
The core `extend` utility is still warning-free, and used internally in many places. In QUnit 3.0, those can move to `Object.assign` as well.
Added deprecated status on docs, guessing that this would land in 2.12.