### PR TITLE
HTML Reporter: Check for undefined `testItem` in testDone callback

### DIFF
--- a/src/html-reporter/html.js
+++ b/src/html-reporter/html.js
@@ -902,15 +902,14 @@ export function escapeText( s ) {
 	} );
 
 	QUnit.testDone( function( details ) {
-		var testTitle, time, testItem, assertList, status,
+		var testTitle, time, assertList, status,
 			good, bad, testCounts, skipped, sourceName,
-			tests = id( "qunit-tests" );
+			tests = id( "qunit-tests" ),
+			testItem = id( "qunit-test-output-" + details.testId );
 
-		if ( !tests ) {
+		if ( !tests || !testItem ) {
 			return;
 		}
-
-		testItem = id( "qunit-test-output-" + details.testId );
 
 		removeClass( testItem, "running" );
 


### PR DESCRIPTION
For added robustness, allow the DOM node to be missing at this point just in case.

Extracted from https://github.com/qunitjs/qunit/pull/1391.