### PR TITLE
HTML Reporter: Avoid leaking `Map` variable in older browsers

### DIFF
--- a/reporter/es6-map.js
+++ b/reporter/es6-map.js
@@ -1,0 +1,15 @@
+// Support IE 9-10, PhantomJS: Fallback for fuzzysort.js used by /reporter/html.js
+// eslint-disable-next-line no-unused-vars
+var Map = typeof Map === "function" ? Map : function StringMap() {
+	var store = Object.create( null );
+	this.get = function( strKey ) {
+		return store[ strKey ];
+	};
+	this.set = function( strKey, val ) {
+		store[ strKey ] = val;
+		return this;
+	};
+	this.clear = function() {
+		store = Object.create( null );
+	};
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 
+const fs = require( "fs" );
 const { babel } = require( "@rollup/plugin-babel" );
 const { nodeResolve } = require( "@rollup/plugin-node-resolve" );
 const commonjs = require( "@rollup/plugin-commonjs" );
@@ -27,6 +28,16 @@ module.exports = {
  *\n\
  * Date: @DATE\n\
  */",
+
+		intro: function() {
+
+			// Define the (partial) ES6 Map polyfill for "fuzzysort".
+			// Per https://github.com/qunitjs/qunit/issues/1508:
+			// 1. Must not leak as global variable, since it's not full Map implementation.
+			// 2. Must be seen by fuzzysort as-is (e.g. not get renamed as normal
+			//    variables in an imported file would be).
+			return fs.readFileSync( __dirname + "/reporter/es6-map.js", "utf-8" ).toString().trim();
+		},
 
 		globals: {
 			global: "(function() { return this; }())"

--- a/src/globals.js
+++ b/src/globals.js
@@ -19,20 +19,3 @@ export const localSessionStorage = ( function() {
 		return undefined;
 	}
 }() );
-
-// Support IE 9-10: Fallback for fuzzysort.js used by /reporter/html.js
-if ( !global.Map ) {
-	global.Map = function StringMap() {
-		var store = Object.create( null );
-		this.get = function( strKey ) {
-			return store[ strKey ];
-		};
-		this.set = function( strKey, val ) {
-			store[ strKey ] = val;
-			return this;
-		};
-		this.clear = function() {
-			store = Object.create( null );
-		};
-	};
-}


### PR DESCRIPTION
On IE6-8 and in PhantomJS, our partial ES6 Map implementation was leaking as global variable.

Follows https://github.com/qunitjs/qunit/commit/2f2eaba36e9c4be7eaa82a71107ea5f66c7b1519.
Fixes https://github.com/qunitjs/qunit/issues/1508.