### PR TITLE
Docs: Modernize and improve documentation examples

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.yml]
+[*.{yml,md}]
 indent_style = space
 indent_size = 2

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -4,4 +4,7 @@ ruby RUBY_VERSION
 # To upgrade, run `bundle update github-pages`.
 gem "github-pages", group: :jekyll_plugins
 
+# Temporary fix for https://github.com/github/pages-gem/issues/752
+gem "webrick", "~> 1.7"
+
 gem 'jekyll-algolia', "1.6.0", group: :jekyll_plugins

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -9,9 +9,9 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    algolia_html_extractor (2.6.2)
+    algolia_html_extractor (2.6.4)
       json (~> 2.0)
-      nokogiri (~> 1.10.4)
+      nokogiri (~> 1.10)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
@@ -223,15 +223,16 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.14.2)
+    minitest (5.14.3)
     multipart-post (2.1.1)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     octokit (4.20.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -239,6 +240,7 @@ GEM
       forwardable-extended (~> 2.6)
     progressbar (1.11.0)
     public_suffix (3.1.1)
+    racc (1.5.2)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -271,6 +273,7 @@ GEM
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     verbal_expressions (0.1.5)
+    webrick (1.7.0)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -279,9 +282,10 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll-algolia (= 1.6.0)
+  webrick (~> 1.7)
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 3.0.0p0
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docs/QUnit/start.md
+++ b/docs/QUnit/start.md
@@ -16,14 +16,15 @@ version_added: "1.0"
 
 When your async test has multiple exit points, call `QUnit.start()` for the corresponding number of `QUnit.stop()` increments.
 
-### Example
+### Examples
 
 A test run that does not begin when the page is done loading. This example uses an Asynchronous Module Definition (AMD) loader-style `require` call.
 
 ```js
 QUnit.config.autostart = false;
 
-require(["test/tests1.js", "test/tests2.js"], function() {
-  QUnit.start();
-});
+require(
+  [ "test/tests1.js", "test/tests2.js" ],
+  QUnit.start
+);
 ```

--- a/docs/QUnit/test.only.md
+++ b/docs/QUnit/test.only.md
@@ -41,7 +41,7 @@ When debugging a larger area of code, you may want to _only_ run all tests withi
 | [QUnit 2.12](https://github.com/qunitjs/qunit/releases/tag/2.12.0) | The `QUnit.only()` method was renamed to `QUnit.test.only()`.<br/>Use of `QUnit.only()` remains supported as an alias.
 | [QUnit 1.20](https://github.com/qunitjs/qunit/releases/tag/1.20.0) | The `QUnit.only()` method was introduced.
 
-### Example
+### Examples
 
 How to use `QUnit.test.only` to filter which tests are run.
 

--- a/docs/QUnit/test.skip.md
+++ b/docs/QUnit/test.skip.md
@@ -33,7 +33,7 @@ As a codebase becomes bigger, you may sometimes want to temporarily disable an e
 | [QUnit 2.12](https://github.com/qunitjs/qunit/releases/tag/2.12.0) | The `QUnit.skip()` method was renamed to `QUnit.test.skip()`.<br/>Use of `QUnit.skip()` remains supported as an alias.
 | [QUnit 1.16](https://github.com/qunitjs/qunit/releases/tag/1.16.0) | The `QUnit.skip()` method was introduced.
 
-### Example
+### Examples
 
 How to use `skip` as a placeholder for future or temporarily broken tests.
 

--- a/docs/QUnit/test.todo.md
+++ b/docs/QUnit/test.todo.md
@@ -39,7 +39,7 @@ You can also use [`QUnit.module.todo()`](./module.md) to manage the "todo" state
 | [QUnit 2.12](https://github.com/qunitjs/qunit/releases/tag/2.12.0) | The `QUnit.todo()` method was renamed to `QUnit.test.todo()`.<br/>Use of `QUnit.todo()` remains supported as an alias.
 | [QUnit 2.2](https://github.com/qunitjs/qunit/releases/tag/2.2.0) | The `QUnit.todo()` method was introduced.
 
-### Example
+### Examples
 
 How to use `QUnit.test.todo` to denote code that is still under development.
 

--- a/docs/assert/deepEqual.md
+++ b/docs/assert/deepEqual.md
@@ -29,25 +29,29 @@ The `deepEqual()` assertion can be used just like `equal()` when comparing the v
 
 ### Examples
 
-Compare the value of two objects.
-```js
-QUnit.test( "deepEqual test", function( assert ) {
-  var obj = { foo: "bar" };
+Validate the properties and values of a given object.
 
-  assert.deepEqual( obj, { foo: "bar" }, "Two objects can be the same in value" );
+```js
+QUnit.test( "good example", assert => {
+  const result = { foo: "bar" };
+
+  assert.deepEqual( result, { foo: "bar" }, "result object" );
 });
 ```
 
 ```js
-QUnit.test( 'deepEqual failing test', function( assert ) {
-  assert.deepEqual( {
-    a: 'Albert',
-    b: 'Berta',
+QUnit.test( "bad example", assert => {
+  const result = {
+    a: "Albert",
+    b: "Berta",
     num: 123
-  }, {
-    a: 'Albert',
-    b: 'Berta',
-    num: '123' // Fails: the number `123` is not strictly equal to the string `'123'`.
+  };
+
+  // fails because the number 123 is not strictly equal to the string "123".
+  assert.deepEqual( result, {
+    a: "Albert",
+    b: "Berta",
+    num: "123"
   } );
 } );
 ```

--- a/docs/assert/equal.md
+++ b/docs/assert/equal.md
@@ -13,7 +13,7 @@ version_added: "1.0"
 
 `equal( actual, expected [, message ] )`
 
-A non-strict value comparison.
+A non-strict comparison of two values.
 
 | name               | description                          |
 |--------------------|--------------------------------------|
@@ -24,6 +24,8 @@ A non-strict value comparison.
 ### Description
 
 The `equal` assertion uses the simple comparison operator (`==`) to compare the actual and expected arguments. When they are equal, the assertion passes; otherwise, it fails. When it fails, both actual and expected values are displayed in the test result, in addition to a given message.
+
+This method is similar to the `assertEquals()` method found in xUnit-style frameworks.
 
 [`notEqual()`](./notEqual.md) can be used to explicitly test inequality.
 

--- a/docs/assert/false.md
+++ b/docs/assert/false.md
@@ -20,20 +20,24 @@ A strict comparison that passes if the first argument is boolean `false`.
 
 `false()` requires just one argument. If the argument evaluates to false, the assertion passes; otherwise, it fails.
 
+This method is similar to the `assertFalse()` method found in xUnit-style frameworks.
+
 [`true()`](./true.md) can be used to explicitly test for a true value.
 
 ### Examples
 
 ```js
-QUnit.test( "false test", function( assert ) {
-  assert.false( false, "false succeeds" );
+QUnit.test( "example", assert => {
+  // success
+  assert.false( false, "boolean false" );
 
-  assert.false( "not-empty", "not-empty string fails" );
-  assert.false( "", "empty string fails" );
-  assert.false( 0, "0 fails" );
-  assert.false( true, "true fails" );
-  assert.false( NaN, "NaN fails" );
-  assert.false( null, "null fails" );
-  assert.false( undefined, "undefined fails" );
+  // failure
+  assert.false( "foo", "non-empty string" );
+  assert.false( "", "empty string" );
+  assert.false( 0, "number zero" );
+  assert.false( true, "boolean true" );
+  assert.false( NaN, "NaN value" );
+  assert.false( null, "null value" );
+  assert.false( undefined, "undefined value" );
 });
 ```

--- a/docs/assert/notDeepEqual.md
+++ b/docs/assert/notDeepEqual.md
@@ -30,9 +30,10 @@ The `notDeepEqual()` assertion can be used just like `equal()` when comparing th
 Compare the value of two objects.
 
 ```js
-QUnit.test( "notDeepEqual test", function( assert ) {
-  var obj = { foo: "bar" };
+QUnit.test( "example", assert => {
+  const result = { foo: "yep" };
 
-  assert.notDeepEqual( obj, { foo: "bla" }, "Different object, same key, different value, not equal" );
+  // succeeds, objects are similar but have a different foo value.
+  assert.notDeepEqual( result, { foo: "nope" } );
 });
 ```

--- a/docs/assert/notEqual.md
+++ b/docs/assert/notEqual.md
@@ -32,7 +32,18 @@ The `notEqual` assertion uses the simple inverted comparison operator (`!=`) to 
 The simplest assertion example:
 
 ```js
-QUnit.test( "a test", function( assert ) {
-  assert.notEqual( 1, "2", "String '2' and number 1 don't have the same value" );
+QUnit.test( "good example", assert => {
+  const result = "2";
+
+  // succeeds, 1 and 2 are different.
+  assert.notEqual( result, 1, "string and number" );
+});
+
+QUnit.test( "bad example", assert => {
+  const result = "2";
+
+  // fails, the number 2 and the string "2" are actually considered equal
+  // when loosely compared. Use notStrictEqual instead to consider them different
+  assert.notEqual( result, 2, "string and number" );
 });
 ```

--- a/docs/assert/notOk.md
+++ b/docs/assert/notOk.md
@@ -20,18 +20,21 @@ A boolean check, inverse of `ok()`. Passes if the first argument is falsy.
 
 `notOk()` requires just one argument. If the argument evaluates to false, the assertion passes; otherwise, it fails. If a second message argument is provided, it will be displayed in place of the result.
 
-### Examples:
+### Examples
 
 ```js
-QUnit.test( "notOk test", function( assert ) {
-  assert.notOk( false, "false succeeds" );
-  assert.notOk( "", "empty string succeeds" );
-  assert.notOk( NaN, "NaN succeeds" );
-  assert.notOk( null, "null succeeds" );
-  assert.notOk( undefined, "undefined succeeds" );
+QUnit.test( "example", assert => {
+  // success
+  assert.notOk( false, "boolean false" );
+  assert.notOk( "", "empty string" );
+  assert.notOk( 0, "number zero" );
+  assert.notOk( NaN, "NaN value" );
+  assert.notOk( null, "null value" );
+  assert.notOk( undefined, "undefined value" );
 
-  assert.notOk( true, "true fails" );
-  assert.notOk( 1, "1 fails" );
-  assert.notOk( "not-empty", "not-empty string fails" );
+  // failure
+  assert.notOk( "foo", "non-empty string" );
+  assert.notOk( true, "boolean true" );
+  assert.notOk( 1, "number one" );
 });
 ```

--- a/docs/assert/notPropEqual.md
+++ b/docs/assert/notPropEqual.md
@@ -33,19 +33,21 @@ Compare the values of two objects properties.
 
 ```js
 QUnit.test( "example", assert => {
-  function Foo() {
-    this.x = 1;
-    this.y = "2";
+  class Foo {
+    constructor() {
+      this.x = "1";
+      this.y = 2;
+    }
+    walk() {}
+    run() {}
   }
-  Foo.prototype.walk = function () {};
-  Foo.prototype.run = function () {};
-  Foo.prototype.z = "inherited";
 
-  const result = new Foo();
+  const foo = new Foo();
+  const expected = ;
 
-  // succeeds, property values are compared with strict equality
-  // and result has a "y" property with a string instead of a number.
-  assert.notPropEqual( result, {
+  // succeeds, only own property values are compared (using strict equality),
+  // and propery "x" is indeed not equal (string instead of number).
+  assert.notPropEqual( foo, {
     x: 1,
     y: 2
   } );

--- a/docs/assert/notPropEqual.md
+++ b/docs/assert/notPropEqual.md
@@ -32,18 +32,22 @@ When they aren't equal, the assertion passes; otherwise, it fails. When it fails
 Compare the values of two objects properties.
 
 ```js
-QUnit.test( "notPropEqual test", function( assert ) {
-  function Foo( x, y, z ) {
-    this.x = x;
-    this.y = y;
-    this.z = z;
+QUnit.test( "example", assert => {
+  function Foo() {
+    this.x = 1;
+    this.y = "2";
   }
-  Foo.prototype.doA = function () {};
-  Foo.prototype.doB = function () {};
-  Foo.prototype.bar = 'prototype';
+  Foo.prototype.walk = function () {};
+  Foo.prototype.run = function () {};
+  Foo.prototype.z = "inherited";
 
-  var foo = new Foo( 1, "2", [] );
-  var bar = new Foo( "1", 2, {} );
-  assert.notPropEqual( foo, bar, "Properties values are strictly compared." );
+  const result = new Foo();
+
+  // succeeds, property values are compared with strict equality
+  // and result has a "y" property with a string instead of a number.
+  assert.notPropEqual( result, {
+    x: 1,
+    y: 2
+  } );
 });
 ```

--- a/docs/assert/notStrictEqual.md
+++ b/docs/assert/notStrictEqual.md
@@ -29,10 +29,11 @@ The `notStrictEqual` assertion uses the strict inverted comparison operator (`!=
 
 ### Examples
 
-The simplest assertion example:
-
 ```js
-QUnit.test( "a test", function( assert ) {
-  assert.notStrictEqual( 1, "1", "String '1' and number 1 have the same value but not the same type" );
+QUnit.test( "example", assert => {
+  const result = "2";
+
+  // succeeds, while the number 2 and string 2 are similar, they are strictly different.
+  assert.notStrictEqual( result, 2 );
 });
 ```

--- a/docs/assert/ok.md
+++ b/docs/assert/ok.md
@@ -22,16 +22,21 @@ A boolean check. Passes if the first argument is truthy.
 
 The most basic assertion in QUnit, `ok()` requires just one argument. If the argument evaluates to true, the assertion passes; otherwise, it fails. If a second message argument is provided, it will be displayed in place of the result.
 
-```js
-QUnit.test( "ok test", function( assert ) {
-  assert.ok( true, "true succeeds" );
-  assert.ok( "non-empty", "non-empty string succeeds" );
+### Examples
 
-  assert.ok( false, "false fails" );
-  assert.ok( 0, "0 fails" );
-  assert.ok( NaN, "NaN fails" );
-  assert.ok( "", "empty string fails" );
-  assert.ok( null, "null fails" );
-  assert.ok( undefined, "undefined fails" );
+```js
+QUnit.test( "example", assert => {
+  // success
+  assert.ok( true, "boolean true" );
+  assert.ok( "foo", "non-empty string" );
+  assert.ok( 1, "number one" );
+
+  // failure
+  assert.ok( false, "boolean false" );
+  assert.ok( "", "empty string" );
+  assert.ok( 0, "number zero" );
+  assert.ok( NaN, "NaN value" );
+  assert.ok( null, "null value" );
+  assert.ok( undefined, "undefined value" );
 });
 ```

--- a/docs/assert/propEqual.md
+++ b/docs/assert/propEqual.md
@@ -33,19 +33,45 @@ Compare the properties values of two objects.
 
 ```js
 QUnit.test( "example", assert => {
+  class Foo {
+    constructor() {
+      this.x = 1;
+      this.y = 2;
+    }
+    walk() {}
+    run() {}
+  }
+
+  const foo = new Foo();
+  const expected = {
+    x: 1,
+    y: 2
+  };
+
+  // succeeds, own properties are strictly equal,
+  // and inherited properties (such as which object constructor) are ignored.
+  assert.propEqual( foo,  );
+});
+```
+
+Using classic ES5 syntax:
+
+```js
+QUnit.test( "example", function ( assert ) {
   function Foo() {
     this.x = 1;
-    this.y = "2";
+    this.y = 2;
   }
   Foo.prototype.walk = function () {};
   Foo.prototype.run = function () {};
-  Foo.prototype.z = "inherited";
 
-  const result = new Foo();
-
-  assert.propEqual( result, {
+  var foo = new Foo();
+  var expected = {
     x: 1,
-    y: "2"
-  } );
+    y: 2
+  };
+
+  // succeeds, own properties are strictly equal.
+  assert.propEqual( foo, expected );
 });
 ```

--- a/docs/assert/propEqual.md
+++ b/docs/assert/propEqual.md
@@ -27,27 +27,25 @@ The `propEqual()` assertion provides strictly (`===`) comparison of Object prope
 
 [`notPropEqual()`](./notPropEqual.md) can be used to explicitly test strict inequality of Object properties.
 
-### Example
+### Examples
 
 Compare the properties values of two objects.
 
 ```js
-QUnit.test( "propEqual test", function( assert ) {
-  function Foo( x, y, z ) {
-    this.x = x;
-    this.y = y;
-    this.z = z;
+QUnit.test( "example", assert => {
+  function Foo() {
+    this.x = 1;
+    this.y = "2";
   }
-  Foo.prototype.doA = function () {};
-  Foo.prototype.doB = function () {};
-  Foo.prototype.bar = 'prototype';
+  Foo.prototype.walk = function () {};
+  Foo.prototype.run = function () {};
+  Foo.prototype.z = "inherited";
 
-  var foo = new Foo( 1, "2", [] );
-  var bar = {
-    x : 1,
-    y : "2",
-    z : []
-  };
-  assert.propEqual( foo, bar, "Strictly the same properties without comparing objects constructors." );
+  const result = new Foo();
+
+  assert.propEqual( result, {
+    x: 1,
+    y: "2"
+  } );
 });
 ```

--- a/docs/assert/pushResult.md
+++ b/docs/assert/pushResult.md
@@ -20,7 +20,7 @@ Report the result of a custom assertion.
 
 ### Examples
 
-If you need to express an expectation that is not abstracted by QUnit's built-in assertions, you can performing your own logic ad-hoc, and then pass two directly comparable values to [`assert.strictEqual()`](./strictEqual.md), or pass a representative boolean result to [`assert.true()`](./true.md).
+If you need to express an expectation that is not abstracted by QUnit's built-in assertions, you can perform your own logic ad-hoc, and then pass two directly comparable values to [`assert.strictEqual()`](./strictEqual.md), or pass your own representative boolean result to [`assert.true()`](./true.md).
 
 ```js
 QUnit.test( "bad example with remainder", assert => {

--- a/docs/assert/rejects.md
+++ b/docs/assert/rejects.md
@@ -33,53 +33,60 @@ The `expectedMatcher` argument can be:
 
 Note: in order to avoid confusion between the `message` and the `expectedMatcher`, the `expectedMatcher` **can not** be a string.
 
-### Example
-
-Assert the correct error message is received for a custom error object.
+### Examples
 
 ```js
-QUnit.test( "rejects", function( assert ) {
+QUnit.test( "rejects example", assert => {
 
-  assert.rejects(Promise.reject("some error description"));
+  // simple check
+  assert.rejects( Promise.reject( "some error" ) );
 
+  // simple check
   assert.rejects(
-    Promise.reject(new Error("some error description")),
-    "rejects with just a message, not using the 'expectedMatcher' argument"
+    Promise.reject( "some error" ),
+    "optional description here"
   );
 
+  // match pattern on actual error
   assert.rejects(
-    Promise.reject(new Error("some error description")),
-    /description/,
-    "`rejectionValue.toString()` contains `description`"
+    Promise.reject( new Error( "some error" ) ),
+    /some error/,
+    "optional description here"
   );
 
-  // Using a custom error like object
+  // Using a custom error constructor
   function CustomError( message ) {
     this.message = message;
   }
-
   CustomError.prototype.toString = function() {
     return this.message;
   };
 
+  // actual error is an instance of the expected constructor
   assert.rejects(
-    Promise.reject(new CustomError()),
-    CustomError,
-    "raised error is an instance of CustomError"
+    Promise.reject( new CustomError( "some error" ) ),
+    CustomError
   );
 
+  // actual error has strictly equal `constructor`, `name` and `message` properties
+  // of the expected error object
   assert.rejects(
-    Promise.reject(new CustomError("some error description")),
-    new CustomError("some error description"),
-    "raised error instance matches the CustomError instance"
+    Promise.reject( new CustomError( "some error" ) ),
+    new CustomError( "some error" )
   );
 
+  // custom validation arrow function
   assert.rejects(
-    Promise.reject(new CustomError("some error description")),
+    Promise.reject( new CustomError( "some error" ) ),
+    ( err ) => err.toString() === "some error"
+  );
+
+  // custom validation function
+  assert.rejects(
+    Promise.reject( new CustomError( "some error" ) ),
     function( err ) {
-      return err.toString() === "some error description";
-    },
-    "raised error instance satisfies the callback function"
+      return err.toString() === "some error";
+    }
   );
 });
 ```

--- a/docs/assert/step.md
+++ b/docs/assert/step.md
@@ -21,16 +21,18 @@ The `step()` assertion registers a passing assertion with a provided message. Th
 
 Together with the `verifySteps()` method, `step()` assertions give you an easy way to verify both the count and order of code execution.
 
-### Example
+### Examples
 
 ```js
-QUnit.test( "step test", function( assert ) {
-  assert.expect( 1 );
-  obj.hook = function() {
-    assert.step('Hook is called!');
-  };
-  obj.invokeHookIndirectly();
+QUnit.test( "step example", assert => {
+  const thing = new MyThing();
+  thing.on( "something", () => {
+    assert.step( "something happened" );
+  });
+  thing.run();
+
+  assert.verifySteps([ "something happened" ]);
 });
 ```
 
-_Note: See the [`verifySteps`](./verifySteps.md) entry for more detailed examples._
+_Note: See [`verifySteps`](./verifySteps.md) for more detailed examples._

--- a/docs/assert/strictEqual.md
+++ b/docs/assert/strictEqual.md
@@ -33,12 +33,14 @@ The `strictEqual()` assertion provides the most rigid comparison of type and val
 
 * Prior to QUnit 1.1, this method was known as `assert.same`.<br>The alias was removed in QUnit 1.3.
 
-### Example
+### Examples
 
 Compare the value of two primitives, having the same value and type.
 
 ```js
-QUnit.test( "strictEqual test", function( assert ) {
-  assert.strictEqual( 1, 1, "1 and 1 have the same value and type" );
+QUnit.test( "strictEqual example", assert => {
+  const result = 2;
+
+  assert.strictEqual( result, 2 );
 });
 ```

--- a/docs/assert/throws.md
+++ b/docs/assert/throws.md
@@ -40,68 +40,74 @@ The `expectedMatcher` argument can be:
 | [QUnit 2.12](https://github.com/qunitjs/qunit/releases/tag/2.12.0) | Added support for arrow functions as `expectedMatcher` callback function.
 | [QUnit 1.9](https://github.com/qunitjs/qunit/releases/tag/v1.9.0) | `assert.raises()` was renamed to `assert.throws()`.<br>The  `assert.raises()` method remains supported as an alias.
 
-### Example
-
-Assert the correct error message is received for a custom error object.
+### Examples
 
 ```js
-QUnit.test( "throws", assert => {
+QUnit.test( "throws example", assert => {
 
+  // simple check
+  assert.throws( function() {
+    throw new Error( "boo" );
+  });
+
+  // simple check
+  assert.throws(
+    function() {
+      throw new Error( "boo" );
+    },
+    "optional description here"
+  );
+
+  // match pattern on actual error
+  assert.throws(
+    function() {
+      throw new Error( "some error" );
+    },
+    /some error/,
+    "optional description here"
+  );
+
+  // using a custom error constructor
   function CustomError( message ) {
     this.message = message;
   }
-
   CustomError.prototype.toString = function() {
     return this.message;
   };
 
+  // actual error is an instance of the expected constructor
   assert.throws(
     function() {
-      throw "error"
+      throw new CustomError( "some error" );
     },
-    "throws with just a message, not using the 'expected' argument"
+    CustomError
   );
 
+  // actual error has strictly equal `constructor`, `name` and `message` properties
+  // of the expected error object
   assert.throws(
     function() {
-      throw new CustomError("some error description");
+      throw new CustomError( "some error" );
     },
-    /description/,
-    "raised error message contains 'description'"
+    new CustomError( "some error" )
   );
 
+  // custom validation arrow function
   assert.throws(
     function() {
-      throw new CustomError();
+      throw new CustomError( "some error" );
     },
-    CustomError,
-    "raised error is an instance of CustomError"
+    ( err ) => err.toString() === "some error"
   );
 
+  // custom validation function
   assert.throws(
     function() {
-      throw new CustomError("some error description");
-    },
-    new CustomError("some error description"),
-    "raised error instance matches the CustomError instance"
-  );
-
-  assert.throws(
-    function() {
-      throw new CustomError("some error description");
-    },
-    ( err ) => err.toString() === "some error description",
-    "raised error instance satisfies the arrow function"
-  );
-
-  assert.throws(
-    function() {
-      throw new CustomError("some error description");
+      throw new CustomError( "some error" );
     },
     function( err ) {
-      return err.toString() === "some error description";
-    },
-    "raised error instance satisfies the callback function"
+      return err.toString() === "some error";
+    }
   );
 });
 ```

--- a/docs/assert/timeout.md
+++ b/docs/assert/timeout.md
@@ -27,32 +27,38 @@ If `0` is passed, then the test will be assumed to be completely synchronous. If
 ### Examples
 
 ```js
-QUnit.test( "Waiting for focus event", function( assert ) {
-  assert.timeout( 1000 ); // Timeout of 1 second
-  var done = assert.async();
-  var input = $( "#test-input" ).focus();
-  setTimeout(function() {
-    assert.equal( document.activeElement, input[0], "Input was focused" );
+QUnit.test( "wait for an event", assert => {
+  assert.timeout( 1000 ); // Timeout after 1 second
+  const done = assert.done();
+
+  const adder = new NumberAdder();
+  adder.on( "ready", res => {
+    assert.strictEqual( res, 12 );
     done();
   });
+  adder.run([ 1, 1, 2, 3, 5 ]);
 });
 ```
 
 ```js
-QUnit.test( "Waiting for async function", function( assert ) {
-  assert.timeout( 500 ); // Timeout of .5 seconds
-  var promise = asyncFunction();
+QUnit.test( "wait for an async function", async assert => {
+  assert.timeout( 500 ); // Timeout after 0.5 seconds
+
+  const result = await asyncAdder( 5, 7 );
+  assert.strictEqual( result, 12 );
+});
+```
+
+Using classic ES5 syntax:
+
+```js
+QUnit.test( "wait for a returned promise", function( assert ) {
+  assert.timeout( 500 ); // Timeout after 0.5 seconds
+
+  var promise = asyncAdder( 5, 7 );
+
   return promise.then( function( result ) {
-    assert.true( result );
+    assert.strictEqual( result, 12 );
   } );
-});
-```
-
-```js
-QUnit.test( "Waiting in an async test", async assert => {
-  assert.timeout( 500 ); // Timeout of .5 seconds
-
-  let result = await asyncFunction();
-  assert.true( result );
 });
 ```

--- a/docs/assert/true.md
+++ b/docs/assert/true.md
@@ -20,21 +20,25 @@ A strict comparison that passes if the first argument is boolean `true`.
 
 `true()` requires just one argument. If the argument evaluates to true, the assertion passes; otherwise, it fails.
 
+This method is similar to the `assertTrue()` method found in xUnit-style frameworks.
+
 [`false()`](./false.md) can be used to explicitly test for a false value.
 
 ### Examples
 
 ```js
-QUnit.test( "true test", function( assert ) {
-  assert.true( true, "true succeeds" );
+QUnit.test( "example", assert => {
+  // success
+  assert.true( true, "boolean true" );
 
-  assert.true( "non-empty", "non-empty string fails" );
-  assert.true( "", "empty string fails" );
-  assert.true( 1, "1 fails" );
-  assert.true( false, "false fails" );
-  assert.true( NaN, "NaN fails" );
-  assert.true( null, "null fails" );
-  assert.true( undefined, "undefined fails" );
+  // failure
+  assert.true( "foo", "non-empty string" );
+  assert.true( "", "empty string" );
+  assert.true( 0, "number zero" );
+  assert.true( false, "boolean false" );
+  assert.true( NaN, "NaN value" );
+  assert.true( null, "null value" );
+  assert.true( undefined, "undefined value" );
 });
 ```
 

--- a/docs/assert/verifySteps.md
+++ b/docs/assert/verifySteps.md
@@ -22,132 +22,130 @@ The `assert.verifySteps()` assertion compares a given array of string values (re
 
 The list of steps to validate is reset when `assert.verifySteps([/* ...snip ... */])` is called. This allows multiple combinations of `assert.step` and `assert.verifySteps` within the same test.
 
+Learn how to use the Step API and the value it adds to your test suite.
+
+* [Example: Testing event-based interfaces](#example-testing-event-based-interfaces)
+* [Example: Testing publish/subscribe systems](#example-testing-publishsubscribe-systems)
+* [Example: Multiple steps verifications in one test](#example-multiple-steps-verifications-in-one-test)
+
 ### Examples
 
-The following examples look at scenarios in which the Step API is particularly useful and shows how you might have implemented the same functionality with less-specific APIs.
+The **Step API** strictly validates the order and frequency of observed values. It also allows detecting of unexpected steps, which are then shown as part the test failure.
 
-#### Verifying Hook Execution Order
+#### Example: Testing event-based interfaces
 
-**Without Step API**
+This example uses a class based on an [`EventEmitter`](https://nodejs.org/api/events.html), such as the one provided by Node.js and other environments:
 
 ```js
-QUnit.test( "user-defined hooks execute in correct order", function( assert ) {
-  let lastStep = 'none';
-  let startCount = 0;
-  let middleCount = 0;
-  let endCount = 0;
+QUnit.test( "good example", async assert => {
+  const thing = new MyThing();
+  thing.on( "start", () => {
+    assert.step( "start" );
+  });
+  thing.on( "middle", () => {
+    assert.step( "middle" );
+  });
+  thing.on( "end", () => {
+    assert.step( "end" );
+  });
+  thing.on( "error", message => {
+    assert.step( { error: message } );
+  });
 
-  obj.start = function() {
-    assert.equal(lastStep, 'none');
-    lastStep = 'start';
-    startCount++;
-  };
-  obj.middle = function() {
-    assert.equal(lastStep, 'start');
-    lastStep = 'middle';
-    middleCount++;
-  };
-  obj.end = function() {
-    assert.equal(lastStep, 'middle');
-    endCount++;
-  };
+  await thing.process();
 
-  return obj.process().then(function() {
-    assert.equal(startCount, 1);
-    assert.equal(middleCount, 1);
-    assert.equal(endCount, 1);
+  assert.verifySteps( [ "start", "middle", "end" ] );
+});
+```
+
+When approaching this scenario **without the Step API** one might be tempted to place comparison checks directly inside event callbacks. It is considered an anti-pattern to make dummy assertions in callbacks that the test does not have control over, because that would provide loose assurances and can easily cause false positives (a callback might not run, run out of order, or run multipe times). It also offers rather limited debugging information in case of problems.
+
+```js
+// WARNING: This is a BAD example
+QUnit.test( "bad example 1", assert => {
+  const thing = new MyThing();
+  thing.on( "start", () => {
+    assert.true( true, "start" );
+  });
+  thing.on( "middle", () => {
+    assert.true( true, "middle" );
+  });
+  thing.on( "end", () => {
+    assert.true( true, "end" );
+  });
+  thing.on( "error", () => {
+    assert.true( false, "error" );
+  });
+
+  return thing.process();
+});
+```
+
+A less fragile approach could involve a local counter variable with an array that we check with [`deepEqual`](./deepEqual.md). This catches out-of-order issues, unexpected values, duplicate values, and provides detailed debugging information in case of problems. This is basically how the Step API works:
+
+```js
+QUnit.test( "manual example without Step API", assert => {
+  const values = [];
+
+  const thing = new MyThing();
+  thing.on( "start", () => {
+    values.push( "start" );
+  });
+  thing.on( "middle", () => {
+    values.push( "middle" );
+  });
+  thing.on( "end", () => {
+    values.push( "end" );
+  });
+  thing.on( "error", () => {
+    values.push( "error" );
+  });
+
+
+  return thing.process().then(() => {
+    assert.deepEqual( values, [ "start", "middle", "end" ] );
   });
 });
 ```
 
-**With Step API**
+#### Example: Testing publish/subscribe systems
+
+Use the **Step API** to verify messages received in a Pub-Sub channel or topic.
 
 ```js
-QUnit.test( "user-defined hooks execute in correct order", function( assert ) {
-  obj.start = function() {
-    assert.step('start');
-  };
-  obj.middle = function() {
-    assert.step('middle');
-  };
-  obj.end = function() {
-    assert.step('end');
-  };
-
-  return obj.process().then(function() {
-    assert.verifySteps(['start', 'middle', 'end']);
-  });
-});
-```
-
-#### Verifying Evented Systems
-
-**Without Step API**
-
-```js
-QUnit.test( "subscribe/unsubscribe", function( assert ) {
-
+QUnit.test( "good example", assert => {
   const publisher = new Publisher();
-  const messages = [];
 
-  const subscriber1 = message => messages.push(`Subscriber #1: ${message}`);
-  const subscriber2 = message => messages.push(`Subscriber #2: ${message}`);
+  const subscriber1 = (message) => assert.step(`Sub 1: ${message}`);
+  const subscriber2 = (message) => assert.step(`Sub 2: ${message}`);
 
   publisher.subscribe(subscriber1);
   publisher.subscribe(subscriber2);
-
-  publisher.publish('Hello!');
-
-  publisher.unsubscribe(subscriber1);
-
-  publisher.publish('World!');
-
-  assert.deepEqual(messages, [
-    'Subscriber #1: Hello!',
-    'Subscriber #2: Hello!',
-    'Subscriber #2: World!'
-  ]);
-});
-```
-
-**With Step API**
-
-```js
-QUnit.test( "subscribe/unsubscribe", function( assert ) {
-
-  const publisher = new Publisher();
-
-  const subscriber1 = message => assert.step(`Subscriber #1: ${message}`);
-  const subscriber2 = message => assert.step(`Subscriber #2: ${message}`);
-
-  publisher.subscribe(subscriber1);
-  publisher.subscribe(subscriber2);
-
-  publisher.publish('Hello!');
+  publisher.publish( "Hello!" );
 
   publisher.unsubscribe(subscriber1);
-
-  publisher.publish('World!');
+  publisher.publish( "World!" );
 
   assert.verifySteps([
-    'Subscriber #1: Hello!',
-    'Subscriber #2: Hello!',
-    'Subscriber #2: World!'
+    "Sub 1: Hello!",
+    "Sub 2: Hello!",
+    "Sub 2: World!"
   ]);
 });
 ```
 
-#### Verifying Steps Multiple Times
+#### Example: Multiple steps verifications in one test
+
+The internal buffer of observed steps is automatically reset when calling `verifySteps()`.
 
 ```js
-QUnit.test( "verify steps", function test(assert){
-    assert.expect( 5 );
+QUnit.test( "multiple verifications example", assert => {
+  assert.step( "one" );
+  assert.step( "two" );
+  assert.verifySteps([ "one", "two" ]);
 
-    assert.step( "do stuff 1" );
-    assert.step( "do stuff 2" );
-    assert.verifySteps( [ "do stuff 1", "do stuff 2" ] );
-
-    assert.step( "do stuff 3" );
-    assert.verifySteps( [ "do stuff 3" ] );
-} );
-```
+  assert.step( "three" );
+  assert.step( "four" );
+  assert.verifySteps([ "three", "four" ]);
+});
+ ```

--- a/docs/callbacks/QUnit.begin.md
+++ b/docs/callbacks/QUnit.begin.md
@@ -13,7 +13,7 @@ version_added: "1.0"
 
 Register a callback to fire whenever the test suite begins. The callback may be an async function, or a function that returns a promise, which will be waited for before the next callback is handled.
 
-The begin callback will be called once before QUnit runs any tests.
+The callback will be called once, before QUnit runs any tests.
 
 | parameter | description |
 |-----------|-------------|

--- a/docs/callbacks/QUnit.begin.md
+++ b/docs/callbacks/QUnit.begin.md
@@ -11,45 +11,62 @@ version_added: "1.0"
 
 `QUnit.begin( callback )`
 
-Register a callback to fire whenever the test suite begins. The callback can return a promise that will be waited for before the next callback is handled.
+Register a callback to fire whenever the test suite begins. The callback may be an async function, or a function that returns a promise, which will be waited for before the next callback is handled.
 
-`QUnit.begin()` is called once before running any tests.
+The begin callback will be called once before QUnit runs any tests.
 
 | parameter | description |
 |-----------|-------------|
-| callback (function) | Callback to execute. Provides a single argument with the callback details object |
+| callback (function) | Callback to execute. Provides a single argument with the callback Details object |
 
-#### Callback details: `callback( details: { totalTests } )`
+##### Details object
 
-| parameter | description |
+Passed to the callback:
+
+| property | description |
 |-----------|-------------|
 | `totalTests` | The number of total tests in the test suite |
 
-### Example
+### Examples
 
-Get total amount of tests.
+Get total number of tests known at the start.
 
 ```js
-QUnit.begin(function( details ) {
-  console.log( "Test amount:", details.totalTests );
+QUnit.begin( details => {
+  console.log( `Test amount: ${details.totalTests}` );
 });
 ```
 
-Using modern syntax:
+Use async-await to wait for some asynchronous work:
 
 ```js
-QUnit.begin( ( { totalTests } ) => {
-  console.log( `Test amount: ${totalTests}` );
+QUnit.begin( async details => {
+  await someAsyncWork();
+
+  console.log( `Test amount: ${details.totalTests}` );
 });
 ```
 
-Returning a promise:
+Using classic ES5 syntax:
 
 ```js
-QUnit.begin( () => {
-  return new Promise(function(resolve, reject) {
+QUnit.begin( function( details ) {
+  console.log( "Test amount:" + details.totalTests );
+});
+```
+
+```js
+function someAsyncWork() {
+  return new Promise( function( resolve, reject ) {
     // do some async work
     resolve();
+  });
+}
+
+QUnit.begin( function( details ) {
+  return someAsyncWork().then( function () {
+
+    console.log( "Test amount:" + details.totalTests );
   });
 });
 ```

--- a/docs/callbacks/QUnit.done.md
+++ b/docs/callbacks/QUnit.done.md
@@ -11,46 +11,43 @@ version_added: "1.0"
 
 `QUnit.done( callback )`
 
-Register a callback to fire whenever the test suite ends. The callback can return a promise that will be waited for before the next callback is handled.
+Register a callback to fire whenever the test suite ends. The callback may be an async function, or a function that return a promise which will be waited for before the next callback is handled.
 
 | parameter | description |
 |-----------|-------------|
-| callback (function) | Callback to execute. Provides a single argument with the callback details object |
+| callback (function) | Callback to execute. Provides a single argument with the callback Details object |
 
-#### Callback details: `callback( details: { failed, passed, total, runtime } )`
+##### Details object
 
-| parameter | description |
+Passed to the callback:
+
+| property | description |
 |-----------|-------------|
 | `failed` (number) | The number of failed assertions |
 | `passed` (number) | The number of passed assertions |
 | `total` (number) | The total number of assertions |
 | `runtime` (number) | The time in milliseconds it took tests to run from start to finish. |
 
-### Example
+### Examples
 
 Register a callback that logs test results to the console.
 
 ```js
-QUnit.done(function( details ) {
-  console.log( "Total: ", details.total, " Failed: ", details.failed, " Passed: ", details.passed, " Runtime: ", details.runtime );
+QUnit.done( details => {
+  console.log(
+    `Total: ${details.total} Failed: ${details.failed} `
+      + `Passed: ${details.passed} Runtime: ${details.runtime}`
+  );
 });
 ```
 
-Using modern syntax:
+Using classic ES5 syntax:
 
 ```js
-QUnit.done( ( { total, failed, passed, runtime } ) => {
-  console.log( `Total: ${total}, Failed: ${failed}, Passed: ${passed}, Runtime: ${runtime}` );
-});
-```
-
-Returning a promise:
-
-```js
-QUnit.done( () => {
-  return new Promise(function(resolve, reject) {
-    // do some async work
-    resolve();
-  });
+QUnit.done( function( details ) {
+  console.log(
+    "Total: " + details.total + " Failed: " + details.failed
+    + " Passed: " + details.passed + " Runtime: " + details.runtime
+  );
 });
 ```

--- a/docs/callbacks/QUnit.log.md
+++ b/docs/callbacks/QUnit.log.md
@@ -13,18 +13,19 @@ version_added: "1.0"
 
 Register a callback to fire whenever an assertion completes.
 
-This is one of several callbacks QUnit provides. Its intended for integration scenarios like PhantomJS or Jenkins.
-The properties of the details argument are listed below as options.
+This is one of several callbacks QUnit provides. Its intended for continous integration scenarios.
+
+**NOTE: The QUnit.log() callback does not handle promises and MUST be synchronous.**
 
 | parameter | description |
 |-----------|-------------|
-| callback (function) | Callback to execute. Provides a single argument with the callback details object |
+| callback (function) | Callback to execute. Provides a single argument with the callback Details object |
 
-**NOTE: Callback in QUnit.log() does not handle promises and must be synchronous.**
+##### Details object
 
-#### Callback details: `callback( details: { result, actual, expected, message, source, module, name, runtime, todo } )`
+Passed to the callback:
 
-| parameter | description |
+| property | description |
 |-----------|-------------|
 | `result` (boolean) | The boolean result of an assertion, `true` means passed, `false` means failed. |
 | `actual` | One side of a comparison assertion. Can be _undefined_ when `ok()` is used. |
@@ -38,62 +39,34 @@ The properties of the details argument are listed below as options.
 
 ### Examples
 
-Register a callback that logs the assertion result and its message
+Register a callback that logs the assertion result and its message:
 
 ```js
-QUnit.log(function( details ) {
-  console.log( "Log: ", details.result, details.message );
-});
-```
-
-Using modern syntax:
-
-```js
-QUnit.log( ( { result, message } ) => {
-  console.log( `Log: ${result}, ${message}` );
+QUnit.log( details => {
+  console.log( `Log: ${details.result}, ${details.message}` );
 });
 ```
 
 ---
 
-Logs the module and test block whenever an assertion fails.
+Log the module name and test result whenever an assertion fails:
 
 ```js
-QUnit.log(function( details ) {
+QUnit.log( details ) => {
   if ( details.result ) {
     return;
   }
-  var loc = details.module + ": " + details.name + ": ",
-    output = "FAILED: " + loc + ( details.message ? details.message + ", " : "" );
 
+  let output = `[FAILED] ${details.module} > ${details.name}`;
+
+  if ( details.message ) {
+    output += `: ${details.message}`;
+  }
   if ( details.actual ) {
-    output += "expected: " + details.expected + ", actual: " + details.actual;
+    output += `\nexpected: ${details.expected}\nactual: ${details.actual}`;
   }
   if ( details.source ) {
-    output += ", " + details.source;
-  }
-  console.log( output );
-});
-```
-
-Using modern syntax:
-
-```js
-QUnit.log( ( { result, module, name, message, actual, expected, source } ) => {
-  if ( result ) {
-    return;
-  }
-
-  let output = `FAILED: ${module}: ${name}: `;
-
-  if ( message ) {
-    output += `${message}, `;
-  }
-  if ( actual ) {
-    output += `expected: ${expected}, actual: ${actual}`;
-  }
-  if ( source ) {
-    output += `, ${source}`;
+    output += `\n${details.source}`;
   }
 
   console.log( output );

--- a/docs/callbacks/QUnit.log.md
+++ b/docs/callbacks/QUnit.log.md
@@ -13,7 +13,7 @@ version_added: "1.0"
 
 Register a callback to fire whenever an assertion completes.
 
-This is one of several callbacks QUnit provides. Its intended for continous integration scenarios.
+This is one of several callbacks QUnit provides. It's intended for continuous integration scenarios.
 
 **NOTE: The QUnit.log() callback does not handle promises and MUST be synchronous.**
 

--- a/docs/callbacks/QUnit.moduleDone.md
+++ b/docs/callbacks/QUnit.moduleDone.md
@@ -11,15 +11,17 @@ version_added: "1.0"
 
 `QUnit.moduleDone( callback )`
 
-Register a callback to fire whenever a module ends. The callback can return a promise that will be waited for before the next callback is handled.
+Register a callback to fire whenever a module ends. The callback may be an async function, or a function that return a promise which will be waited for before the next callback is handled.
 
 | parameter | description |
 |-----------|-------------|
-| callback (function) | Callback to execute. Provides a single argument with the callback details object |
+| callback (function) | Callback to execute. Provides a single argument with the callback Details object |
 
-#### Callback details: `callback( details: { name, failed, passed, total, runtime } )`
+##### Details object
 
-| parameter | description |
+Passed to the callback:
+
+| property | description |
 |-----------|-------------|
 | `name` (string) | Name of this module |
 | `failed` (number) | The number of failed assertions |
@@ -27,31 +29,12 @@ Register a callback to fire whenever a module ends. The callback can return a pr
 | `total` (number) | The total number of assertions |
 | `runtime` (number) | The execution time in millseconds of this module |
 
-### Example
+### Examples
 
 Register a callback that logs the module results
 
 ```js
-QUnit.moduleDone(function( details ) {
-  console.log( "Finished running: ", details.name, "Failed/total: ", details.failed, details.total );
-});
-```
-
-Using modern syntax:
-
-```js
-QUnit.moduleDone( ( { name, failed, total } ) => {
-  console.log( `Finished running: ${name} Failed/total: ${failed}, ${total}` );
-});
-```
-
-Returning a promise:
-
-```js
-QUnit.moduleDone( () => {
-  return new Promise(function(resolve, reject) {
-    // do some async work
-    resolve();
-  });
+QUnit.moduleDone( details => {
+  console.log( `Finished running: ${details.name} Failed/total: ${details.failed}/${total}` );
 });
 ```

--- a/docs/callbacks/QUnit.moduleStart.md
+++ b/docs/callbacks/QUnit.moduleStart.md
@@ -15,39 +15,22 @@ Register a callback to fire whenever a module begins. The callback can return a 
 
 | parameter | description |
 |-----------|-------------|
-| callback (function) | Callback to execute. Provides a single argument with the callback details object |
+| callback (function) | Callback to execute. Provides a single argument with the callback Details object |
 
-#### Callback details: `callback( details: { name } )`
+##### Details object
 
-| parameter | description |
+Passed to the callback:
+
+| property | description |
 |-----------|-------------|
 | `name` (string) | Name of the next module to run |
 
-### Example
+### Examples
 
 Register a callback that logs the module name
 
 ```js
-QUnit.moduleStart(function( details ) {
-  console.log( "Now running: ", details.name );
-});
-```
-
-Using modern syntax:
-
-```js
-QUnit.moduleStart( ( { name } ) => {
-  console.log( `Now running: ${name}` );
-});
-```
-
-Returning a promise:
-
-```js
-QUnit.moduleStart( () => {
-  return new Promise(function(resolve, reject) {
-    // do some async work
-    resolve();
-  });
+QUnit.moduleStart( details => {
+  console.log( `Now running: ${details.name}` );
 });
 ```

--- a/docs/callbacks/QUnit.on.md
+++ b/docs/callbacks/QUnit.on.md
@@ -11,37 +11,25 @@ version_added: "2.2"
 
 Register a callback to fire whenever the specified event is emitted. Conforms to the [js-reporters standard](https://github.com/js-reporters/js-reporters).
 
-`QUnit.on()` allows you to listen for events related to the test suite's execution. Available event names and corresponding data payloads are defined in the [js-reporters specification](https://github.com/js-reporters/js-reporters).
+Use this to listen for events related to the test suite's execution. Available event names and corresponding data payloads are defined in the [js-reporters specification](https://github.com/js-reporters/js-reporters).
+
+**NOTE: The QUnit.on() callback does not handle promises and MUST be synchronous.**
 
 | parameter | description |
 |-----------|-------------|
 | eventName (string) | The name of the event for which to execute the provided callback. |
 | callback (function) | Callback to execute. Receives a single argument representing the data for the event. |
 
-**NOTE: Callback in QUnit.on() does not handle promises and must be synchronous.**
-
-### Example
+### Examples
 
 Printing results of a test suite.
 
 ```js
-QUnit.on( "runEnd", function( data ) {
-  console.log( "Passed: " + data.testCounts.passed );
-  console.log( "Failed: " + data.testCounts.failed );
-  console.log( "Skipped: " + data.testCounts.skipped );
-  console.log( "Todo: " + data.testCounts.todo );
-  console.log( "Total: " + data.testCounts.total );
-} );
-```
-
-Using modern syntax:
-
-```js
-QUnit.on( "runEnd", ( { testCounts: { passed, failed, skipped, todo, total } } ) => {
-  console.log( `Passed: ${passed}` );
-  console.log( `Failed: ${failed}` );
-  console.log( `Skipped: ${skipped}` );
-  console.log( `Todo: ${todo}` );
-  console.log( `Total: ${total}` );
+QUnit.on( "runEnd", runEnd => {
+  console.log( `Passed: ${runEnd.passed}` );
+  console.log( `Failed: ${runEnd.failed}` );
+  console.log( `Skipped: ${runEnd.skipped}` );
+  console.log( `Todo: ${runEnd.todo}` );
+  console.log( `Total: ${runEnd.total}` );
 } );
 ```

--- a/docs/callbacks/QUnit.testDone.md
+++ b/docs/callbacks/QUnit.testDone.md
@@ -11,15 +11,17 @@ version_added: "1.0"
 
 `QUnit.testDone( callback )`
 
-Register a callback to fire whenever a test ends. The callback can return a promise that will be waited for before the next callback is handled.
+Register a callback to fire whenever a test ends. The callback may be an async function, or a function that return a promise which will be waited for before the next callback is handled.
 
 | parameter | description |
 |-----------|-------------|
-| callback (function) | Callback to execute. Provides a single argument with the callback details object |
+| callback (function) | Callback to execute. Provides a single argument with the callback Details object |
 
-#### Callback details: `callback( details: { name, module, failed, passed, total, runtime, skipped, todo } )`
+##### Details object
 
-| parameter | description |
+Passed to the callback:
+
+| property | description |
 |-----------|-------------|
 | `name` (string) | Name of the current test |
 | `module` (string) | Name of the current module |
@@ -30,13 +32,13 @@ Register a callback to fire whenever a test ends. The callback can return a prom
 | `skipped` (boolean) | Indicates whether or not the current test was skipped |
 | `todo` (boolean) | Indicates whether or not the current test was a todo |
 
-### Example
+### Examples
 
-Register a callback that logs results of a single test
+Register a callback that logs results of a single test:
 
 ```js
-QUnit.testDone( function( details ) {
-  var result = {
+QUnit.testDone( details => {
+  const result = {
     "Module name": details.module,
     "Test name": details.name,
     "Assertions": {
@@ -51,36 +53,4 @@ QUnit.testDone( function( details ) {
 
   console.log( JSON.stringify( result, null, 2 ) );
 } );
-```
-
-Using modern syntax:
-
-```js
-QUnit.testDone( ( { module, name, total, passed, failed, skipped, todo, runtime } ) => {
-  var result = {
-    "Module name": module,
-    "Test name": name,
-    "Assertions": {
-      "Total": total,
-      "Passed": passed,
-      "Failed": failed
-    },
-    "Skipped": skipped,
-    "Todo": todo,
-    "Runtime": runtime
-  };
-
-  console.log( JSON.stringify( result, null, 2 ) );
-} );
-```
-
-Returning a promise:
-
-```js
-QUnit.testDone( () => {
-  return new Promise(function(resolve, reject) {
-    // do some async work
-    resolve();
-  });
-});
 ```

--- a/docs/callbacks/QUnit.testStart.md
+++ b/docs/callbacks/QUnit.testStart.md
@@ -11,46 +11,29 @@ version_added: "1.0"
 
 `QUnit.testStart( callback )`
 
-Register a callback to fire whenever a test begins. The callback can return a promise that will be waited for before the next callback is handled.
+Register a callback to fire whenever a test begins. The callback may be an async function, or a function that return a promise which will be waited for before the next callback is handled.
 
 | parameter | description |
 |-----------|-------------|
-| callback (function) | Callback to execute. Provides a single argument with the callback details object |
+| callback (function) | Callback to execute. Provides a single argument with the callback Details object |
 
-#### Callback details: `callback( details: { name, module, testId, previousFailure } )`
+##### Details object
 
-| parameter | description |
+Passed to the callback:
+
+| property | description |
 |-----------|-------------|
 | `name` (string) | Name of the next test to run |
 | `module` (string) | Name of the current module |
 | `testId` (string) | Id of the next test to run |
 | `previousFailure` (boolean) | Whether the next test failed on a previous run |
 
-### Example
+### Examples
 
-Register a callback that logs the module and name
-
-```js
-QUnit.testStart(function( details ) {
-  console.log( "Now running: ", details.module, details.name );
-});
-```
-
-Using modern syntax:
+Register a callback that logs the module and test name:
 
 ```js
-QUnit.testStart( ( { module, name } ) => {
-  console.log( `Now running: ${module}: ${name}` );
-});
-```
-
-Returning a promise:
-
-```js
-QUnit.testStart( () => {
-  return new Promise(function(resolve, reject) {
-    // do some async work
-    resolve();
-  });
+QUnit.testStart( details => {
+  console.log( `Now running: ${details.module} ${details.name}` );
 });
 ```

--- a/docs/config/QUnit.assert.md
+++ b/docs/config/QUnit.assert.md
@@ -1,24 +1,14 @@
 ---
 layout: default
 title: QUnit.assert
-excerpt: Namespace for QUnit assertions.
+excerpt: Namespace for QUnit assertion methods.
 categories:
   - config
 version_added: "1.7"
 ---
 
-Namespace for QUnit assertions.
+Namespace for QUnit assertion methods. This object is the prototype for the internal Assert class of which instances are passed as the argument to [`QUnit.test()`](../QUnit/test.md) callbacks.
 
-QUnit's built-in assertions are defined on the `QUnit.assert` object. An instance of this object is passed as the only argument to the `QUnit.test` function callback.
+This object contains QUnit's [built-in assertion methods](../assert/index.md), and may be extended by plugins to register additional assertion methods.
 
-This object has properties for each of [QUnit's built-in assertion methods](../assert/index.md).
-
-### Example
-
-Use the `true` assertion through the test callback parameter:
-
-```js
-QUnit.test( "`true` assertion defined in the callback parameter", function( assert ) {
-  assert.true( true, "on the object passed to the `test` function" );
-});
-```
+See [`assert.pushResult()`](../assert/pushResult.md) for how to create a custom assertion.

--- a/docs/config/QUnit.extend.md
+++ b/docs/config/QUnit.extend.md
@@ -23,13 +23,13 @@ Copy the properties defined by the `mixin` object into the `target` object
 
 This method will modify the `target` object to contain the "own" properties defined by the `mixin`. If the `mixin` object specifies the value of any attribute as `undefined`, this property will instead be removed from the `target` object.
 
-### Example
+### Examples
 
 Use `QUnit.extend` to merge two objects.
 
 ```js
-QUnit.test( "QUnit.extend", function( assert ) {
-  var base = {
+QUnit.test( "QUnit.extend", assert => {
+  const base = {
     a: 1,
     b: 2,
     z: 3

--- a/docs/config/QUnit.stack.md
+++ b/docs/config/QUnit.stack.md
@@ -22,7 +22,7 @@ Not all [browsers support retrieving stracktraces][browsers]. In those, `QUnit.s
 
 [browsers]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack#Browser_compatibility
 
-### Example
+### Examples
 
 The stacktrace line can be used on custom assertions and reporters. The following example [logs](../callbacks/QUnit.log.md) the line of each passing assertion.
 
@@ -35,7 +35,7 @@ QUnit.log( function( details ) {
   }
 } );
 
-QUnit.test( "foo", function( assert ) {
+QUnit.test( "foo", assert => {
 
   // the log callback will report the position of the following line.
   assert.true( true );

--- a/src/assert.js
+++ b/src/assert.js
@@ -477,7 +477,7 @@ Assert.prototype.raises = Assert.prototype[ "throws" ];
  * Converts an error into a simple string for comparisons.
  *
  * @param {Error|Object} error
- * @return {String}
+ * @return {string}
  */
 function errorString( error ) {
 	const resultErrorString = error.toString();

--- a/src/core/processing-queue.js
+++ b/src/core/processing-queue.js
@@ -102,7 +102,7 @@ function addToTaskQueue( tasksArray ) {
 
 /**
  * Return the number of tasks remaining in the task queue to be processed.
- * @return {Number}
+ * @return {number}
  */
 function taskQueueLength() {
 	return taskQueue.length;
@@ -111,8 +111,8 @@ function taskQueueLength() {
 /**
  * Adds a test to the TestQueue for execution.
  * @param {Function} testTasksFunc
- * @param {Boolean} prioritize
- * @param {String} seed
+ * @param {boolean} prioritize
+ * @param {string} seed
  */
 function addToTestQueue( testTasksFunc, prioritize, seed ) {
 	if ( prioritize ) {

--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -60,7 +60,7 @@ export function diff( a, b ) {
  * @method inArray
  * @param {Any} elem
  * @param {Array} array
- * @return {Boolean}
+ * @return {boolean}
  */
 export function inArray( elem, array ) {
 	return array.indexOf( elem ) !== -1;

--- a/src/events.js
+++ b/src/events.js
@@ -19,9 +19,9 @@ const SUPPORTED_EVENTS = [
  *
  * @private
  * @method emit
- * @param {String} eventName
+ * @param {string} eventName
  * @param {Object} data
- * @return {Void}
+ * @return {void}
  */
 export function emit( eventName, data ) {
 	if ( objectType( eventName ) !== "string" ) {
@@ -42,9 +42,9 @@ export function emit( eventName, data ) {
  *
  * @public
  * @method on
- * @param {String} eventName
+ * @param {string} eventName
  * @param {Function} callback
- * @return {Void}
+ * @return {void}
  */
 export function on( eventName, callback ) {
 	if ( objectType( eventName ) !== "string" ) {


### PR DESCRIPTION
* Use modern syntax by default.
  Keep a few alternative "classic ES5 syntax" examples, explicitly described as such.

* Consistent parameter naming test formatting.

* Make the examples for `assert.timeout`, `assert.async`, `assert.verifySteps`, and `assert.pushResult` more appealing by replacing them with something that seems more reflecting of current best practices.

* Point out that callback methods support async functions.