### PR TITLE
Build: Remove 'commitplease' hook in favour of contribs doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ to take a look at the [GitHub Guides](https://guides.github.com/).
 As a first step, in order to contribute to QUnit, you will need to sign the JS
 Foundation's [CLA for QUnit](https://cla.js.foundation/qunitjs/qunit).
 
-### Code
+## Code
 
 For code changes, you'll need to have [Node.js](https://nodejs.org/en/) installed.
 
@@ -24,9 +24,48 @@ In general, code changes should be accompanied by a unit tests to verify the
 change in functionality. Once the new tests are passing, make a commit, push it
 to your GitHub fork, and create the pull request.
 
-### Documentation
+## Documentation
 
 The API documentation for QUnit lives in the `docs/` directory of this
 repository. For the rest of the QUnit website, see the [qunitjs.com repo](https://github.com/qunitjs/qunitjs.com).
 
 See [docs/README.md](docs/README.md) for how to preview the API documentation.
+
+## Commit messages
+
+If you're a new contributor, don't worry if you're unsure about
+the commit message. The team will edit or write it for you as part
+of their code review and merge activities. If you're a regular
+contributor, do try to follow this structure as it helps others to
+more quickly find, understand, and merge your changes. Thanks!
+
+Structure:
+
+```
+Component: Short subject line about what is changing
+
+Additional details about the commit are placed after a new line
+in the commit message body. That's this paragraph here.
+
+As well as any additional paragraphs. The last block is the footer,
+which is reserved for any "Ref", "Fixes" or "Closes" instructions
+(one per line).
+
+Fixes #1.
+```
+
+The subject line should use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood),
+and start with one of the following components:
+
+* `All`
+* `Assert`
+* `Build`
+* `CLI`
+* `Core`
+* `Docs`
+* `Dump`
+* `HTML Reporter`
+* `Release`
+* `Tests`
+
+See also [Commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qunit",
-  "version": "2.11.3-pre",
+  "version": "2.12.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1355,9 +1355,9 @@
       }
     },
     "@rollup/plugin-commonjs": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-15.0.0.tgz",
-      "integrity": "sha512-8uAdikHqVyrT32w1zB9VhW6uGwGjhKgnDNP4pQJsjdnyF4FgCj6/bmv24c7v2CuKhq32CcyCwRzMPEElaKkn0w==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-16.0.0.tgz",
+      "integrity": "sha512-LuNyypCP3msCGVQJ7ki8PqYdpjfEkE/xtFa5DqlF+7IBD0JsfMZ87C58heSwIMint58sAUZbt3ITqOmdQv/dXw==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -1369,12 +1369,6 @@
         "resolve": "^1.17.0"
       },
       "dependencies": {
-        "estree-walker": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
-          "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==",
-          "dev": true
-        },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -1389,30 +1383,22 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "magic-string": {
-          "version": "0.25.7",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-          "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.4"
-          }
-        },
         "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
           "dev": true,
           "requires": {
+            "is-core-module": "^2.1.0",
             "path-parse": "^1.0.6"
           }
         }
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz",
-      "integrity": "sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-10.0.0.tgz",
+      "integrity": "sha512-sNijGta8fqzwA1VwUEtTvWCx2E7qC70NMsDh4ZG13byAXYigBNZMxALhKUSycBks5gupJdq0lFrKumFrRZ8H3A==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -1423,18 +1409,13 @@
         "resolve": "^1.17.0"
       },
       "dependencies": {
-        "builtin-modules": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-          "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
-          "dev": true
-        },
         "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
           "dev": true,
           "requires": {
+            "is-core-module": "^2.1.0",
             "path-parse": "^1.0.6"
           }
         }
@@ -1482,9 +1463,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
-      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
+      "version": "14.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
+      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
       "dev": true
     },
     "@types/resolve": {
@@ -1746,6 +1727,12 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "builtin-modules": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+      "dev": true
+    },
     "bytes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
@@ -1902,18 +1889,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
       "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
-    },
-    "commitplease": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/commitplease/-/commitplease-3.1.0.tgz",
-      "integrity": "sha512-bMIzmsatPX6Wu2VmUKmtyiHxd6q2zZp4/+Y+M4HlX9wwH4iiHADuRMfN/X09x/UdcnjHP6sT2hHGEj2h38v+NA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.1",
-        "git-tools": "^0.2.1",
-        "ini": "^1.3.4",
-        "semver": "^5.1.0"
-      }
     },
     "commondir": {
       "version": "1.0.1",
@@ -2689,6 +2664,12 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
+      "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3093,15 +3074,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "git-tools": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/git-tools/-/git-tools-0.2.1.tgz",
-      "integrity": "sha1-bhhGrywOkatZJYtI+bU8EnmzsnM=",
-      "dev": true,
-      "requires": {
-        "spawnback": "~1.0.0"
-      }
-    },
     "glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -3498,6 +3470,15 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -3693,12 +3674,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
-    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -3713,6 +3688,15 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
+    },
+    "is-core-module": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+      "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -5031,9 +5015,9 @@
       }
     },
     "rollup": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.0.tgz",
-      "integrity": "sha512-1kwpBuxQERz+ymjPLepaXqf3NMRDwSumuEfW/fsTtflmyyhI6ev7nLy5Vdadvn01zd0WWAojRuvA2+0coPGCGQ==",
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.33.1.tgz",
+      "integrity": "sha512-uY4O/IoL9oNW8MMcbA5hcOaz6tZTMIh7qJHx/tzIJm+n1wLoY38BLn6fuy7DhR57oNFLMbDQtDeJoFURt5933w==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@babel/core": "^7.11.1",
     "@babel/plugin-external-helpers": "^7.10.4",
     "@babel/preset-env": "^7.11.0",
-    "commitplease": "^3.1.0",
     "coveralls": "^3.1.0",
     "es6-promise": "^4.2.5",
     "eslint-config-jquery": "^1.0.1",
@@ -68,7 +67,7 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-eslint": "^23.0.0",
     "grunt-git-authors": "^3.2.0",
-    "rollup": "^2.26.0",
+    "rollup": "^2.30.0",
     "grunt-search": "^0.1.8",
     "npm-reporter": "file:./test/cli/fixtures/npm-reporter",
     "nyc": "^15.1.0",
@@ -76,8 +75,8 @@
     "requirejs": "^2.3.5",
     "rimraf": "^2.7.1",
     "@rollup/plugin-babel": "^5.2.0",
-    "@rollup/plugin-commonjs": "^15.0.0",
-    "@rollup/plugin-node-resolve": "^9.0.0",
+    "@rollup/plugin-commonjs": "^16.0.0",
+    "@rollup/plugin-node-resolve": "^10.0.0",
     "@rollup/plugin-replace": "^2.3.3",
     "semver": "^5.4.1",
     "tiny-lr": "^1.1.1"
@@ -96,20 +95,6 @@
     "coverage:_cli": "nyc --use-spawn-wrap --silent bin/qunit.js test/cli/*.js",
     "coverage:_main": "nyc instrument --in-place dist/ && grunt connect:nolivereload qunit",
     "coveralls": "npm run coverage && cat coverage/lcov.info | coveralls"
-  },
-  "commitplease": {
-    "components": [
-      "All",
-      "Assert",
-      "Build",
-      "CLI",
-      "Core",
-      "Docs",
-      "Dump",
-      "HTML Reporter",
-      "Release",
-      "Tests"
-    ]
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
I've had to manually disable (and subsequently undo) this in package.json everytime I run `npm i`  or `npm ci`.

A secure dev environment must not allow npm scripts to write to .git/hooks. I use such an environment, and commitplease is
incompatible with that.

We could register it as part of npm-test or something else, but in practice it seems more often in the way than not. Especially as it is not very compatible with a PR-workflow where you might have fixup commits. I personally don't prefer that workflow, but it's what works best within GitHub (today). If that gets better, and we can assume each commit stands on its own, we could add this back as part of npm-test and/or in CI.

For now, just remove it and I'll take it on us as team to edit this as needed when performing the merge operation, which GitHub makes easy to do with it prompting to edit the commit message at that time.
