### PR TITLE
CLI: Update "node-watch" and "commander" dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1899,9 +1899,9 @@
       }
     },
     "commander": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.0.0.tgz",
-      "integrity": "sha512-s7EA+hDtTYNhuXkTlhqew4txMZVdszBmKWSPEMxGr8ru8JXR7bLUFIAtPhcSuFdJQ0ILMxnJi8GkQL0yvDy/YA=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
     },
     "commitplease": {
       "version": "3.1.0",
@@ -4337,9 +4337,9 @@
       "dev": true
     },
     "node-watch": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.6.4.tgz",
-      "integrity": "sha512-cI6CHzivIFESe8djiK3Wh90CtWQBxLwMem8x8S+2GSvCvFgoMuOKVlfJtQ/2v3Afg3wOnHl/+tXotEs8z5vOrg=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.0.tgz",
+      "integrity": "sha512-OOBiglke5SlRQT5WYfwXTmYqTfXjcTNBHpalyHLtLxDpQYVpVRkJqabcch1kmwJsjV/J4OZuzEafeb4soqtFZA=="
     },
     "nopt": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "node": ">=10"
   },
   "dependencies": {
-    "commander": "6.0.0",
+    "commander": "6.2.0",
     "js-reporters": "1.2.3",
-    "node-watch": "0.6.4",
+    "node-watch": "0.7.0",
     "tiny-glob": "0.2.6"
   },
   "devDependencies": {


### PR DESCRIPTION
node-watch:

* Changelog: https://github.com/yuanchuan/node-watch/blob/0.7.0/Changelog.md
* Diff: https://github.com/yuanchuan/node-watch/compare/0.6.4...0.7.0
* Summary:
  - Remains dependency-free.
  - Audited by me.
  - No notable changes for us (adds a new option).

commander:

* Changelog: https://github.com/tj/commander.js/blob/v6.2.0/CHANGELOG.md
* Diff: https://github.com/tj/commander.js/compare/v6.0.0...v6.2.0?w=1#files_bucket
* Summary:
  - Remains dependency-free.
  - Audited by me.
  - No notable changes for us (fixes bugs with options we didn't use,
    and adds new options).