### PR TITLE
Build: fix missing coverage from main browser tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -110,7 +110,6 @@ module.exports = function( grunt ) {
 						require.resolve( "grunt-contrib-qunit/chrome/bridge" )
 					],
 					urls: [
-						"test/sandboxed-iframe.html",
 						"test/index.html",
 						"test/autostart.html",
 						"test/startError.html",
@@ -145,7 +144,11 @@ module.exports = function( grunt ) {
 						"test/string-filter.html",
 						"test/module-only.html",
 						"test/module-skip.html",
-						"test/module-todo.html"
+						"test/module-todo.html",
+
+						// ensure this is last - it has the potential to drool
+						// and omit subsequent tests during coverage runs
+						"test/sandboxed-iframe.html"
 					].map( file => `http://localhost:${connectPort}/${file}` )
 				}
 			}


### PR DESCRIPTION
A continuation of what #1493 was getting at - the right test _phases_ were being run, but many testpoints were _missed_.

I isolated that the "sandboxed-iframe.html" test was the one causing issues in the browser tests, though only in coverage mode. I admit I don't understand what that iframe and injection step is doing, but it was leaking into the other tests queued up, and resulting in a lot of testpoints being omitted.

With it listed first, we get 129 tests completed with 210 assertions, and overall code coverage at 61%.
Moving it to the end, we get **348** tests completed with **949** assertions, and overall code coverage at **88%**.