### PR TITLE
Tests: Update internal fixture to accomodate Node 15 source map traces

### DIFF
--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -172,7 +172,7 @@ not ok 2 Example > bad
   severity: failed
   actual  : false
   expected: true
-  stack:     at .* \\(.*source.js:7:14\\)
+  stack:     at Object.<anonymous> (/qunit/test/cli/fixtures/sourcemap/source.js:7:14)
   ...
 1..2
 # pass 1
@@ -189,8 +189,7 @@ not ok 2 Example > bad
   severity: failed
   actual  : false
   expected: true
-  stack:     at Object.<anonymous> (/qunit/test/cli/fixtures/sourcemap/source.min.js:1:133)
-        -> /qunit/test/cli/fixtures/sourcemap/sourcemap/source.js:7:10
+  stack:     at Object.<anonymous> (/qunit/test/cli/fixtures/sourcemap/sourcemap/source.js:7:10)
   ...
 1..2
 # pass 1

--- a/test/cli/helpers/execute.js
+++ b/test/cli/helpers/execute.js
@@ -14,6 +14,14 @@ function normalize( actual ) {
 	return actual
 		.replace( reDir, "/qunit" )
 		.replace( /(\/qunit\/qunit\/qunit\.js):\d+:\d+\)/g, "$1)" )
+
+		// convert sourcemap'ed traces from Node 14 and earlier to the
+		// standard format used by Node 15+.
+		// https://github.com/nodejs/node/commit/15804e0b3f
+		// https://github.com/nodejs/node/pull/37252
+		// Convert "at foo (/min.js:1)\n -> /src.js:2" to "at foo (/src.js:2)"
+		.replace( /\b(at [^(]+\s\()[^)]+(\))\n\s+-> ([^\n]+)/g, "$1$3$2" )
+
 		.replace( / at .+\([^/)][^)]*\)/g, " at internal" )
 
 		// merge successive lines after initial frame

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -161,8 +161,7 @@ QUnit.module( "CLI Main", function() {
 			} catch ( e ) {
 				assert.equal( e.code, 1 );
 				assert.equal( e.stderr, "" );
-				const re = new RegExp( expectedOutput[ command ] );
-				assert.equal( re.test( e.stdout ), true );
+				assert.equal( e.stdout, expectedOutput[ command ] );
 			}
 		} );
 


### PR DESCRIPTION
Follows-up e295106, which left one test case still using regexes. Upon changing that to use the new normalised tracing, I found that it failed on Node 15 because the format of source map traces changed between Node 14 and Node 15.

This doesn't matter for QUnit in general, since it just prints whatever trace was given to it by the runtime, regardless of formatting, but for our test cases to pass when run against Node 15 we do need to have two test cases or normalise across them. I did the latter.