### PR TITLE
Build: Use qunit/ during development instead of dist/

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,8 +36,8 @@
         "__codeorigin/**",
         "coverage/**",
         "docs/_site/**",
-        "dist/**",
         "lib/**",
+        "qunit/**",
         "temp/**"
     ],
     "overrides": [

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 /.nyc_output
 /__codeorigin
 /coverage
-/dist
 /node_modules
-/browserstack-run.pid
+/qunit
 /temp
 /docs/_site/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function( grunt ) {
 
 			"src-css": {
 				src: "src/qunit.css",
-				dest: "dist/qunit.css"
+				dest: "qunit/qunit.css"
 			}
 		},
 		eslint: {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -89,11 +89,6 @@ This guide walks you through the QUnit release.
    npm run build
    ```
 
-   * Rename `dist/` to `qunit/`:
-   ```
-   mv dist/ qunit/
-   ```
-
    * Review the changes to the package and library files, compared to the previous release.
    ```
    node build/review-package.js @LAST_VERSION

--- a/build/tasks/test-on-node.js
+++ b/build/tasks/test-on-node.js
@@ -18,7 +18,7 @@ module.exports = function( grunt ) {
 		}
 
 		// Refresh the QUnit global to be used in other tests
-		global.QUnit = requireFresh( "../../dist/qunit" );
+		global.QUnit = requireFresh( "../../qunit/qunit.js" );
 
 		done( !totals.failed );
 	} );
@@ -33,7 +33,7 @@ module.exports = function( grunt ) {
 
 		// Resolve current QUnit path and remove it from the require cache
 		// to avoid stacking the QUnit logs.
-		var QUnit = requireFresh( "../../dist/qunit" );
+		var QUnit = requireFresh( "../../qunit/qunit.js" );
 
 		// Expose QUnit to the global scope to be seen on the other tests.
 		global.QUnit = QUnit;

--- a/package.json
+++ b/package.json
@@ -91,13 +91,13 @@
     "authors": "grunt authors",
     "coverage": "npm run build:coverage && npm run coverage:_cli && npm run coverage:_main && nyc report",
     "coverage:_cli": "nyc --use-spawn-wrap --silent bin/qunit.js test/cli/*.js",
-    "coverage:_main": "nyc instrument --in-place dist/ && grunt connect:nolivereload qunit",
+    "coverage:_main": "nyc instrument --in-place qunit/ && grunt connect:nolivereload qunit",
     "coveralls": "npm run coverage && cat coverage/lcov.info | coveralls"
   },
   "nyc": {
     "include": [
       "bin/**",
-      "dist/**",
+      "qunit/**",
       "src/**"
     ],
     "reporter": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,7 @@ const isCoverage = process.env.BUILD_TARGET === "coverage";
 module.exports = {
 	input: "src/qunit.js",
 	output: {
-		file: "dist/qunit.js",
+		file: "qunit/qunit.js",
 		sourcemap: isCoverage,
 		format: "iife",
 		exports: "none",

--- a/src/cli/require-qunit.js
+++ b/src/cli/require-qunit.js
@@ -3,7 +3,19 @@
 module.exports = function requireQUnit( resolve = require.resolve ) {
 	try {
 
-		// First we attempt to find QUnit relative to the current working directory.
+		// For:
+		//
+		// - QUnit is installed as local dependency and invoked normally
+		//   within the current project, e.g. via `npm test`, `npm run …`,
+		//   or `node_modules/.bin/qunit`.
+		//   The below will lead to the same package directory that
+		//   the CLI command belonged to.
+		//
+		// - QUnit is installed both as local dependency in the current project,
+		//   and also globally installed via npm by the end-user.
+		//   If the user (accidentally) ran the CLI command from their global
+		//   install, then we prefer to stil use the qunit library file from the
+		//   current project's dependency.
 		// eslint-disable-next-line node/no-missing-require
 		const localQUnitPath = resolve( "qunit", {
 
@@ -14,24 +26,25 @@ module.exports = function requireQUnit( resolve = require.resolve ) {
 		delete require.cache[ localQUnitPath ];
 		return require( localQUnitPath );
 	} catch ( e ) {
-		try {
+		if ( e.code === "MODULE_NOT_FOUND" ) {
 
-			// Second, we use the globally installed QUnit
-			// eslint-disable-next-line node/no-unpublished-require, node/no-missing-require
+			// For:
+			//
+			// - QUnit is installed globally via npm by the end-user, and the
+			//   the user ran this global CLI command in a project directory that
+			//   does not have a qunit dependency installed.
+			//   Use the library file relative to the global CLI command in that case.
+			//
+			// - We are running a local command from within the source directory
+			//   of the QUnit project itself (e.g. qunit Git repository).
+			//   Use the library file relative to this command, within the source directory.
+			//
+			// eslint-disable-next-line node/no-missing-require, node/no-unpublished-require
 			delete require.cache[ resolve( "../../qunit/qunit" ) ];
 			// eslint-disable-next-line node/no-missing-require, node/no-unpublished-require
 			return require( "../../qunit/qunit" );
-		} catch ( e ) {
-			if ( e.code === "MODULE_NOT_FOUND" ) {
-
-				// Finally, we use the local development version of QUnit
-				// eslint-disable-next-line node/no-unpublished-require, node/no-missing-require
-				delete require.cache[ resolve( "../../dist/qunit" ) ];
-				// eslint-disable-next-line node/no-missing-require, node/no-unpublished-require
-				return require( "../../dist/qunit" );
-			}
-
-			throw e;
 		}
+
+		throw e;
 	}
 };

--- a/test/amd.html
+++ b/test/amd.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit AMD Test Suite</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
+	<link rel="stylesheet" href="../qunit/qunit.css">
 	<script src="../node_modules/requirejs/require.js"></script>
 </head>
 <body>
@@ -13,7 +13,7 @@
 
 	require.config( {
 		paths: {
-			qunit: "../dist/qunit"
+			qunit: "../qunit/qunit"
 		}
 	} );
 

--- a/test/autostart.html
+++ b/test/autostart.html
@@ -3,11 +3,11 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Autostart Test Suite</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
+	<link rel="stylesheet" href="../qunit/qunit.css">
 </head>
 <body>
 	<div id="qunit"></div>
-	<script src="../dist/qunit.js"></script>
+	<script src="../qunit/qunit.js"></script>
 	<script>
 	window.times = {};
 

--- a/test/callbacks-promises.html
+++ b/test/callbacks-promises.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Callbacks Test Suite</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
-	<script src="../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
 	<script src="callbacks-promises.js"></script>
 </head>
 <body>

--- a/test/callbacks.html
+++ b/test/callbacks.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Callbacks Test Suite</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
-	<script src="../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
 	<script src="callbacks.js"></script>
 </head>
 <body>

--- a/test/cli/require-qunit-test.js
+++ b/test/cli/require-qunit-test.js
@@ -14,43 +14,30 @@ QUnit.module( "requireQUnit", function( hooks ) {
 		process.chdir( cwd );
 	} );
 
-	QUnit.test( "finds QUnit in the current working directory", function( assert ) {
+	QUnit.test( "finds QUnit package in the current working directory", function( assert ) {
 		const requireQUnit = require( "../../src/cli/require-qunit" );
 		process.chdir( path.join( __dirname, "./fixtures/require-from-cwd" ) );
 
 		assert.propEqual( requireQUnit(), { version: "from-cwd" } );
 	} );
 
-	QUnit.test( "finds globally installed QUnit", function( assert ) {
+	// For development mode invoked locally,
+	// or for global install without local dependency installed.
+	QUnit.test( "finds relative self", function( assert ) {
 		const globalQUnit = {
 			"version": "from-global"
 		};
 		const requireQUnit = proxyquire( "../../src/cli/require-qunit", {
 			"qunit": null,
-			"../../dist/qunit": null,
 			"../../qunit/qunit": globalQUnit
 		} );
 		assert.strictEqual( requireQUnit( resolveStub ), globalQUnit );
 	} );
 
-	QUnit.test( "finds development mode QUnit", function( assert ) {
-		const devQUnit = {
-			"version": "from-dist"
-		};
-		const requireQUnit = proxyquire( "../../src/cli/require-qunit", {
-			"qunit": null,
-			"../../qunit/qunit": null,
-			"../../dist/qunit": devQUnit
-		} );
-
-		assert.strictEqual( requireQUnit( resolveStub ), devQUnit );
-	} );
-
 	QUnit.test( "throws error if none of the modules are found", function( assert ) {
 		const requireQUnit = proxyquire( "../../src/cli/require-qunit", {
 			"qunit": null,
-			"../../qunit/qunit": null,
-			"../../dist/qunit": null
+			"../../qunit/qunit": null
 		} );
 
 		assert.throws( requireQUnit, /Cannot find module/ );

--- a/test/events-filters.html
+++ b/test/events-filters.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>Events Filters</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
-	<script src="../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
 	<script src="events-filters.js"></script>
 </head>
 <body>

--- a/test/events-in-test.html
+++ b/test/events-in-test.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Events During Tests</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
-	<script src="../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
 	<script src="events-in-test.js"></script>
 </head>
 <body>

--- a/test/events.html
+++ b/test/events.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Events Test Suite</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
-	<script src="../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
 	<script src="events.js"></script>
 </head>
 <body>

--- a/test/headless.html
+++ b/test/headless.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Headless Test Suite</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
-	<script src="../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
 	<script src="main/test.js"></script>
 	<script src="main/deepEqual.js"></script>
 	<script>

--- a/test/index.html
+++ b/test/index.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Main Test Suite</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
-	<script src="../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
 	<script src="main/test.js"></script>
 	<script src="main/assert.js"></script>
 	<script src="main/assert/step.js"></script>

--- a/test/logs.html
+++ b/test/logs.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Logs Test Suite</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
-	<script src="../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
 	<script src="logs.js"></script>
 </head>
 <body>

--- a/test/main/stack.js
+++ b/test/main/stack.js
@@ -8,7 +8,7 @@
 		assert.true( /(\/|\\)test(\/|\\)main(\/|\\)stack\.js/.test( stack ) );
 
 		stack = QUnit.stack( 2 );
-		assert.true( /(\/|\\)dist(\/|\\)qunit\.js/.test( stack ), "can use offset argument to return a different stacktrace line" );
+		assert.true( /(\/|\\)qunit(\/|\\)qunit\.js/.test( stack ), "can use offset argument to return a different stacktrace line" );
 		assert.false( /\/test\/main\/stack\.js/.test( stack ), "stack with offset argument" );
 	} );
 }() );

--- a/test/module-filter.html
+++ b/test/module-filter.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <title>QUnit Module Filter Test Suite</title>
-    <link rel="stylesheet" href="../dist/qunit.css">
-    <script src="../dist/qunit.js"></script>
+    <link rel="stylesheet" href="../qunit/qunit.css">
+    <script src="../qunit/qunit.js"></script>
     <script src="module-filter.js"></script>
   </head>
   <body>

--- a/test/module-skip.html
+++ b/test/module-skip.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>QUnit module Test Suite</title>
-		<link rel="stylesheet" href="../dist/qunit.css">
-		<script src="../dist/qunit.js"></script>
+		<link rel="stylesheet" href="../qunit/qunit.css">
+		<script src="../qunit/qunit.js"></script>
 		<script src="module-skip.js"></script>
 	</head>
 	<body>

--- a/test/module-todo.html
+++ b/test/module-todo.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>QUnit module Test Suite</title>
-		<link rel="stylesheet" href="../dist/qunit.css">
-		<script src="../dist/qunit.js"></script>
+		<link rel="stylesheet" href="../qunit/qunit.css">
+		<script src="../qunit/qunit.js"></script>
 		<script src="module-todo.js"></script>
 	</head>
 	<body>

--- a/test/moduleId.html
+++ b/test/moduleId.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>QUnit ModuleId Test Suite</title>
-		<link rel="stylesheet" href="../dist/qunit.css">
-		<script src="../dist/qunit.js"></script>
+		<link rel="stylesheet" href="../qunit/qunit.css">
+		<script src="../qunit/qunit.js"></script>
 		<script src="moduleId.js"></script>
 	</head>
 	<body>

--- a/test/mozjs.js
+++ b/test/mozjs.js
@@ -2,7 +2,7 @@
 /* eslint-disable lines-around-comment */
 /* global loadRelativeToScript */
 
-loadRelativeToScript( "../dist/qunit.js" );
+loadRelativeToScript( "../qunit/qunit.js" );
 
 QUnit.on( "runStart", () => {
 	print( "Running tests..." );

--- a/test/onerror/inside-test.html
+++ b/test/onerror/inside-test.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>QUnit onerror tests</title>
-		<link rel="stylesheet" href="../../dist/qunit.css">
-		<script src="../../dist/qunit.js"></script>
+		<link rel="stylesheet" href="../../qunit/qunit.css">
+		<script src="../../qunit/qunit.js"></script>
 		<script src="./inside-test.js"></script>
 	</head>
 	<body>

--- a/test/onerror/outside-test.html
+++ b/test/onerror/outside-test.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>QUnit onerror tests</title>
-		<link rel="stylesheet" href="../../dist/qunit.css">
-		<script src="../../dist/qunit.js"></script>
+		<link rel="stylesheet" href="../../qunit/qunit.css">
+		<script src="../../qunit/qunit.js"></script>
 		<script src="./outside-test.js"></script>
 	</head>
 	<body>

--- a/test/overload.html
+++ b/test/overload.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>QUnit Only Test Suite</title>
-		<link rel="stylesheet" href="../dist/qunit.css">
-		<script src="../dist/qunit.js"></script>
+		<link rel="stylesheet" href="../qunit/qunit.css">
+		<script src="../qunit/qunit.js"></script>
 		<script>
 			window.onerror = function( error ) {
 				QUnit.module( "Overload", function() {
@@ -16,7 +16,7 @@
 				return false;
 			};
 		</script>
-		<script src="../dist/qunit.js"></script>
+		<script src="../qunit/qunit.js"></script>
 	</head>
 	<body>
 		<div id="qunit"></div>

--- a/test/performance-mark.html
+++ b/test/performance-mark.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>QUnit Performance Test Suite</title>
-		<link rel="stylesheet" href="../dist/qunit.css">
-		<script src="../dist/qunit.js"></script>
+		<link rel="stylesheet" href="../qunit/qunit.css">
+		<script src="../qunit/qunit.js"></script>
 		<script src="performance-mark.js"></script>
 	</head>
 	<body>

--- a/test/preconfigured.html
+++ b/test/preconfigured.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Preconfigured Test Suite</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
+	<link rel="stylesheet" href="../qunit/qunit.css">
 	<script>
 		window.QUnit = {
 			config: {
@@ -12,7 +12,7 @@
 			}
 		};
 	</script>
-	<script src="../dist/qunit.js"></script>
+	<script src="../qunit/qunit.js"></script>
 	<script src="preconfigured.js"></script>
 </head>
 <body>

--- a/test/regex-exclude-filter.html
+++ b/test/regex-exclude-filter.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>QUnit Regex Exclude Filtering Test Suite</title>
-		<link rel="stylesheet" href="../dist/qunit.css">
-		<script src="../dist/qunit.js"></script>
+		<link rel="stylesheet" href="../qunit/qunit.css">
+		<script src="../qunit/qunit.js"></script>
 		<script src="regex-exclude-filter.js"></script>
 	</head>
 	<body>

--- a/test/regex-filter.html
+++ b/test/regex-filter.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>QUnit Regex Filtering Test Suite</title>
-		<link rel="stylesheet" href="../dist/qunit.css">
-		<script src="../dist/qunit.js"></script>
+		<link rel="stylesheet" href="../qunit/qunit.css">
+		<script src="../qunit/qunit.js"></script>
 		<script src="regex-filter.js"></script>
 	</head>
 	<body>

--- a/test/reorder.html
+++ b/test/reorder.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Reordering Functionality Works in Browser</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
-	<script src="../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
 	<script src="reorder.js"></script>
 </head>
 <body>

--- a/test/reorderError1.html
+++ b/test/reorderError1.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit - Asserts it does not skip tests after reordering</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
-	<script src="../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
 	<script>
 
 	// Ref #907
@@ -46,7 +46,7 @@
 		This new QUnit load could be replaced by an async call, but the grunt qunit
 		relies on QUnit loaded below and ignores the previously failed results.
 	-->
-	<script src="../dist/qunit.js"></script>
+	<script src="../qunit/qunit.js"></script>
 	<script src="reorderError1.js"></script>
 </head>
 <body>

--- a/test/reorderError2.html
+++ b/test/reorderError2.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit - Asserts it does not skip tests after reordering</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
-	<script src="../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
 	<script>
 
 	// Ref #907
@@ -43,7 +43,7 @@
 		This new QUnit load could be replaced by an async call, but the grunt qunit
 		relies on QUnit loaded below and ignores the previously failed results.
 	-->
-	<script src="../dist/qunit.js"></script>
+	<script src="../qunit/qunit.js"></script>
 	<script src="reorderError2.js"></script>
 </head>
 <body>

--- a/test/reporter-html/legacy-markup.html
+++ b/test/reporter-html/legacy-markup.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit HTML Reporter - Legacy Markup</title>
-	<link rel="stylesheet" href="../../dist/qunit.css">
-	<script src="../../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../../qunit/qunit.css">
+	<script src="../../qunit/qunit.js"></script>
 	<script src="reporter-html.js"></script>
 </head>
 <body>

--- a/test/reporter-html/no-qunit-element.html
+++ b/test/reporter-html/no-qunit-element.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit HTML Reporter - No Markup</title>
-	<link rel="stylesheet" href="../../dist/qunit.css">
-	<script src="../../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../../qunit/qunit.css">
+	<script src="../../qunit/qunit.js"></script>
 	<script>
 		var time = setTimeout( function() {
 			console.error( "timeout error with no QUnit markup" );

--- a/test/reporter-html/single-testid.html
+++ b/test/reporter-html/single-testid.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Main Test Suite</title>
-	<link rel="stylesheet" href="../../dist/qunit.css">
-	<script src="../../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../../qunit/qunit.css">
+	<script src="../../qunit/qunit.js"></script>
 	<script src="single-testid.js"></script>
 </head>
 <body>

--- a/test/reporter-html/window-onerror-preexisting-handler.html
+++ b/test/reporter-html/window-onerror-preexisting-handler.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit HTML Reporter - window.onerror tests with preexisting handler</title>
-	<link rel="stylesheet" href="../../dist/qunit.css">
+	<link rel="stylesheet" href="../../qunit/qunit.css">
 	<script>
 		/* exported onerrorCallingContext */
 		var onerrorReturnValue, onerrorCallingContext;
@@ -15,7 +15,7 @@
 		};
 
 	</script>
-	<script src="../../dist/qunit.js"></script>
+	<script src="../../qunit/qunit.js"></script>
 	<script src="./window-onerror-preexisting-handler.js"></script>
 </head>
 <body>

--- a/test/reporter-html/window-onerror.html
+++ b/test/reporter-html/window-onerror.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit HTML Reporter - window.onerror tests with no existing handler</title>
-	<link rel="stylesheet" href="../../dist/qunit.css">
-	<script src="../../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../../qunit/qunit.css">
+	<script src="../../qunit/qunit.js"></script>
 	<script src="./window-onerror.js"></script>
 </head>
 <body>

--- a/test/reporter-html/xhtml-escape-details-source.xhtml
+++ b/test/reporter-html/xhtml-escape-details-source.xhtml
@@ -4,8 +4,8 @@
 <head>
 	<meta charset="UTF-8" />
 	<title>QUnit Main Test Suite</title>
-	<link rel="stylesheet" href="../../dist/qunit.css" />
-	<script src="../../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../../qunit/qunit.css" />
+	<script src="../../qunit/qunit.js"></script>
 	<script src="test-escape-details-source.js"></script>
 </head>
 <body>

--- a/test/reporter-html/xhtml-single-testid.xhtml
+++ b/test/reporter-html/xhtml-single-testid.xhtml
@@ -4,8 +4,8 @@
 <head>
 	<meta charset="UTF-8" />
 	<title>QUnit Main Test Suite</title>
-	<link rel="stylesheet" href="../../dist/qunit.css" />
-	<script src="../../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../../qunit/qunit.css" />
+	<script src="../../qunit/qunit.js"></script>
 	<script src="single-testid.js"></script>
 </head>
 <body>

--- a/test/reporter-urlparams-hidepassed.html
+++ b/test/reporter-urlparams-hidepassed.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>QUnit URL Parameters Test Suite</title>
-		<link rel="stylesheet" href="../dist/qunit.css">
-		<script src="../dist/qunit.js"></script>
+		<link rel="stylesheet" href="../qunit/qunit.css">
+		<script src="../qunit/qunit.js"></script>
 		<script src="reporter-urlparams-hidepassed.js"></script>
 	</head>
 	<body>

--- a/test/reporter-urlparams.html
+++ b/test/reporter-urlparams.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>QUnit URL Parameters Test Suite</title>
-		<link rel="stylesheet" href="../dist/qunit.css">
-		<script src="../dist/qunit.js"></script>
+		<link rel="stylesheet" href="../qunit/qunit.css">
+		<script src="../qunit/qunit.js"></script>
 		<script src="reporter-urlparams.js"></script>
 	</head>
 	<body>

--- a/test/sandboxed-iframe-contents.html
+++ b/test/sandboxed-iframe-contents.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>QUnit in Sandboxed Iframe Test Suite - Inside Iframe</title>
-		<link rel="stylesheet" href="../dist/qunit.css">
-		<script src="../dist/qunit.js"></script>
+		<link rel="stylesheet" href="../qunit/qunit.css">
+		<script src="../qunit/qunit.js"></script>
 		<script src="sandboxed-iframe.js"></script>
 		<script src="../node_modules/grunt-contrib-qunit/chrome/bridge.js"></script>
 	</head>

--- a/test/seed.html
+++ b/test/seed.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <title>QUnit Randomization Test Suite</title>
-    <link rel="stylesheet" href="../dist/qunit.css">
-    <script src="../dist/qunit.js"></script>
+    <link rel="stylesheet" href="../qunit/qunit.css">
+    <script src="../qunit/qunit.js"></script>
     <script src="seed.js"></script>
   </head>
   <body>

--- a/test/stack-errors.html
+++ b/test/stack-errors.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Main Test Suite</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
-	<script src="../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
 	<script src="stack-errors.js"></script>
 </head>
 <body>

--- a/test/startError.html
+++ b/test/startError.html
@@ -3,11 +3,11 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Start Error Test Suite</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
+	<link rel="stylesheet" href="../qunit/qunit.css">
 </head>
 <body>
 	<div id="qunit"></div>
-	<script src="../dist/qunit.js"></script>
+	<script src="../qunit/qunit.js"></script>
 	<script src="startError.js"></script>
 </body>
 </html>

--- a/test/string-filter.html
+++ b/test/string-filter.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>QUnit String Filtering Test Suite</title>
-		<link rel="stylesheet" href="../dist/qunit.css">
-		<script src="../dist/qunit.js"></script>
+		<link rel="stylesheet" href="../qunit/qunit.css">
+		<script src="../qunit/qunit.js"></script>
 		<script src="string-filter.js"></script>
 	</head>
 	<body>

--- a/test/webWorker-worker.js
+++ b/test/webWorker-worker.js
@@ -1,7 +1,7 @@
 /* global importScripts */
 /* eslint-env es6 */
 importScripts(
-	"../dist/qunit.js",
+	"../qunit/qunit.js",
 	"main/test.js",
 	"main/assert.js",
 	"main/assert/step.js",

--- a/test/webWorker.html
+++ b/test/webWorker.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>QUnit Web Worker Test Suite</title>
-	<link rel="stylesheet" href="../dist/qunit.css">
-	<script src="../dist/qunit.js"></script>
+	<link rel="stylesheet" href="../qunit/qunit.css">
+	<script src="../qunit/qunit.js"></script>
 	<script src="webWorker.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Use the same directory structure for the build artefact during releases and during development.

Since the release file path is used by published npm and bower packages, keep that as-is, and rename the internal development target from `dist/` to `qunit/`.

After this, contributors and maintainers will want to delete any `dist/` directory they might have, to avoid accidental linting or
publishing.

Fixes https://github.com/qunitjs/qunit/issues/1133.