### PR TITLE
Assert: Fix assert.timeout() bug causing a non-async test to fail

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -25,6 +25,7 @@ class Assert {
 		// If a timeout has been set, clear it and reset with the new duration
 		if ( config.timeout ) {
 			clearTimeout( config.timeout );
+			config.timeout = null;
 
 			if ( config.timeoutHandler && this.test.timeout > 0 ) {
 				resetTestTimeout( this.test.timeout );

--- a/src/test.js
+++ b/src/test.js
@@ -760,9 +760,9 @@ export function internalStop( test ) {
 		}
 
 		if ( typeof timeoutDuration === "number" && timeoutDuration > 0 ) {
-			clearTimeout( config.timeout );
 			config.timeoutHandler = function( timeout ) {
 				return function() {
+					config.timeout = null;
 					pushFailure(
 						`Test took longer than ${timeout}ms; test timed out.`,
 						sourceFromStacktrace( 2 )
@@ -771,6 +771,7 @@ export function internalStop( test ) {
 					internalRecover( test );
 				};
 			};
+			clearTimeout( config.timeout );
 			config.timeout = setTimeout(
 				config.timeoutHandler( timeoutDuration ),
 				timeoutDuration
@@ -827,17 +828,14 @@ function internalStart( test ) {
 
 	// Add a slight delay to allow more assertions etc.
 	if ( setTimeout ) {
-		if ( config.timeout ) {
-			clearTimeout( config.timeout );
-		}
+		clearTimeout( config.timeout );
 		config.timeout = setTimeout( function() {
 			if ( test.semaphore > 0 ) {
 				return;
 			}
 
-			if ( config.timeout ) {
-				clearTimeout( config.timeout );
-			}
+			clearTimeout( config.timeout );
+			config.timeout = null;
 
 			begin();
 		} );


### PR DESCRIPTION
For an async test, we normally remember the assigned timeout amount, and the actual scheduling and enforcement of the timeout doesn't happen until after the test callback returns.

If the test doesn't happen to be asynchronous, then the amount is discarded and we simply move on to the next test.

Sometimes, the timeout ID stored in `config.timeout` for a previous async test would remain and thus caused `assert.timeout()` to wrongly think it was called twice in the same test, and tries clear and reschedule it, when actually it is clearing nothing and scheduling the first timeout and doing so before the test callback has returned.

Thus when the test is over and we "ignore" the timeout, QUnit then got confused thinking it's an async test and thus waits until it times out.

Fix this by making sure `config.timeout` is always explicitly emptied (or re-assigned) when a timeout is cancelled or has completed.

Fixes https://github.com/qunitjs/qunit/issues/1539.