### PR TITLE
Core: Fix test counter bug when nesting invalid test functions

### DIFF
--- a/test/main/test.js
+++ b/test/main/test.js
@@ -229,11 +229,11 @@ QUnit.module( "Missing Callbacks" );
 QUnit.test( "QUnit.test without a callback logs a descriptive error", function( assert ) {
 	assert.throws( function() {
 		QUnit.test( "should throw an error" );
-	}, /You must provide a function as a test callback to QUnit.test\("should throw an error"\)/ );
+	}, /You must provide a callback to QUnit.test\("should throw an error"\)/ );
 } );
 
 QUnit.test( "QUnit.todo without a callback logs a descriptive error", function( assert ) {
 	assert.throws( function() {
 		QUnit.todo( "should throw an error" );
-	}, /You must provide a function as a test callback to QUnit.todo\("should throw an error"\)/ );
+	}, /You must provide a callback to QUnit.todo\("should throw an error"\)/ );
 } );


### PR DESCRIPTION
This doesn't affect end-users, since nesting QUnit.test() calls
isn't supported. In our own unit tests, we assert early bail out
behaviour for passing invalid arguments to QUnit.test(), and naturally
we do this from inside another QUnit.test() call.

The previous code left bailed out *after* we had already registered
the test and handed out references to reporting code. This meant
that it would count this as two tests of which one had an unknown
state, which js-reporters casts to a failed test.

This wasn't caught in CI because:

- When we run the test via the HTML Reporter and via the
  test-on-node task, we report it via the legacy QUnit.testDone()
  and QUnit.done() which didn't pay attention to this half-known
  test.

- And we don't currently run this test via the QUnit CLI
  (if we did, it would be failing)

Fixes https://github.com/qunitjs/qunit/issues/1514