### PR TITLE
Docs: Fix incomplete propEqual() example

### DIFF
--- a/docs/assert/notPropEqual.md
+++ b/docs/assert/notPropEqual.md
@@ -43,7 +43,6 @@ QUnit.test( "example", assert => {
   }
 
   const foo = new Foo();
-  const expected = ;
 
   // succeeds, only own property values are compared (using strict equality),
   // and propery "x" is indeed not equal (string instead of number).

--- a/docs/assert/propEqual.md
+++ b/docs/assert/propEqual.md
@@ -43,14 +43,13 @@ QUnit.test( "example", assert => {
   }
 
   const foo = new Foo();
-  const expected = {
-    x: 1,
-    y: 2
-  };
 
   // succeeds, own properties are strictly equal,
   // and inherited properties (such as which object constructor) are ignored.
-  assert.propEqual( foo,  );
+  assert.propEqual( foo, {
+    x: 1,
+    y: 2
+  } );
 });
 ```
 


### PR DESCRIPTION
Follows-up 9ab52becfdd, in which I made a small last-minute change after having reviewed the diff last, and in that change I caused some copy-paste mistakes behind.