### PR TITLE
HTML Reporter: headers fixed, tests scrollable

### DIFF
--- a/src/qunit.css
+++ b/src/qunit.css
@@ -15,6 +15,28 @@
    the tested app might load. Don't affect buttons in #qunit-fixture!
    https://github.com/qunitjs/qunit/pull/1395
    https://github.com/qunitjs/qunit/issues/1437 */
+
+/** Fixed headers with scrollable tests **/
+
+body {
+  width: calc(100vw - 4px);
+  height: calc(100vh - 4px);
+  margin: 2px;
+}
+
+#qunit {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+#qunit-tests {
+  flex: 1;
+  overflow: auto;
+}
+
+/** END Fixed headers with scrollable tests **/
+
 #qunit-testrunner-toolbar button,
 #qunit-testresult button {
 	font-size: initial;

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -19,7 +19,9 @@
 /** Fixed headers with scrollable tests **/
 
 body {
-  height: calc(100vh - 4px);
+  position: fixed;
+  top: 0px;
+  bottom: 0px;
   padding: 2px;
 }
 

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -18,7 +18,7 @@
 
 /** Fixed headers with scrollable tests **/
 
-body {
+#qunit {
   position: fixed;
   left: 0px;
   right: 0px;

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -23,6 +23,7 @@ body {
   top: 0px;
   bottom: 0px;
   padding: 2px;
+  margin: 0px;
 }
 
 #qunit {

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -34,6 +34,10 @@
   #qunit-tests {
     overflow: scroll;
   }
+
+  #qunit-banner {
+    flex: 5px 0 0;
+  }
 }
 /** END Fixed headers with scrollable tests **/
 

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -19,9 +19,8 @@
 /** Fixed headers with scrollable tests **/
 
 body {
-  width: calc(100vw - 4px);
   height: calc(100vh - 4px);
-  margin: 2px;
+  padding: 2px;
 }
 
 #qunit {

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -16,26 +16,25 @@
    https://github.com/qunitjs/qunit/pull/1395
    https://github.com/qunitjs/qunit/issues/1437 */
 
-/** Fixed headers with scrollable tests **/
+@supports (display: flex) or (display: -webkit-box) {
+  /** Fixed headers with scrollable tests **/
 
-#qunit {
-  position: fixed;
-  left: 0px;
-  right: 0px;
-  top: 0px;
-  bottom: 0px;
-  padding: 2px;
-  margin: 0px;
+  #qunit {
+    position: fixed;
+    left: 0px;
+    right: 0px;
+    top: 0px;
+    bottom: 0px;
+    padding: 2px;
+    display: -webkit-box;
+    display: flex;
+    flex-direction: column;
+  }
+
+  #qunit-tests {
+    overflow: scroll;
+  }
 }
-
-#qunit-tests {
-  position: absolute;
-  top: 205px;
-  bottom: 0px;
-  overflow: auto;
-  width: 100%;
-}
-
 /** END Fixed headers with scrollable tests **/
 
 #qunit-testrunner-toolbar button,

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -30,9 +30,10 @@ body {
 
 #qunit-tests {
   position: absolute;
-  top: 185px;
+  top: 205px;
   bottom: 0px;
   overflow: auto;
+  width: 100%;
 }
 
 /** END Fixed headers with scrollable tests **/

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -20,20 +20,18 @@
 
 body {
   position: fixed;
+  left: 0px;
+  right: 0px;
   top: 0px;
   bottom: 0px;
   padding: 2px;
   margin: 0px;
 }
 
-#qunit {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
 #qunit-tests {
-  flex: 1;
+  position: absolute;
+  top: 185px;
+  bottom: 0px;
   overflow: auto;
 }
 

--- a/src/qunit.css
+++ b/src/qunit.css
@@ -19,24 +19,26 @@
 @supports (display: flex) or (display: -webkit-box) {
   /** Fixed headers with scrollable tests **/
 
-  #qunit {
-    position: fixed;
-    left: 0px;
-    right: 0px;
-    top: 0px;
-    bottom: 0px;
-    padding: 2px;
-    display: -webkit-box;
-    display: flex;
-    flex-direction: column;
-  }
+  @media (min-height: 500px) {
+    #qunit {
+      position: fixed;
+      left: 0px;
+      right: 0px;
+      top: 0px;
+      bottom: 0px;
+      padding: 2px;
+      display: -webkit-box;
+      display: flex;
+      flex-direction: column;
+    }
 
-  #qunit-tests {
-    overflow: scroll;
-  }
+    #qunit-tests {
+      overflow: scroll;
+    }
 
-  #qunit-banner {
-    flex: 5px 0 0;
+    #qunit-banner {
+      flex: 5px 0 0;
+    }
   }
 }
 /** END Fixed headers with scrollable tests **/


### PR DESCRIPTION
CSS change to keep test headers fixed at the top and make test results scrollable. Much improved dev experience.

Fixes #1512 

![image](https://user-images.githubusercontent.com/2016523/99577005-a00cda80-29d2-11eb-90f6-ebc0b0b819ef.png)
