### PR TITLE
Build: Avoid non-deterministic timestamp in published builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 <img src="/docs/img/QUnit-Logo-Large.png" width="250" height="auto">
 
 [![Build Status](https://travis-ci.com/qunitjs/qunit.svg?branch=master)](https://travis-ci.com/qunitjs/qunit)
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fqunitjs%2Fqunit.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fqunitjs%2Fqunit?ref=badge_shield)
+[![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-success?labelColor=1e5b96)](https://reproducible-builds.org/)
 [![Coverage Status](https://coveralls.io/repos/qunitjs/qunit/badge.svg)](https://coveralls.io/github/qunitjs/qunit)
 [![Chat on Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/qunitjs/qunit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fqunitjs%2Fqunit.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fqunitjs%2Fqunit?ref=badge_shield)
 [![npm](https://img.shields.io/npm/v/qunit.svg?style=flat)](https://www.npmjs.com/package/qunit)
 
 # [QUnit](https://qunitjs.com) - A JavaScript Unit Testing Framework.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -79,6 +79,7 @@ Prerequisites:
 
 4. Generate the release artifacts:
    ```
+   export SOURCE_DATE_EPOCH="$(git log -s --format=%at -1)"
    npm run build
    ```
 

--- a/build/dist-replace.js
+++ b/build/dist-replace.js
@@ -1,12 +1,37 @@
-// Used for JS files by rollup.config.js
-// Used for CSS files by Gruntfile.js via preprocess()
+// Helper used for JS files by rollup.config.js,
+// and for CSS files by Gruntfile.js via preprocess()
+
+const distVersion = require( "../package.json" ).version;
+
+let distEpoch;
+let distDate;
+if ( /pre/.test( distVersion ) ) {
+
+	// During development, insert a detailed timestamp.
+	//
+	// Format as 0000-00-00T00:00Z
+	distDate = ( new Date() ).toISOString().replace( /:\d+\.\d+Z$/, "Z" );
+} else {
+
+	// Release builds should be deterministic and reproducible.
+	// Use the date of the release prep commit via an environment variable
+	// See RELEASE.md and <https://reproducible-builds.org/docs/source-date-epoch/>.
+	//
+	// Format as 0000-00-00
+	distEpoch = process.env.SOURCE_DATE_EPOCH;
+	if ( !/^\d{7,}$/.test( distEpoch ) ) {
+		throw new Error( "SOURCE_DATE_EPOCH must be set to a UNIX timestamp" );
+	}
+	distDate = ( new Date( distEpoch * 1000 ) ).toISOString().replace( /T.+$/, "" );
+}
+
 const replacements = {
 
 	// Embed version
-	"@VERSION": require( "../package.json" ).version,
+	"@VERSION": distVersion,
 
-	// Embed date (yyyy-mm-ddThh:mmZ)
-	"@DATE": ( new Date() ).toISOString().replace( /:\d+\.\d+Z$/, "Z" )
+	// Embed date
+	"@DATE": distDate
 };
 
 function preprocess( code ) {


### PR DESCRIPTION
Make QUnit releases deterministic by embedding a known date instead of the "current" date and time.

Adopt the standard mechanism for this based on <https://reproducible-builds.org/docs/source-date-epoch/> which involves an environment variable named `SOURCE_DATE_EPOCH` set to a UNIX timestamp. This requires one line of code to then reformat to the ISO date were prefer, but this seems worth it.

In an earlier iteration on this patch, I had the Git CLI format it that way from the start, like so:

```
QUNIT_RELEASE_DATE="$(git show -s --format=%cd --date=short HEAD)"
# 2021-01-09
```

Instead, we use:

```
SOURCE_DATE_EPOCH="$(git log -s --format=%at -1)"
# 1610349865
```

... and dist-replace.js reformats it as needed.

Also add a badge to the README, inspired by <https://github.com/jvm-repo-rebuild/reproducible-central>, but with improved color contrast, using the same dark blue as for the reproducible-builds.org logo, and the same green as used for other "success" badges (e.g. CI, license check, etc.)

Fixes https://github.com/qunitjs/qunit/issues/1538.