### PR TITLE
CLI: Simplify internal find-reporter.js logic for js-reporters

### DIFF
--- a/src/cli/find-reporter.js
+++ b/src/cli/find-reporter.js
@@ -4,18 +4,20 @@ const JSReporters = require( "js-reporters" );
 const utils = require( "./utils" );
 const pkg = require( "../../package.json" );
 
+const hasOwn = Object.prototype.hasOwnProperty;
+const builtin = {
+	console: JSReporters.ConsoleReporter,
+	tap: JSReporters.TapReporter
+};
+
 function findReporter( reporterName ) {
 	if ( !reporterName ) {
 		return JSReporters.TapReporter;
 	}
 
 	// First, check if the reporter is one of the standard js-reporters ones
-
-	const capitalizedName = utils.capitalize( reporterName );
-	const jsReporterName = `${capitalizedName}Reporter`;
-
-	if ( JSReporters[ jsReporterName ] ) {
-		return JSReporters[ jsReporterName ];
+	if ( hasOwn.call( builtin, reporterName ) ) {
+		return builtin[ reporterName ];
 	}
 
 	// Second, check if the reporter is an npm package
@@ -38,26 +40,17 @@ function displayAvailableReporters( inputReporterName ) {
 		message.push( `No reporter found matching "${inputReporterName}".` );
 	}
 
-	const jsReporters = getReportersFromJSReporters();
-
-	message.push( `Available reporters from JS Reporters are: ${jsReporters.join( ", " )}` );
+	const jsReporters = Object.keys( builtin ).sort();
+	message.push( `Built-in reporters: ${jsReporters.join( ", " )}` );
 
 	const npmReporters = getReportersFromDependencies();
 	if ( npmReporters.length ) {
 		message.push(
-			`Available custom reporters from dependencies are: ${npmReporters.join( ", " )}`
+			`Extra reporters found among package dependencies: ${npmReporters.join( ", " )}`
 		);
 	}
 
 	utils.error( message.join( "\n" ) );
-}
-
-function getReportersFromJSReporters() {
-	const jsReporterRegex = /(.*)Reporter$/;
-	return Object.keys( JSReporters )
-		.filter( key => jsReporterRegex.test( key ) )
-		.map( reporter => reporter.match( jsReporterRegex )[ 1 ].toLowerCase() )
-		.sort();
 }
 
 function getReportersFromDependencies() {

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -96,12 +96,12 @@ ok 5 A-Test > derp
 
 	"qunit --reporter npm-reporter": "Run ended!",
 	"qunit --reporter does-not-exist": `No reporter found matching "does-not-exist".
-Available reporters from JS Reporters are: console, tap
-Available custom reporters from dependencies are: npm-reporter
+Built-in reporters: console, tap
+Extra reporters found among package dependencies: npm-reporter
 `,
 
-	"qunit --reporter": `Available reporters from JS Reporters are: console, tap
-Available custom reporters from dependencies are: npm-reporter
+	"qunit --reporter": `Built-in reporters: console, tap
+Extra reporters found among package dependencies: npm-reporter
 `,
 
 	/* eslint-disable max-len */


### PR DESCRIPTION
This is in prep for the js-reporters v2 release, which introduces a third reporter (SummaryReporter) that is for programmatic use only (it has no CLI output).