### PR TITLE
Build: Upgrade `tiny-glob` to 0.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qunit",
-  "version": "2.12.0-pre",
+  "version": "2.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3107,9 +3107,9 @@
       }
     },
     "globalyzer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.4.tgz",
-      "integrity": "sha512-LeguVWaxgHN0MNbWC6YljNMzHkrCny9fzjmEUdnF1kQ7wATFD1RHFRqA1qxaX2tgxGENlcxjOflopBwj3YZiXA=="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
     },
     "globrex": {
       "version": "0.1.2",
@@ -5399,12 +5399,12 @@
       "dev": true
     },
     "tiny-glob": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.6.tgz",
-      "integrity": "sha512-A7ewMqPu1B5PWwC3m7KVgAu96Ch5LA0w4SnEN/LbDREj/gAD0nPWboRbn8YoP9ISZXqeNAlMvKSKoEuhcfK3Pw==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.8.tgz",
+      "integrity": "sha512-vkQP7qOslq63XRX9kMswlby99kyO5OvKptw7AMwBVMjXEI7Tb61eoI5DydyEMOseyGS5anDN1VPoVxEvH01q8w==",
       "requires": {
-        "globalyzer": "^0.1.0",
-        "globrex": "^0.1.1"
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
       }
     },
     "tiny-lr": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "commander": "6.2.0",
     "js-reporters": "1.2.3",
     "node-watch": "0.7.0",
-    "tiny-glob": "0.2.6"
+    "tiny-glob": "0.2.8"
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",


### PR DESCRIPTION
Ref https://github.com/qunitjs/qunit/issues/1522.

> ### Verify publication: tiny-glob 0.2.6 -> 0.2.8
> 
> ```
> $ npm info tiny-glob@0.2.8
> 
> dependencies:
> - globalyzer: 0.1.0
> - globrex: ^0.1.2  
> 
> maintainers:
> - terkelg <terkel@terkel.com>
> 
> published a week ago by terkelg <terkel@terkel.com>
> ```
> 
> ✅ It was published by the same account as previously.
> ✅ No new maintainers were added.
> ✅ No new dependencies were added.
> ⚠️ Some dependency versions changed:
> 
> ```diff
> -        "globalyzer": "^0.1.0" -> 0.1.4
> +        "globalyzer": "0.1.0" -> 0.1.0
> -        "globrex": "^0.1.1" -> 0.1.1
> +        "globrex": "^0.1.2" -> 0.1.2
> ```
> 
> ### Verify publication: globalyzer 0.1.4 -> 0.1.0 (downgrade)
> 
> ```
> $ npm info globalyzer@0.1.0
> 
> globalyzer@0.1.0
> 
> maintainers:
> - terkelg <terkel@terkel.com>
> 
> published over a year ago by terkelg <terkel@terkel.com>
> ```
> 
> ✅ It was published by the same account as previously.
> ✅ No new maintainers were added.
> ✅ No new dependencies were added.
> ✅ No dependency versions changed.
> ### Verify publication: globrex 0.1.1 -> 0.1.2
> 
> ```
> globrex@0.1.2 
> 
> maintainers:
> - terkelg <terkel@terkel.com>
> 
> published a year ago by terkelg <terkel@terkel.com>
> ```
> 
> ✅ It was published by the same account as previously.
> ✅ No new maintainers were added.
> ✅ No new dependencies were added.
> ✅ No dependency versions changed.
> ### Review package diff: globalyzer 0.1.4 -> 0.1.0 (downgrade)
> 
> https://diff.intrinsic.com/globalyzer/0.1.0/0.1.4 (inverse!)
> 
>     * Effectively reverts away use of `path.normalize()`, and going back to using `os.platform()`. Upstream mentions that this change caused an issue in their tests, although we didn't run into it, and thus reverts for now. Ref [terkelg/tiny-glob@7e61029](https://github.com/terkelg/tiny-glob/commit/7e61029d4e3441c366ed21bca5495c89f6846d81)
> 
> 
> LGTM.
> ### Review package diff: globrex 0.1.1 -> 0.1.2
> 
> https://diff.intrinsic.com/globrex/0.1.1/0.1.2
> 
>     * No code was added or changed.
> 
> 
> ### Review package diff: tiny-glob 0.2.6 -> 0.2.8
> 
> https://diff.intrinsic.com/tiny-glob/0.2.6/0.2.8
> 
>     * Minor style changes.
> 
>     * Added TypeScript declaration file.
> 
>     * Changes to internal logic.
> 
> 
> LGTM.

