### PR TITLE
Core: convert var to let/const in src

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -28,8 +28,8 @@ export const globalSuite = new SuiteReport();
 // it since each module has a suiteReport associated with it.
 config.currentModule.suiteReport = globalSuite;
 
-var globalStartCalled = false;
-var runStarted = false;
+let globalStartCalled = false;
+let runStarted = false;
 
 // Figure out if we're running the tests from a server or not
 QUnit.isLocal = ( window && window.location && window.location.protocol === "file:" );
@@ -64,7 +64,7 @@ extend( QUnit, {
 			throw new Error( "QUnit.start cannot be called inside a test context." );
 		}
 
-		var globalStartAlreadyCalled = globalStartCalled;
+		const globalStartAlreadyCalled = globalStartCalled;
 		globalStartCalled = true;
 
 		if ( runStarted ) {

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -62,7 +62,7 @@ const config = {
 };
 
 // take a predefined QUnit.config and extend the defaults
-var globalConfig = window && window.QUnit && window.QUnit.config;
+const globalConfig = window && window.QUnit && window.QUnit.config;
 
 // only extend the global config if there is no QUnit overload
 if ( window && window.QUnit && !window.QUnit.version ) {

--- a/src/core/logging.js
+++ b/src/core/logging.js
@@ -4,12 +4,11 @@ import Promise from "../promise";
 
 // Register logging callbacks
 export function registerLoggingCallbacks( obj ) {
-	var i, l, key,
-		callbackNames = [ "begin", "done", "log", "testStart", "testDone",
-			"moduleStart", "moduleDone" ];
+	const callbackNames = [ "begin", "done", "log", "testStart", "testDone",
+		"moduleStart", "moduleDone" ];
 
 	function registerLoggingCallback( key ) {
-		var loggingCallback = function( callback ) {
+		const loggingCallback = function( callback ) {
 			if ( objectType( callback ) !== "function" ) {
 				throw new Error(
 					"QUnit logging methods require a callback function as their first parameters."
@@ -22,8 +21,8 @@ export function registerLoggingCallbacks( obj ) {
 		return loggingCallback;
 	}
 
-	for ( i = 0, l = callbackNames.length; i < l; i++ ) {
-		key = callbackNames[ i ];
+	for ( let i = 0, l = callbackNames.length; i < l; i++ ) {
+		const key = callbackNames[ i ];
 
 		// Initialize key collection of logging callback
 		if ( objectType( config.callbacks[ key ] ) === "undefined" ) {
@@ -35,7 +34,7 @@ export function registerLoggingCallbacks( obj ) {
 }
 
 export function runLoggingCallbacks( key, args ) {
-	var callbacks = config.callbacks[ key ];
+	const callbacks = config.callbacks[ key ];
 
 	// Handling 'log' callbacks separately. Unlike the other callbacks,
 	// the log callback is not controlled by the processing queue,

--- a/src/core/stacktrace.js
+++ b/src/core/stacktrace.js
@@ -1,22 +1,20 @@
 // Doesn't support IE9, it will return undefined on these browsers
 // See also https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error/Stack
-var fileName = ( sourceFromStacktrace( 0 ) || "" )
+const fileName = ( sourceFromStacktrace( 0 ) || "" )
 	.replace( /(:\d+)+\)?/, "" )
 	.replace( /.+\//, "" );
 
 export function extractStacktrace( e, offset ) {
 	offset = offset === undefined ? 4 : offset;
 
-	var stack, include, i;
-
 	if ( e && e.stack ) {
-		stack = e.stack.split( "\n" );
+		const stack = e.stack.split( "\n" );
 		if ( /^error$/i.test( stack[ 0 ] ) ) {
 			stack.shift();
 		}
 		if ( fileName ) {
-			include = [];
-			for ( i = offset; i < stack.length; i++ ) {
+			const include = [];
+			for ( let i = offset; i < stack.length; i++ ) {
 				if ( stack[ i ].indexOf( fileName ) !== -1 ) {
 					break;
 				}
@@ -31,7 +29,7 @@ export function extractStacktrace( e, offset ) {
 }
 
 export function sourceFromStacktrace( offset ) {
-	var error = new Error();
+	let error = new Error();
 
 	// Support: Safari <=7 only, IE <=10 - 11 only
 	// Not all browsers generate the `stack` property for `new Error()`, see also #636

--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -40,11 +40,10 @@ export const performance = {
 
 // Returns a new Array with the elements that are in a but not in b
 export function diff( a, b ) {
-	var i, j,
-		result = a.slice();
+	const result = a.slice();
 
-	for ( i = 0; i < result.length; i++ ) {
-		for ( j = 0; j < b.length; j++ ) {
+	for ( let i = 0; i < result.length; i++ ) {
+		for ( let j = 0; j < b.length; j++ ) {
 			if ( result[ i ] === b[ j ] ) {
 				result.splice( i, 1 );
 				i--;
@@ -75,11 +74,10 @@ export function inArray( elem, array ) {
  * @return {Object} New object with only the own properties (recursively).
  */
 export function objectValues( obj ) {
-	var key, val,
-		vals = is( "array", obj ) ? [] : {};
-	for ( key in obj ) {
+	const vals = is( "array", obj ) ? [] : {};
+	for ( const key in obj ) {
 		if ( hasOwn.call( obj, key ) ) {
-			val = obj[ key ];
+			const val = obj[ key ];
 			vals[ key ] = val === Object( val ) ? objectValues( val ) : val;
 		}
 	}
@@ -87,7 +85,7 @@ export function objectValues( obj ) {
 }
 
 export function extend( a, b, undefOnly ) {
-	for ( var prop in b ) {
+	for ( const prop in b ) {
 		if ( hasOwn.call( b, prop ) ) {
 			if ( b[ prop ] === undefined ) {
 				delete a[ prop ];
@@ -110,8 +108,8 @@ export function objectType( obj ) {
 		return "null";
 	}
 
-	var match = toString.call( obj ).match( /^\[object\s(.*)\]$/ ),
-		type = match && match[ 1 ];
+	const match = toString.call( obj ).match( /^\[object\s(.*)\]$/ );
+	const type = match && match[ 1 ];
 
 	switch ( type ) {
 	case "Number":

--- a/src/dump.js
+++ b/src/dump.js
@@ -39,26 +39,27 @@ export default ( function() {
 		return o + "";
 	}
 	function join( pre, arr, post ) {
-		var s = dump.separator(),
-			base = dump.indent(),
-			inner = dump.indent( 1 );
+		const s = dump.separator();
+		const inner = dump.indent( 1 );
 		if ( arr.join ) {
 			arr = arr.join( "," + s + inner );
 		}
 		if ( !arr ) {
 			return pre + post;
 		}
+		const base = dump.indent();
 		return [ pre, inner + arr, base + post ].join( s );
 	}
 	function array( arr, stack ) {
-		var i = arr.length,
-			ret = new Array( i );
 
 		if ( dump.maxDepth && dump.depth > dump.maxDepth ) {
 			return "[object Array]";
 		}
 
 		this.up();
+
+		let i = arr.length;
+		const ret = new Array( i );
 		while ( i-- ) {
 			ret[ i ] = this.parse( arr[ i ], undefined, stack );
 		}
@@ -81,233 +82,229 @@ export default ( function() {
 		);
 	}
 
-	var reName = /^function (\w+)/,
-		dump = {
+	const reName = /^function (\w+)/;
+	const dump = {
 
-			// The objType is used mostly internally, you can fix a (custom) type in advance
-			parse: function( obj, objType, stack ) {
-				stack = stack || [];
-				var res, parser, parserType,
-					objIndex = stack.indexOf( obj );
+		// The objType is used mostly internally, you can fix a (custom) type in advance
+		parse: function( obj, objType, stack ) {
+			stack = stack || [];
+			const objIndex = stack.indexOf( obj );
 
-				if ( objIndex !== -1 ) {
-					return `recursion(${objIndex - stack.length})`;
+			if ( objIndex !== -1 ) {
+				return `recursion(${objIndex - stack.length})`;
+			}
+
+			objType = objType || this.typeOf( obj );
+			const parser = this.parsers[ objType ];
+			const parserType = typeof parser;
+
+			if ( parserType === "function" ) {
+				stack.push( obj );
+				const res = parser.call( this, obj, stack );
+				stack.pop();
+				return res;
+			}
+			return ( parserType === "string" ) ? parser : this.parsers.error;
+		},
+		typeOf: function( obj ) {
+			let type;
+
+			if ( obj === null ) {
+				type = "null";
+			} else if ( typeof obj === "undefined" ) {
+				type = "undefined";
+			} else if ( is( "regexp", obj ) ) {
+				type = "regexp";
+			} else if ( is( "date", obj ) ) {
+				type = "date";
+			} else if ( is( "function", obj ) ) {
+				type = "function";
+			} else if ( obj.setInterval !== undefined &&
+					obj.document !== undefined &&
+					obj.nodeType === undefined ) {
+				type = "window";
+			} else if ( obj.nodeType === 9 ) {
+				type = "document";
+			} else if ( obj.nodeType ) {
+				type = "node";
+			} else if ( isArray( obj ) ) {
+				type = "array";
+			} else if ( obj.constructor === Error.prototype.constructor ) {
+				type = "error";
+			} else {
+				type = typeof obj;
+			}
+			return type;
+		},
+
+		separator: function() {
+			if ( this.multiline ) {
+				return this.HTML ? "<br />" : "\n";
+			} else {
+				return this.HTML ? "&#160;" : " ";
+			}
+		},
+
+		// Extra can be a number, shortcut for increasing-calling-decreasing
+		indent: function( extra ) {
+			if ( !this.multiline ) {
+				return "";
+			}
+			let chr = this.indentChar;
+			if ( this.HTML ) {
+				chr = chr.replace( /\t/g, "   " ).replace( / /g, "&#160;" );
+			}
+			return new Array( this.depth + ( extra || 0 ) ).join( chr );
+		},
+		up: function( a ) {
+			this.depth += a || 1;
+		},
+		down: function( a ) {
+			this.depth -= a || 1;
+		},
+		setParser: function( name, parser ) {
+			this.parsers[ name ] = parser;
+		},
+
+		// The next 3 are exposed so you can use them
+		quote: quote,
+		literal: literal,
+		join: join,
+		depth: 1,
+		maxDepth: config.maxDepth,
+
+		// This is the list of parsers, to modify them, use dump.setParser
+		parsers: {
+			window: "[Window]",
+			document: "[Document]",
+			error: function( error ) {
+				return "Error(\"" + error.message + "\")";
+			},
+			unknown: "[Unknown]",
+			"null": "null",
+			"undefined": "undefined",
+			"function": function( fn ) {
+				let ret = "function";
+
+				// Functions never have name in IE
+				const name = "name" in fn ? fn.name : ( reName.exec( fn ) || [] )[ 1 ];
+
+				if ( name ) {
+					ret += " " + name;
+				}
+				ret += "(";
+
+				ret = [ ret, dump.parse( fn, "functionArgs" ), "){" ].join( "" );
+				return join( ret, dump.parse( fn, "functionCode" ), "}" );
+			},
+			array: array,
+			nodelist: array,
+			"arguments": array,
+			object: function( map, stack ) {
+				const ret = [];
+
+				if ( dump.maxDepth && dump.depth > dump.maxDepth ) {
+					return "[object Object]";
 				}
 
-				objType = objType || this.typeOf( obj );
-				parser = this.parsers[ objType ];
-				parserType = typeof parser;
-
-				if ( parserType === "function" ) {
-					stack.push( obj );
-					res = parser.call( this, obj, stack );
-					stack.pop();
-					return res;
+				dump.up();
+				const keys = [];
+				for ( const key in map ) {
+					keys.push( key );
 				}
-				return ( parserType === "string" ) ? parser : this.parsers.error;
-			},
-			typeOf: function( obj ) {
-				var type;
 
-				if ( obj === null ) {
-					type = "null";
-				} else if ( typeof obj === "undefined" ) {
-					type = "undefined";
-				} else if ( is( "regexp", obj ) ) {
-					type = "regexp";
-				} else if ( is( "date", obj ) ) {
-					type = "date";
-				} else if ( is( "function", obj ) ) {
-					type = "function";
-				} else if ( obj.setInterval !== undefined &&
-						obj.document !== undefined &&
-						obj.nodeType === undefined ) {
-					type = "window";
-				} else if ( obj.nodeType === 9 ) {
-					type = "document";
-				} else if ( obj.nodeType ) {
-					type = "node";
-				} else if ( isArray( obj ) ) {
-					type = "array";
-				} else if ( obj.constructor === Error.prototype.constructor ) {
-					type = "error";
-				} else {
-					type = typeof obj;
-				}
-				return type;
-			},
-
-			separator: function() {
-				if ( this.multiline ) {
-					return this.HTML ? "<br />" : "\n";
-				} else {
-					return this.HTML ? "&#160;" : " ";
-				}
-			},
-
-			// Extra can be a number, shortcut for increasing-calling-decreasing
-			indent: function( extra ) {
-				if ( !this.multiline ) {
-					return "";
-				}
-				var chr = this.indentChar;
-				if ( this.HTML ) {
-					chr = chr.replace( /\t/g, "   " ).replace( / /g, "&#160;" );
-				}
-				return new Array( this.depth + ( extra || 0 ) ).join( chr );
-			},
-			up: function( a ) {
-				this.depth += a || 1;
-			},
-			down: function( a ) {
-				this.depth -= a || 1;
-			},
-			setParser: function( name, parser ) {
-				this.parsers[ name ] = parser;
-			},
-
-			// The next 3 are exposed so you can use them
-			quote: quote,
-			literal: literal,
-			join: join,
-			depth: 1,
-			maxDepth: config.maxDepth,
-
-			// This is the list of parsers, to modify them, use dump.setParser
-			parsers: {
-				window: "[Window]",
-				document: "[Document]",
-				error: function( error ) {
-					return "Error(\"" + error.message + "\")";
-				},
-				unknown: "[Unknown]",
-				"null": "null",
-				"undefined": "undefined",
-				"function": function( fn ) {
-					var ret = "function",
-
-						// Functions never have name in IE
-						name = "name" in fn ? fn.name : ( reName.exec( fn ) || [] )[ 1 ];
-
-					if ( name ) {
-						ret += " " + name;
-					}
-					ret += "(";
-
-					ret = [ ret, dump.parse( fn, "functionArgs" ), "){" ].join( "" );
-					return join( ret, dump.parse( fn, "functionCode" ), "}" );
-				},
-				array: array,
-				nodelist: array,
-				"arguments": array,
-				object: function( map, stack ) {
-					var keys, key, val, i, nonEnumerableProperties,
-						ret = [];
-
-					if ( dump.maxDepth && dump.depth > dump.maxDepth ) {
-						return "[object Object]";
-					}
-
-					dump.up();
-					keys = [];
-					for ( key in map ) {
+				// Some properties are not always enumerable on Error objects.
+				const nonEnumerableProperties = [ "message", "name" ];
+				for ( const i in nonEnumerableProperties ) {
+					const key = nonEnumerableProperties[ i ];
+					if ( key in map && !inArray( key, keys ) ) {
 						keys.push( key );
 					}
-
-					// Some properties are not always enumerable on Error objects.
-					nonEnumerableProperties = [ "message", "name" ];
-					for ( i in nonEnumerableProperties ) {
-						key = nonEnumerableProperties[ i ];
-						if ( key in map && !inArray( key, keys ) ) {
-							keys.push( key );
-						}
-					}
-					keys.sort();
-					for ( i = 0; i < keys.length; i++ ) {
-						key = keys[ i ];
-						val = map[ key ];
-						ret.push( dump.parse( key, "key" ) + ": " +
-							dump.parse( val, undefined, stack ) );
-					}
-					dump.down();
-					return join( "{", ret, "}" );
-				},
-				node: function( node ) {
-					var len, i, val,
-						open = dump.HTML ? "&lt;" : "<",
-						close = dump.HTML ? "&gt;" : ">",
-						tag = node.nodeName.toLowerCase(),
-						ret = open + tag,
-						attrs = node.attributes;
-
-					if ( attrs ) {
-						for ( i = 0, len = attrs.length; i < len; i++ ) {
-							val = attrs[ i ].nodeValue;
-
-							// IE6 includes all attributes in .attributes, even ones not explicitly
-							// set. Those have values like undefined, null, 0, false, "" or
-							// "inherit".
-							if ( val && val !== "inherit" ) {
-								ret += " " + attrs[ i ].nodeName + "=" +
-									dump.parse( val, "attribute" );
-							}
-						}
-					}
-					ret += close;
-
-					// Show content of TextNode or CDATASection
-					if ( node.nodeType === 3 || node.nodeType === 4 ) {
-						ret += node.nodeValue;
-					}
-
-					return ret + open + "/" + tag + close;
-				},
-
-				// Function calls it internally, it's the arguments part of the function
-				functionArgs: function( fn ) {
-					var args,
-						l = fn.length;
-
-					if ( !l ) {
-						return "";
-					}
-
-					args = new Array( l );
-					while ( l-- ) {
-
-						// 97 is 'a'
-						args[ l ] = String.fromCharCode( 97 + l );
-					}
-					return " " + args.join( ", " ) + " ";
-				},
-
-				// Object calls it internally, the key part of an item in a map
-				key: quote,
-
-				// Function calls it internally, it's the content of the function
-				functionCode: "[code]",
-
-				// Node calls it internally, it's a html attribute value
-				attribute: quote,
-				string: quote,
-				date: quote,
-				regexp: literal,
-				number: literal,
-				"boolean": literal,
-				symbol: function( sym ) {
-					return sym.toString();
 				}
+				keys.sort();
+				for ( let i = 0; i < keys.length; i++ ) {
+					const key = keys[ i ];
+					const val = map[ key ];
+					ret.push( dump.parse( key, "key" ) + ": " +
+						dump.parse( val, undefined, stack ) );
+				}
+				dump.down();
+				return join( "{", ret, "}" );
+			},
+			node: function( node ) {
+				const open = dump.HTML ? "&lt;" : "<";
+				const close = dump.HTML ? "&gt;" : ">";
+				const tag = node.nodeName.toLowerCase();
+				let ret = open + tag;
+				const attrs = node.attributes;
+
+				if ( attrs ) {
+					for ( let i = 0, len = attrs.length; i < len; i++ ) {
+						const val = attrs[ i ].nodeValue;
+
+						// IE6 includes all attributes in .attributes, even ones not explicitly
+						// set. Those have values like undefined, null, 0, false, "" or
+						// "inherit".
+						if ( val && val !== "inherit" ) {
+							ret += " " + attrs[ i ].nodeName + "=" +
+								dump.parse( val, "attribute" );
+						}
+					}
+				}
+				ret += close;
+
+				// Show content of TextNode or CDATASection
+				if ( node.nodeType === 3 || node.nodeType === 4 ) {
+					ret += node.nodeValue;
+				}
+
+				return ret + open + "/" + tag + close;
 			},
 
-			// If true, entities are escaped ( <, >, \t, space and \n )
-			HTML: false,
+			// Function calls it internally, it's the arguments part of the function
+			functionArgs: function( fn ) {
+				let l = fn.length;
 
-			// Indentation unit
-			indentChar: "  ",
+				if ( !l ) {
+					return "";
+				}
 
-			// If true, items in a collection, are separated by a \n, else just a space.
-			multiline: true
-		};
+				const args = new Array( l );
+				while ( l-- ) {
+
+					// 97 is 'a'
+					args[ l ] = String.fromCharCode( 97 + l );
+				}
+				return " " + args.join( ", " ) + " ";
+			},
+
+			// Object calls it internally, the key part of an item in a map
+			key: quote,
+
+			// Function calls it internally, it's the content of the function
+			functionCode: "[code]",
+
+			// Node calls it internally, it's a html attribute value
+			attribute: quote,
+			string: quote,
+			date: quote,
+			regexp: literal,
+			number: literal,
+			"boolean": literal,
+			symbol: function( sym ) {
+				return sym.toString();
+			}
+		},
+
+		// If true, entities are escaped ( <, >, \t, space and \n )
+		HTML: false,
+
+		// Indentation unit
+		indentChar: "  ",
+
+		// If true, items in a collection, are separated by a \n, else just a space.
+		multiline: true
+	};
 
 	return dump;
 } )();

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -7,9 +7,9 @@ export default ( function() {
 	// Value pairs queued for comparison. Used for breadth-first processing order, recursion
 	// detection and avoiding repeated comparison (see below for details).
 	// Elements are { a: val, b: val }.
-	var pairs = [];
+	let pairs = [];
 
-	var getProto = Object.getPrototypeOf || function( obj ) {
+	const getProto = Object.getPrototypeOf || function( obj ) {
 		return obj.__proto__;
 	};
 
@@ -31,8 +31,8 @@ export default ( function() {
 	}
 
 	function compareConstructors( a, b ) {
-		var protoA = getProto( a );
-		var protoB = getProto( b );
+		let protoA = getProto( a );
+		let protoB = getProto( b );
 
 		// Comparing constructors is more strict than using `instanceof`
 		if ( a.constructor === b.constructor ) {
@@ -88,7 +88,7 @@ export default ( function() {
 		return true;
 	}
 
-	var callbacks = {
+	const callbacks = {
 		"string": useStrictEquality,
 		"boolean": useStrictEquality,
 		"number": useStrictEquality,
@@ -114,9 +114,8 @@ export default ( function() {
 		},
 
 		"array": function( a, b ) {
-			var i, len;
 
-			len = a.length;
+			const len = a.length;
 			if ( len !== b.length ) {
 
 				// Safe and faster
@@ -124,7 +123,7 @@ export default ( function() {
 			}
 
 
-			for ( i = 0; i < len; i++ ) {
+			for ( let i = 0; i < len; i++ ) {
 
 				// Compare non-containers; queue non-reference-equal containers
 				if ( !breadthFirstCompareChild( a[ i ], b[ i ] ) ) {
@@ -140,8 +139,6 @@ export default ( function() {
 		// a = new Set( [ {}, [], [] ] );
 		// b = new Set( [ {}, {}, [] ] );
 		"set": function( a, b ) {
-			var innerEq,
-				outerEq = true;
 
 			if ( a.size !== b.size ) {
 
@@ -151,6 +148,8 @@ export default ( function() {
 				// make them non-equivalent.
 				return false;
 			}
+
+			let outerEq = true;
 
 			a.forEach( function( aVal ) {
 
@@ -162,10 +161,9 @@ export default ( function() {
 					return;
 				}
 
-				innerEq = false;
+				let innerEq = false;
 
 				b.forEach( function( bVal ) {
-					var parentPairs;
 
 					// Likewise, short-circuit if the result is already known
 					if ( innerEq ) {
@@ -174,7 +172,7 @@ export default ( function() {
 
 					// Swap out the global pairs list, as the nested call to
 					// innerEquiv will clobber its contents
-					parentPairs = pairs;
+					const parentPairs = pairs;
 					if ( innerEquiv( bVal, aVal ) ) {
 						innerEq = true;
 					}
@@ -198,8 +196,6 @@ export default ( function() {
 		// a = new Map( [ [ {}, 1 ], [ {}, 1 ], [ [], 1 ] ] );
 		// b = new Map( [ [ {}, 1 ], [ [], 1 ], [ [], 1 ] ] );
 		"map": function( a, b ) {
-			var innerEq,
-				outerEq = true;
 
 			if ( a.size !== b.size ) {
 
@@ -209,6 +205,8 @@ export default ( function() {
 				// can make them non-equivalent.
 				return false;
 			}
+
+			let outerEq = true;
 
 			a.forEach( function( aVal, aKey ) {
 
@@ -220,10 +218,9 @@ export default ( function() {
 					return;
 				}
 
-				innerEq = false;
+				let innerEq = false;
 
 				b.forEach( function( bVal, bKey ) {
-					var parentPairs;
 
 					// Likewise, short-circuit if the result is already known
 					if ( innerEq ) {
@@ -232,7 +229,7 @@ export default ( function() {
 
 					// Swap out the global pairs list, as the nested call to
 					// innerEquiv will clobber its contents
-					parentPairs = pairs;
+					const parentPairs = pairs;
 					if ( innerEquiv( [ bVal, bKey ], [ aVal, aKey ] ) ) {
 						innerEq = true;
 					}
@@ -250,16 +247,16 @@ export default ( function() {
 		},
 
 		"object": function( a, b ) {
-			var i,
-				aProperties = [],
-				bProperties = [];
 
 			if ( compareConstructors( a, b ) === false ) {
 				return false;
 			}
 
+			const aProperties = [];
+			const bProperties = [];
+
 			// Be strict: don't ensure hasOwnProperty and go deep
-			for ( i in a ) {
+			for ( const i in a ) {
 
 				// Collect a's properties
 				aProperties.push( i );
@@ -281,7 +278,7 @@ export default ( function() {
 				}
 			}
 
-			for ( i in b ) {
+			for ( const i in b ) {
 
 				// Collect b's properties
 				bProperties.push( i );
@@ -293,7 +290,7 @@ export default ( function() {
 	};
 
 	function typeEquiv( a, b ) {
-		var type = objectType( a );
+		const type = objectType( a );
 
 		// Callbacks for containers will append to the pairs queue to achieve breadth-first
 		// search order. The pairs queue is also used to avoid reprocessing any pair of
@@ -307,7 +304,6 @@ export default ( function() {
 	}
 
 	function innerEquiv( a, b ) {
-		var i, pair;
 
 		// We're done when there's nothing more to compare
 		if ( arguments.length < 2 ) {
@@ -317,8 +313,8 @@ export default ( function() {
 		// Clear the global pair queue and add the top-level values being compared
 		pairs = [ { a: a, b: b } ];
 
-		for ( i = 0; i < pairs.length; i++ ) {
-			pair = pairs[ i ];
+		for ( let i = 0; i < pairs.length; i++ ) {
+			const pair = pairs[ i ];
 
 			// Perform type-specific comparison on any pairs that are not strictly
 			// equal. For container types, that comparison will postpone comparison

--- a/src/globals.js
+++ b/src/globals.js
@@ -10,7 +10,7 @@ export const document = window && window.document;
 export const navigator = window && window.navigator;
 
 export const localSessionStorage = ( function() {
-	var x = "qunit-test-string";
+	const x = "qunit-test-string";
 	try {
 		global.sessionStorage.setItem( x, x );
 		global.sessionStorage.removeItem( x );

--- a/src/test.js
+++ b/src/test.js
@@ -96,8 +96,8 @@ export default function Test( settings ) {
 Test.count = 0;
 
 function getNotStartedModules( startModule ) {
-	var module = startModule,
-		modules = [];
+	let module = startModule;
+	const modules = [];
 
 	while ( module && module.testsRun === 0 ) {
 		modules.push( module );
@@ -117,11 +117,11 @@ Test.prototype = {
 	},
 
 	before: function() {
-		var module = this.module,
-			notStartedModules = getNotStartedModules( module );
+		const module = this.module;
+		const notStartedModules = getNotStartedModules( module );
 
 		// ensure the callbacks are executed serially for each module
-		var callbackPromises = notStartedModules.reduce( ( promiseChain, startModule ) => {
+		const callbackPromises = notStartedModules.reduce( ( promiseChain, startModule ) => {
 			return promiseChain.then( () => {
 				startModule.stats = { all: 0, bad: 0, started: now() };
 				emit( "suiteStart", startModule.suiteReport.start( true ) );
@@ -153,7 +153,6 @@ Test.prototype = {
 	},
 
 	run: function() {
-		var promise;
 
 		config.current = this;
 
@@ -180,7 +179,7 @@ Test.prototype = {
 		}
 
 		function runTest( test ) {
-			promise = test.callback.call( test.testEnvironment, test.assert );
+			const promise = test.callback.call( test.testEnvironment, test.assert );
 			test.resolvePromise( promise );
 
 			// If the test has a "lock" on it, but the timeout is 0, then we push a
@@ -285,14 +284,13 @@ Test.prototype = {
 				"expect(0) to accept zero assertions.", this.stack );
 		}
 
-		var i,
-			module = this.module,
-			moduleName = module.name,
-			testName = this.testName,
-			skipped = !!this.skip,
-			todo = !!this.todo,
-			bad = 0,
-			storage = config.storage;
+		const module = this.module;
+		const moduleName = module.name;
+		const testName = this.testName;
+		const skipped = !!this.skip;
+		const todo = !!this.todo;
+		let bad = 0;
+		const storage = config.storage;
 
 		this.runtime = now() - this.started;
 
@@ -300,7 +298,7 @@ Test.prototype = {
 		config.stats.testCount += 1;
 		module.stats.all += this.assertions.length;
 
-		for ( i = 0; i < this.assertions.length; i++ ) {
+		for ( let i = 0; i < this.assertions.length; i++ ) {
 			if ( !this.assertions[ i ].result ) {
 				bad++;
 				config.stats.bad++;
@@ -450,9 +448,9 @@ Test.prototype = {
 
 	pushResult: function( resultInfo ) {
 		if ( this !== config.current ) {
-			var message = resultInfo && resultInfo.message || "";
-			var testName = this && this.testName || "";
-			var error = "Assertion occurred after test finished.\n" +
+			const message = resultInfo && resultInfo.message || "";
+			const testName = this && this.testName || "";
+			const error = "Assertion occurred after test finished.\n" +
 				"> Test: " + testName + "\n" +
 				"> Message: " + message + "\n";
 
@@ -460,25 +458,24 @@ Test.prototype = {
 		}
 
 		// Destructure of resultInfo = { result, actual, expected, message, negative }
-		var source,
-			details = {
-				module: this.module.name,
-				name: this.testName,
-				result: resultInfo.result,
-				message: resultInfo.message,
-				actual: resultInfo.actual,
-				testId: this.testId,
-				negative: resultInfo.negative || false,
-				runtime: now() - this.started,
-				todo: !!this.todo
-			};
+		const details = {
+			module: this.module.name,
+			name: this.testName,
+			result: resultInfo.result,
+			message: resultInfo.message,
+			actual: resultInfo.actual,
+			testId: this.testId,
+			negative: resultInfo.negative || false,
+			runtime: now() - this.started,
+			todo: !!this.todo
+		};
 
 		if ( hasOwn.call( resultInfo, "expected" ) ) {
 			details.expected = resultInfo.expected;
 		}
 
 		if ( !resultInfo.result ) {
-			source = resultInfo.source || sourceFromStacktrace();
+			const source = resultInfo.source || sourceFromStacktrace();
 
 			if ( source ) {
 				details.source = source;
@@ -529,12 +526,11 @@ Test.prototype = {
 	},
 
 	resolvePromise: function( promise, phase ) {
-		var then, resume, message,
-			test = this;
 		if ( promise != null ) {
-			then = promise.then;
+			const test = this;
+			const then = promise.then;
 			if ( objectType( then ) === "function" ) {
-				resume = internalStop( test );
+				const resume = internalStop( test );
 				if ( config.notrycatch ) {
 					then.call( promise, function() { resume(); } );
 				} else {
@@ -542,7 +538,7 @@ Test.prototype = {
 						promise,
 						function() { resume(); },
 						function( error ) {
-							message = "Promise rejected " +
+							const message = "Promise rejected " +
 								( !phase ? "during" : phase.replace( /Each$/, "" ) ) +
 								" \"" + test.testName + "\": " +
 								( ( error && error.message ) || error );
@@ -561,13 +557,13 @@ Test.prototype = {
 	},
 
 	valid: function() {
-		var filter = config.filter,
-			regexFilter = /^(!?)\/([\w\W]*)\/(i?$)/.exec( filter ),
-			module = config.module && config.module.toLowerCase(),
-			fullName = ( this.module.name + ": " + this.testName );
+		const filter = config.filter;
+		const regexFilter = /^(!?)\/([\w\W]*)\/(i?$)/.exec( filter );
+		const module = config.module && config.module.toLowerCase();
+		const fullName = ( this.module.name + ": " + this.testName );
 
 		function moduleChainNameMatch( testModule ) {
-			var testModuleName = testModule.name ? testModule.name.toLowerCase() : null;
+			const testModuleName = testModule.name ? testModule.name.toLowerCase() : null;
 			if ( testModuleName === module ) {
 				return true;
 			} else if ( testModule.parentModule ) {
@@ -613,8 +609,8 @@ Test.prototype = {
 	},
 
 	regexFilter: function( exclude, pattern, flags, fullName ) {
-		var regex = new RegExp( pattern, flags );
-		var match = regex.test( fullName );
+		const regex = new RegExp( pattern, flags );
+		const match = regex.test( fullName );
 
 		return match !== exclude;
 	},
@@ -623,7 +619,7 @@ Test.prototype = {
 		filter = filter.toLowerCase();
 		fullName = fullName.toLowerCase();
 
-		var include = filter.charAt( 0 ) !== "!";
+		const include = filter.charAt( 0 ) !== "!";
 		if ( !include ) {
 			filter = filter.slice( 1 );
 		}
@@ -645,7 +641,7 @@ export function pushFailure() {
 	}
 
 	// Gets current test obj
-	var currentTest = config.current;
+	const currentTest = config.current;
 
 	return currentTest.pushFailure.apply( currentTest, arguments );
 }
@@ -654,7 +650,7 @@ function saveGlobal() {
 	config.pollution = [];
 
 	if ( config.noglobals ) {
-		for ( var key in global ) {
+		for ( const key in global ) {
 			if ( hasOwn.call( global, key ) ) {
 
 				// In Opera sometimes DOM element ids show up here, ignore them
@@ -668,18 +664,16 @@ function saveGlobal() {
 }
 
 function checkPollution() {
-	var newGlobals,
-		deletedGlobals,
-		old = config.pollution;
+	const old = config.pollution;
 
 	saveGlobal();
 
-	newGlobals = diff( config.pollution, old );
+	const newGlobals = diff( config.pollution, old );
 	if ( newGlobals.length > 0 ) {
 		pushFailure( "Introduced global variable(s): " + newGlobals.join( ", " ) );
 	}
 
-	deletedGlobals = diff( old, config.pollution );
+	const deletedGlobals = diff( old, config.pollution );
 	if ( deletedGlobals.length > 0 ) {
 		pushFailure( "Deleted global variable(s): " + deletedGlobals.join( ", " ) );
 	}


### PR DESCRIPTION
A followup task triggered by https://github.com/qunitjs/qunit/pull/1528#discussion_r549472922
This targets the `src` directory, converting all `var` instances to either `let` or `const` as appropriate.

This endeavor also allowed me to scope a few variables more locally, and (at least on paper) improving performance by deferring work beyond early returns.

The largest churn by far was in `equiv.js`, where some indents were affected (try to diff ignoring whitespace). Otherwise the actual changes were similarly straightforward.