### PR TITLE
Dump: Add copy of jsDump license header

### DIFF
--- a/src/dump.js
+++ b/src/dump.js
@@ -1,8 +1,36 @@
+// QUnit.dump is based on jsDump 1.0.0 by Ariel Flesler
+// From <https://flesler.blogspot.com/2008/05/jsdump-pretty-dump-of-any-javascript.html>
+// Licensed under BSD <https://opensource.org/licenses/BSD-2-Clause>
+//
+// -------
+// Copyright 2008 Ariel Flesler - aflesler(at)gmail(dot)com
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// -------
+
 import config from "./core/config";
 import { inArray, toString, is } from "./core/utilities";
 
-// Based on jsDump by Ariel Flesler
-// https://flesler.blogspot.com/2008/05/jsdump-pretty-dump-of-any-javascript.html
 export default ( function() {
 	function quote( str ) {
 		return "\"" + str.toString().replace( /\\/g, "\\\\" ).replace( /"/g, "\\\"" ) + "\"";


### PR DESCRIPTION
Follows-up a5c3b3075efbd0, in which part of this was accidentally removed from the source. This commit now restores it, resolves the canonical opensource.org URL, and includes a formatted copy of the license itself.

Fixes https://github.com/qunitjs/qunit/issues/1518.