### PR TITLE
feat: better logging for assertions after a test

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -450,7 +450,10 @@ Test.prototype = {
 
 	pushResult: function( resultInfo ) {
 		if ( this !== config.current ) {
-			throw new Error( "Assertion occurred after test had finished." );
+			const message = resultInfo && resultInfo.message || '';
+			const testName = this && this.testName || '';
+
+			throw new Error( "Assertion '" + message + "' occurred after test '" + testName + "' had finished." );
 		}
 
 		// Destructure of resultInfo = { result, actual, expected, message, negative }

--- a/src/test.js
+++ b/src/test.js
@@ -450,10 +450,12 @@ Test.prototype = {
 
 	pushResult: function( resultInfo ) {
 		if ( this !== config.current ) {
-			const message = resultInfo && resultInfo.message || '';
-			const testName = this && this.testName || '';
+			var message = resultInfo && resultInfo.message || "";
+			var testName = this && this.testName || "";
+			var error = "Assertion " + message +
+				" occurred after test " + testName + " had finished.";
 
-			throw new Error( "Assertion '" + message + "' occurred after test '" + testName + "' had finished." );
+			throw new Error( error );
 		}
 
 		// Destructure of resultInfo = { result, actual, expected, message, negative }

--- a/src/test.js
+++ b/src/test.js
@@ -452,8 +452,9 @@ Test.prototype = {
 		if ( this !== config.current ) {
 			var message = resultInfo && resultInfo.message || "";
 			var testName = this && this.testName || "";
-			var error = "Assertion " + message +
-				" occurred after test " + testName + " had finished.";
+			var error = "Assertion occurred after test finished.\n" +
+			"> Test: " + testName + "\n" +
+			"> Message: " + message + "\n";
 
 			throw new Error( error );
 		}

--- a/test/main/test.js
+++ b/test/main/test.js
@@ -234,10 +234,11 @@ QUnit.module( "test", function() {
 
 	( function() {
 		var previousTestAssert;
+		var firstTestName = "assertions after test finishes throws an error - part 1";
 
 		QUnit.module( "bad assertion context" );
 
-		QUnit.test( "assertions after test finishes throws an error - part 1", function( assert ) {
+		QUnit.test( firstTestName, function( assert ) {
 			assert.expect( 0 );
 			previousTestAssert = assert;
 		} );
@@ -245,8 +246,11 @@ QUnit.module( "test", function() {
 		QUnit.test( "assertions after test finishes throws an error - part 2", function( assert ) {
 			assert.expect( 1 );
 			assert.throws( function() {
-				previousTestAssert.ok( true );
-			}, /Assertion occurred after test had finished/ );
+				previousTestAssert.ok( true, "message here" );
+			}, "Assertion occurred after test had finished.\n" +
+			"> Test: " + firstTestName + "\n" +
+			"> Assertion: message here\n"
+			);
 		} );
 	}() );
 

--- a/test/main/test.js
+++ b/test/main/test.js
@@ -244,13 +244,14 @@ QUnit.module( "test", function() {
 		} );
 
 		QUnit.test( "assertions after test finishes throws an error - part 2", function( assert ) {
+			var error = "Assertion occurred after test finished.\n" +
+			"> Test: " + firstTestName + "\n" +
+			"> Message: message here\n";
+
 			assert.expect( 1 );
 			assert.throws( function() {
 				previousTestAssert.ok( true, "message here" );
-			}, "Assertion occurred after test had finished.\n" +
-			"> Test: " + firstTestName + "\n" +
-			"> Assertion: message here\n"
-			);
+			}, new Error( error ), "correct error thrown" );
 		} );
 	}() );
 


### PR DESCRIPTION
Was running into assertions happening after tests for one of our unit tests and locally made this change. It seems useful to know what test and what assertion are running after the test are supposed to have completed so I think that It would be nice to have this change in qunit.