### PR TITLE
Provide QUnit.test aliases for only/todo/skip

### DIFF
--- a/docs/QUnit/test.md
+++ b/docs/QUnit/test.md
@@ -14,6 +14,9 @@ version_added: "1.0"
 ---
 
 `QUnit.test( name, callback )`
+`QUnit.test.only( name, callback )`<br>
+`QUnit.test.skip( name, callback )`<br>
+`QUnit.test.todo( name, callback )`
 
 Add a test to run.
 
@@ -27,6 +30,12 @@ Add a test to run.
 | parameter | description |
 |-----------|-------------|
 | `assert` (object) | A new instance object with the [assertion methods](../assert/index.md) |
+
+The `only`, `skip`, and `todo` variants of `QUnit.test` are aliases to the respective main QUnit methods:<br>
+
+* `QUnit.test.only()` is the same as [`QUnit.only()`](./only.md)
+* `QUnit.test.skip()` is the same as [`QUnit.skip()`](./skip.md)
+* `QUnit.test.todo()` is the same as [`QUnit.todo()`](./todo.md)
 
 ### Description
 

--- a/src/core.js
+++ b/src/core.js
@@ -4,7 +4,7 @@ import equiv from "./equiv";
 import dump from "./dump";
 import module from "./module";
 import Assert from "./assert";
-import Test, { test, skip, only, todo, pushFailure } from "./test";
+import Test, { test, pushFailure } from "./test";
 import exportQUnit from "./export";
 
 import config from "./core/config";
@@ -43,11 +43,10 @@ extend( QUnit, {
 
 	test: test,
 
-	todo: todo,
-
-	skip: skip,
-
-	only: only,
+	// alias other test flavors for easy access
+	todo: test.todo,
+	skip: test.skip,
+	only: test.only,
 
 	start: function( count ) {
 		var globalStartAlreadyCalled = globalStartCalled;

--- a/src/test.js
+++ b/src/test.js
@@ -689,48 +689,46 @@ export function test( testName, callback ) {
 	newTest.queue();
 }
 
-export function todo( testName, callback ) {
-	if ( focused ) {
-		return;
+extend( test, {
+	todo: function todo( testName, callback ) {
+		if ( focused ) {
+			return;
+		}
+
+		const newTest = new Test( {
+			testName,
+			callback,
+			todo: true
+		} );
+
+		newTest.queue();
+	},
+	skip: function skip( testName ) {
+		if ( focused ) {
+			return;
+		}
+
+		const test = new Test( {
+			testName: testName,
+			skip: true
+		} );
+
+		test.queue();
+	},
+	only: function only( testName, callback ) {
+		if ( !focused ) {
+			config.queue.length = 0;
+			focused = true;
+		}
+
+		const newTest = new Test( {
+			testName: testName,
+			callback: callback
+		} );
+
+		newTest.queue();
 	}
-
-	const newTest = new Test( {
-		testName,
-		callback,
-		todo: true
-	} );
-
-	newTest.queue();
-}
-
-// Will be exposed as QUnit.skip
-export function skip( testName ) {
-	if ( focused ) {
-		return;
-	}
-
-	const test = new Test( {
-		testName: testName,
-		skip: true
-	} );
-
-	test.queue();
-}
-
-// Will be exposed as QUnit.only
-export function only( testName, callback ) {
-	if ( !focused ) {
-		config.queue.length = 0;
-		focused = true;
-	}
-
-	const newTest = new Test( {
-		testName: testName,
-		callback: callback
-	} );
-
-	newTest.queue();
-}
+} );
 
 // Resets config.timeout with a new timeout duration.
 export function resetTestTimeout( timeoutDuration ) {

--- a/test/main/test.js
+++ b/test/main/test.js
@@ -193,6 +193,15 @@ QUnit.test( "testForPush", function( assert ) {
 	assert.testForPush( 1, 1, "should be call pushResult" );
 } );
 
+QUnit.module( "aliases" );
+
+[ "todo", "skip", "only" ].forEach( function( flavor ) {
+	QUnit.test( flavor, function( assert ) {
+		assert.true( QUnit.test[ flavor ] instanceof Function );
+		assert.equal( QUnit[ flavor ], QUnit.test[ flavor ] );
+	} );
+} );
+
 QUnit.module( "QUnit.skip", {
 	beforeEach: function( assert ) {
 


### PR DESCRIPTION
Fixes #1402 
```
QUnit.test.only === QUnit.only
QUnit.test.todo === QUnit.todo
QUnit.test.skip === QUnit.skip
```

#1402 called out these QUnit.test variants as aliases _to_ the main QUnit functions, but to keep the code modular, I reversed that in the implementation to make the _main_ QUnit functions aliases to the test implementations. Those are really the "shortcuts" at that level, and Test holds onto the real implementations (as it always had). These methods are now encapsulated and exposed only through the Test function/object, no longer as exported functions.

Our existing tests still use the main QUnit methods, which I think is perfectly valid.

I doc'ed these new aliases in Test.md, pointing to the existing main QUnit methods. I did _not_ touch the main only/todo/skip docs to point to anything about these new aliases, but I could add a "Changelog" section in each to mention these? I didn't want to clutter.