### PR TITLE
Build: Add audit script for reviewing changes to build artifacts 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ jobs:
         - js68 test/mozjs.js
 
     - name: Code coverage
+      # https://docs.travis-ci.com/user/conditions-v1
+      if: (fork = false)
       node_js: "10"
       script: npm run coveralls
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,16 +32,6 @@ module.exports = function( grunt ) {
 				}
 			},
 
-			// For manual testing.
-			any: {
-				options: {
-					port: connectPort,
-					useAvailablePort: true,
-					keepalive: true,
-					base: "."
-				}
-			},
-
 			// For use by the "watch" task.
 			livereload: {
 				options: {

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://travis-ci.com/qunitjs/qunit.svg?branch=master)](https://travis-ci.com/qunitjs/qunit)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fqunitjs%2Fqunit.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fqunitjs%2Fqunit?ref=badge_shield)
-[![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-success?labelColor=1e5b96)](https://reproducible-builds.org/)
 [![Coverage Status](https://coveralls.io/repos/qunitjs/qunit/badge.svg)](https://coveralls.io/github/qunitjs/qunit)
+[![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-success?labelColor=1e5b96)](https://reproducible-builds.org/)
 [![Chat on Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/qunitjs/qunit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![npm](https://img.shields.io/npm/v/qunit.svg?style=flat)](https://www.npmjs.com/package/qunit)
 

--- a/build/prep-release.js
+++ b/build/prep-release.js
@@ -36,7 +36,7 @@ const Repo = {
 				"--format=* %s. (%aN)",
 				"--no-merges",
 				`${oldVersion}...HEAD`
-			], { encoding: "utf-8" } );
+			], { encoding: "utf8" } );
 
 			changes = changes
 				.trim()

--- a/build/review-package.js
+++ b/build/review-package.js
@@ -1,0 +1,116 @@
+// Helper for reviewing build artefacts against a past release.
+//
+// See also RELEASE.md.
+
+/* eslint-env node */
+
+const cp = require( "child_process" );
+const fs = require( "fs" );
+const https = require( "https" );
+const path = require( "path" );
+const readline = require( "readline" );
+
+function getDiff( from, to ) {
+
+	// macOS 10.15+ comes with GNU diff (2.8)
+	// https://unix.stackexchange.com/a/338960/37512
+	// https://stackoverflow.com/a/41770560/319266
+	const gnuDiffVersion = cp.execFileSync( "diff", [ "--version" ], { encoding: "utf8" } );
+	const versionStr = /diff.* (\d+\.\d+)/.exec( gnuDiffVersion );
+	const isOld = ( versionStr && Number( versionStr[ 1 ] ) < 3.4 );
+
+	try {
+		cp.execFileSync( "diff", [
+			"--text",
+			"--unified",
+			...( isOld ? [] : [ "--color=always" ] ),
+			from,
+			to
+		], { encoding: "utf8" } );
+	} catch ( e ) {
+
+		// Expected, `diff` command yields non-zero exit status if files differ
+		return e.stdout;
+	}
+	throw new Error( `Unable to diff between ${from} and ${to}` );
+}
+
+async function confirm( text ) {
+	const rl = readline.createInterface( { input: process.stdin, output: process.stdout } );
+	await new Promise( ( resolve, reject ) => {
+		rl.question( `${text} (y/N)> `, ( answer ) => {
+			rl.close();
+			if ( String( answer ).toLowerCase() === "y" ) {
+				resolve();
+			} else {
+				reject( new Error( "Audit aborted" ) );
+			}
+		} );
+	} );
+}
+
+async function download( url, dest ) {
+	const fileStr = fs.createWriteStream( dest );
+	await new Promise( ( resolve, reject ) => {
+		https.get( url, ( resp ) => {
+			resp.pipe( fileStr );
+			fileStr.on( "finish", () => fileStr.close( resolve ) );
+		} ).on( "error", ( err ) => reject( err ) );
+	} );
+}
+
+const ReleaseAssets = {
+	async audit( prevVersion ) {
+		if ( typeof prevVersion !== "string" || !/^\d+\.\d+\.\d+$/.test( prevVersion ) ) {
+			throw new Error( "Invalid or missing version argument" );
+		}
+		{
+			const file = "package.json";
+			console.log( `Auditing ${file}...` );
+
+			const prevContent = cp.execFileSync( "git", [
+				"show",
+				`${prevVersion}:package.json`
+			], { encoding: "utf8" } );
+			const tempPrevPath = path.join( __dirname, "../temp", file );
+			fs.writeFileSync( tempPrevPath, prevContent );
+
+			const currentPath = path.join( __dirname, "..", file );
+			process.stdout.write( getDiff( tempPrevPath, currentPath ) );
+			await confirm( `Accept ${file}?` );
+		}
+		{
+			const file = "qunit.js";
+			console.log( `Auditing ${file}...` );
+
+			const prevUrl = `https://code.jquery.com/qunit/qunit-${prevVersion}.js`;
+			const tempPrevPath = path.join( __dirname, "../temp", file );
+			await download( prevUrl, tempPrevPath );
+
+			const currentPath = path.join( __dirname, "../qunit", file );
+			process.stdout.write( getDiff( tempPrevPath, currentPath ) );
+			await confirm( `Accept ${file}?` );
+		}
+		{
+			const file = "qunit.css";
+			console.log( `Auditing ${file}...` );
+
+			const prevUrl = `https://code.jquery.com/qunit/qunit-${prevVersion}.css`;
+			const tempPrevPath = path.join( __dirname, "../temp", file );
+			await download( prevUrl, tempPrevPath );
+
+			const currentPath = path.join( __dirname, "../qunit", file );
+			process.stdout.write( getDiff( tempPrevPath, currentPath ) );
+			await confirm( `Accept ${file}?` );
+		}
+	}
+};
+
+const prevVersion = process.argv[ 2 ];
+
+( async function main() {
+	await ReleaseAssets.audit( prevVersion );
+}() ).catch( e => {
+	console.error( e.toString() );
+	process.exit( 1 );
+} );

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "test:main": "npm run build && grunt test",
     "test:cli": "npm run build && bin/qunit.js test/cli/*.js",
     "authors": "grunt authors",
-    "serve": "grunt connect:any",
     "coverage": "npm run build:coverage && npm run coverage:_cli && npm run coverage:_main && nyc report",
     "coverage:_cli": "nyc --use-spawn-wrap --silent bin/qunit.js test/cli/*.js",
     "coverage:_main": "nyc instrument --in-place dist/ && grunt connect:nolivereload qunit",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,7 +38,7 @@ module.exports = {
 			//    variables in an imported file would be).
 			return fs.readFileSync(
 				__dirname + "/src/html-reporter/es6-map.js",
-				"utf-8"
+				"utf8"
 			).toString().trim();
 		},
 

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -16,7 +16,7 @@ function existsStat() {
 function getIgnoreList( baseDir ) {
 	const gitFilePath = path.join( baseDir, ".gitignore" );
 	if ( fs.existsSync( gitFilePath ) ) {
-		const gitIgnore = fs.readFileSync( gitFilePath, "utf-8" );
+		const gitIgnore = fs.readFileSync( gitFilePath, "utf8" );
 		return gitIgnore.trim().split( "\n" );
 	}
 	return [];


### PR DESCRIPTION
* Automate the workflow I have been using for auditing the release artefacts prior to publication. This protects against mistakes or other accidents that may have gone unnnoticed (e.g. in how Rollup is configured, or what files we embed and distribute), as well as against any compromise or other malicious activity in the build chain (in one of the many unaudited dev dependencies we use from npm, or elsewhere).

* No longer recommend `npm run serve`. This can't easily be run in an isolated environment as it needs to expose a port. Unlike other build scripts, this involves unaudited dev dependencies. Recommend use of the built-in and dependency-free HTTP server from Python or PHP instead.

* Minor improvements throughout RELEASE.md, especially to simplify and consolidate related steps, and make the numbering continuous throughout the page (10 steps total, more or less).