### PR TITLE
Trim whitespace of filter input

### DIFF
--- a/src/html-reporter/html.js
+++ b/src/html-reporter/html.js
@@ -51,6 +51,15 @@ export function escapeText( s ) {
 		unfilteredUrl = setUrl( { filter: undefined, module: undefined,
 			moduleId: undefined, testId: undefined } );
 
+
+	function trim( string ) {
+		if ( typeof string.trim === "function" ) {
+			return string.trim();
+		} else {
+			return string.replace( /^\s+|\s+$/g, "" );
+		}
+	}
+
 	function addEvent( elem, type, fn ) {
 		elem.addEventListener( type, fn, false );
 	}
@@ -93,9 +102,7 @@ export function escapeText( s ) {
 		}
 
 		// Trim for prettiness
-		elem.className = typeof set.trim === "function" ?
-			set.trim() :
-			set.replace( /^\s+|\s+$/g, "" );
+		elem.className = trim( set );
 	}
 
 	function id( name ) {
@@ -113,6 +120,11 @@ export function escapeText( s ) {
 	}
 
 	function interceptNavigation( ev ) {
+
+		// Trim potential accidental whitespace so that QUnit doesn't throw an error about no tests matching the filter.
+		var filterInputElem = id( "qunit-filter-input" );
+		filterInputElem.value = trim( filterInputElem.value );
+
 		applyUrlParams();
 
 		if ( ev && ev.preventDefault ) {


### PR DESCRIPTION
Often when pasting in a filter string, a user may copy extra whitespace, causing QUnit to throw an error about no tests matching.

After looking through the tests, I'm not sure the best place to put a unit test. If the maintainers are interested in adding this functionality, I'll figure out the best place to add the test.
