### PR TITLE
Core: Run before and after hooks with module context

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -39,10 +39,10 @@ function createModule( name, testEnvironment, modifiers ) {
 		ignored: modifiers.ignored || false
 	};
 
-	const env = {};
+	let env = {};
 	if ( parentModule ) {
 		parentModule.childModules.push( module );
-		extend( env, parentModule.testEnvironment );
+		env = Object.create( parentModule.testEnvironment || {} );
 	}
 	extend( env, testEnvironment );
 	module.testEnvironment = env;

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -314,18 +314,18 @@ QUnit.module( "assert.async", function() {
 		} );
 	} );
 
+	var inAfterHookModuleState;
 	QUnit.module( "in after hook", {
 		after: function( assert ) {
-			assert.equal( this.state, "done", "called after test callback" );
+			assert.equal( inAfterHookModuleState, "done", "called after test callback" );
 			assert.true( true, "called before expected assert count is validated" );
 		}
 	}, function() {
 		QUnit.test( "call order", function( assert ) {
 			assert.expect( 2 );
-			var done = assert.async(),
-				testContext = this;
+			var done = assert.async();
 			setTimeout( function() {
-				testContext.state = "done";
+				inAfterHookModuleState = "done";
 				done();
 			} );
 		} );


### PR DESCRIPTION
The before and after hooks run once per module as long as there is at least one
test in the module. Using environment inheritance allows us to use the module
context in those hooks, which allows reading the expected changes to the
context from a before hook inside nested modules.

This is a breaking change and would need to be part of a major version bump.

Fixes #1328.
Ref #869.