### PR TITLE
Docs: Add /category/assert/ legacy redirect

### DIFF
--- a/docs/assert/index.md
+++ b/docs/assert/index.md
@@ -6,5 +6,5 @@ categories:
   - topics
 redirect_from:
   - "/QUnit.assert/"
-	- "/category/assert/"
+  - "/category/assert/"
 ---

--- a/docs/assert/index.md
+++ b/docs/assert/index.md
@@ -6,4 +6,5 @@ categories:
   - topics
 redirect_from:
   - "/QUnit.assert/"
+	- "/category/assert/"
 ---


### PR DESCRIPTION
Found links in various tutorials and blogposts.
This was an implicit overview powered by the old WordPress site.

http://web.archive.org/web/20160309213934/https://api.qunitjs.com/category/assert/