### PR TITLE
Build: Update to eslint-plugin-qunit 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qunit",
-  "version": "2.14.0-pre",
+  "version": "2.14.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2609,9 +2609,9 @@
       }
     },
     "eslint-plugin-qunit": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-5.3.0.tgz",
-      "integrity": "sha512-SeN55paT/BkFvNmi+CSnoCymisEJbmDYvPoBbVlRGsL3ara0P6fnGYRxjIhF6cK37CTZf/8vD5lrVxS3mb0LzA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.0.0.tgz",
+      "integrity": "sha512-+R8z2umSTIiWcxmTQ9nGoML8DL0VQJg4C+E9OpJ2KF9QL4WL/FoayROeTG5Z9zhlZ2qqa+9WkZ1YD6mx89io8w==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-config-jquery": "^3.0.0",
     "eslint-plugin-html": "^6.1.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-qunit": "^5.3.0",
+    "eslint-plugin-qunit": "^6.0.0",
     "execa": "^0.8.0",
     "fixturify": "^0.3.4",
     "fuzzysort": "^1.1.4",

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-	"extends": [ "plugin:qunit/two" ],
+	"extends": [ "plugin:qunit/recommended" ],
 	"env": {
 		"browser": true,
 		"es6": false
@@ -17,6 +17,13 @@
 		"console": false
 	},
 	"rules": {
+		"qunit/literal-compare-order": "off",
+		"qunit/no-arrow-tests": "off",
+		"qunit/no-assert-equal-boolean": "off",
+		"qunit/no-assert-logical-expression": "off",
+		"qunit/no-only": "off",
+		"qunit/require-expect": "off",
+		"qunit/resolve-async": "off",
 		"max-len": "off"
 	},
 	"ignorePatterns": [

--- a/test/autostart.js
+++ b/test/autostart.js
@@ -3,7 +3,6 @@ QUnit.start();
 QUnit.module( "autostart" );
 
 QUnit.test( "Prove the test run started as expected", function( assert ) {
-	assert.expect( 2 );
 	assert.true( window.times.autostartOff <= window.times.runStarted );
 	assert.strictEqual( window.beginData.totalTests, 1, "Should have expected 1 test" );
 } );

--- a/test/cli/fixtures/memory-leak/index.js
+++ b/test/cli/fixtures/memory-leak/index.js
@@ -57,8 +57,8 @@ QUnit.module( "later thing", function() {
 		const reHeap = /^.*FooNum\d.*$/gm;
 
 		let snapshot = await streamToString( v8.getHeapSnapshot() );
-		let matches = snapshot.match( reHeap );
-		assert.strictEqual( matches && matches.length, 2, "the before heap" );
+		let matches = snapshot.match( reHeap ) || [];
+		assert.strictEqual( matches.length, 2, "the before heap" );
 
 		snapshot = matches = null;
 		assert.strictEqual( foos.size, 2, "foos in Set" );
@@ -71,6 +71,6 @@ QUnit.module( "later thing", function() {
 
 		snapshot = await streamToString( v8.getHeapSnapshot() );
 		matches = snapshot.match( reHeap );
-		assert.strictEqual( null, matches, "the after heap" );
+		assert.strictEqual( matches, null, "the after heap" );
 	} );
 } );

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -4,8 +4,8 @@ const expectedOutput = require( "./fixtures/expected/tap-outputs" );
 const execute = require( "./helpers/execute" );
 const semver = require( "semver" );
 
-QUnit.module( "CLI Main", function() {
-	QUnit.test( "defaults to running tests in 'test' directory", async function( assert ) {
+QUnit.module( "CLI Main", () => {
+	QUnit.test( "defaults to running tests in 'test' directory", async assert => {
 		const command = "qunit";
 		const execution = await execute( command );
 
@@ -14,7 +14,7 @@ QUnit.module( "CLI Main", function() {
 		assert.equal( execution.stdout, expectedOutput[ command ] );
 	} );
 
-	QUnit.test( "errors if no test files are found to run", async function( assert ) {
+	QUnit.test( "errors if no test files are found to run", async assert => {
 		try {
 			await execute( "qunit does-not-exist.js" );
 		} catch ( e ) {
@@ -22,7 +22,7 @@ QUnit.module( "CLI Main", function() {
 		}
 	} );
 
-	QUnit.test( "accepts globs for test files to run", async function( assert ) {
+	QUnit.test( "accepts globs for test files to run", async assert => {
 		const command = "qunit 'glob/**/*-test.js'";
 		const execution = await execute( command );
 
@@ -31,7 +31,7 @@ QUnit.module( "CLI Main", function() {
 		assert.equal( execution.stdout, expectedOutput[ command ] );
 	} );
 
-	QUnit.test( "runs a single JS file", async function( assert ) {
+	QUnit.test( "runs a single JS file", async assert => {
 		const command = "qunit single.js";
 		const execution = await execute( command );
 
@@ -40,7 +40,7 @@ QUnit.module( "CLI Main", function() {
 		assert.equal( execution.stdout, expectedOutput[ command ] );
 	} );
 
-	QUnit.test( "runs multiple JS files", async function( assert ) {
+	QUnit.test( "runs multiple JS files", async assert => {
 		const command = "qunit single.js double.js";
 		const execution = await execute( command );
 
@@ -49,7 +49,7 @@ QUnit.module( "CLI Main", function() {
 		assert.equal( execution.stdout, expectedOutput[ command ] );
 	} );
 
-	QUnit.test( "runs all JS files in a directory matching an arg", async function( assert ) {
+	QUnit.test( "runs all JS files in a directory matching an arg", async assert => {
 		const command = "qunit test";
 		const execution = await execute( command );
 
@@ -58,7 +58,7 @@ QUnit.module( "CLI Main", function() {
 		assert.equal( execution.stdout, expectedOutput[ command ] );
 	} );
 
-	QUnit.test( "runs multiple types of file paths", async function( assert ) {
+	QUnit.test( "runs multiple types of file paths", async assert => {
 		const command = "qunit test single.js 'glob/**/*-test.js'";
 		const execution = await execute( command );
 
@@ -67,7 +67,7 @@ QUnit.module( "CLI Main", function() {
 		assert.equal( execution.stdout, expectedOutput[ command ] );
 	} );
 
-	QUnit.test( "logs test files that fail to load properly", async function( assert ) {
+	QUnit.test( "logs test files that fail to load properly", async assert => {
 		try {
 			await execute( "qunit syntax-error/test.js" );
 		} catch ( e ) {
@@ -77,7 +77,7 @@ QUnit.module( "CLI Main", function() {
 		}
 	} );
 
-	QUnit.test( "report assert.throws() failures properly", async function( assert ) {
+	QUnit.test( "report assert.throws() failures properly", async assert => {
 		const command = "qunit fail/throws-match.js";
 		try {
 			await execute( command );
@@ -88,7 +88,7 @@ QUnit.module( "CLI Main", function() {
 		}
 	} );
 
-	QUnit.test( "exit code is 1 when failing tests are present", async function( assert ) {
+	QUnit.test( "exit code is 1 when failing tests are present", async assert => {
 		try {
 			await execute( "qunit fail/failure.js" );
 		} catch ( e ) {
@@ -96,7 +96,7 @@ QUnit.module( "CLI Main", function() {
 		}
 	} );
 
-	QUnit.test( "exit code is 1 when no tests are run", async function( assert ) {
+	QUnit.test( "exit code is 1 when no tests are run", async assert => {
 		const command = "qunit no-tests";
 		try {
 			await execute( command );
@@ -107,7 +107,7 @@ QUnit.module( "CLI Main", function() {
 		}
 	} );
 
-	QUnit.test( "exit code is 1 when no tests exit before done", async function( assert ) {
+	QUnit.test( "exit code is 1 when no tests exit before done", async assert => {
 		const command = "qunit hanging-test";
 		try {
 			await execute( command );
@@ -117,7 +117,7 @@ QUnit.module( "CLI Main", function() {
 		}
 	} );
 
-	QUnit.test( "unhandled rejections fail tests", async function( assert ) {
+	QUnit.test( "unhandled rejections fail tests", async assert => {
 		const command = "qunit unhandled-rejection.js";
 
 		try {
@@ -134,7 +134,7 @@ QUnit.module( "CLI Main", function() {
 	} );
 
 	if ( semver.gte( process.versions.node, "12.0.0" ) ) {
-		QUnit.test( "run ESM test suite with import statement", async function( assert ) {
+		QUnit.test( "run ESM test suite with import statement", async assert => {
 			const command = "qunit ../../es2018/esm.mjs";
 			const execution = await execute( command );
 
@@ -143,9 +143,8 @@ QUnit.module( "CLI Main", function() {
 			// Node 12 enabled ESM by default, without experimental flag,
 			// but left the warning in stderr. The warning was removed in Node 14.
 			// Don't bother checking stderr
-			if ( semver.gte( process.versions.node, "14.0.0" ) ) {
-				assert.equal( execution.stderr, "" );
-			}
+			const stderr = semver.gte( process.versions.node, "14.0.0" ) ? execution.stderr : "";
+			assert.equal( stderr, "" );
 
 			assert.equal( execution.stdout, expectedOutput[ command ] );
 		} );
@@ -154,7 +153,7 @@ QUnit.module( "CLI Main", function() {
 	// https://nodejs.org/dist/v12.12.0/docs/api/cli.html#cli_enable_source_maps
 	if ( semver.gte( process.versions.node, "14.0.0" ) ) {
 
-		QUnit.test( "normal trace with native source map", async function( assert ) {
+		QUnit.test( "normal trace with native source map", async assert => {
 			const command = "qunit sourcemap/source.js";
 			try {
 				await execute( command );
@@ -165,7 +164,7 @@ QUnit.module( "CLI Main", function() {
 			}
 		} );
 
-		QUnit.test( "mapped trace with native source map", async function( assert ) {
+		QUnit.test( "mapped trace with native source map", async assert => {
 			const command = "NODE_OPTIONS='--enable-source-maps' qunit sourcemap/source.min.js";
 			try {
 				await execute( command );
@@ -177,7 +176,7 @@ QUnit.module( "CLI Main", function() {
 		} );
 	}
 
-	QUnit.test( "timeouts correctly recover", async function( assert ) {
+	QUnit.test( "timeouts correctly recover", async assert => {
 		const command = "qunit timeout";
 		try {
 			await execute( command );
@@ -188,7 +187,7 @@ QUnit.module( "CLI Main", function() {
 		}
 	} );
 
-	QUnit.test( "allows running zero-assertion tests", async function( assert ) {
+	QUnit.test( "allows running zero-assertion tests", async assert => {
 		const command = "qunit zero-assertions.js";
 		const execution = await execute( command );
 
@@ -200,7 +199,7 @@ QUnit.module( "CLI Main", function() {
 	// https://nodejs.org/docs/v14.0.0/api/v8.html#v8_v8_getheapsnapshot
 	// Created in Node 11.x, but starts working the way we need from Node 14.
 	if ( semver.gte( process.versions.node, "14.0.0" ) ) {
-		QUnit.test( "callbacks and hooks from modules are properly released for garbage collection", async function( assert ) {
+		QUnit.test( "callbacks and hooks from modules are properly released for garbage collection", async assert => {
 			const command = "node --expose-gc ../../../bin/qunit.js memory-leak/*.js";
 			const execution = await execute( command );
 
@@ -210,8 +209,8 @@ QUnit.module( "CLI Main", function() {
 		} );
 	}
 
-	QUnit.module( "filter", function() {
-		QUnit.test( "can properly filter tests", async function( assert ) {
+	QUnit.module( "filter", () => {
+		QUnit.test( "can properly filter tests", async assert => {
 			const command = "qunit --filter 'single' test single.js 'glob/**/*-test.js'";
 			const equivalentCommand = "qunit single.js";
 			const execution = await execute( command );
@@ -221,7 +220,7 @@ QUnit.module( "CLI Main", function() {
 			assert.equal( execution.stdout, expectedOutput[ equivalentCommand ] );
 		} );
 
-		QUnit.test( "exit code is 1 when no tests match filter", async function( assert ) {
+		QUnit.test( "exit code is 1 when no tests match filter", async assert => {
 			const command = "qunit qunit --filter 'no matches' test";
 			try {
 				await execute( command );
@@ -233,8 +232,8 @@ QUnit.module( "CLI Main", function() {
 		} );
 	} );
 
-	QUnit.module( "require", function() {
-		QUnit.test( "can properly require dependencies and modules", async function( assert ) {
+	QUnit.module( "require", () => {
+		QUnit.test( "can properly require dependencies and modules", async assert => {
 			const command = "qunit single.js --require require-dep --require './node_modules/require-dep/module.js'";
 			const execution = await execute( command );
 
@@ -243,7 +242,7 @@ QUnit.module( "CLI Main", function() {
 			assert.equal( execution.stdout, expectedOutput[ command ] );
 		} );
 
-		QUnit.test( "displays helpful error when failing to require a file", async function( assert ) {
+		QUnit.test( "displays helpful error when failing to require a file", async assert => {
 			const command = "qunit single.js --require 'does-not-exist-at-all'";
 			try {
 				await execute( command );
@@ -255,8 +254,8 @@ QUnit.module( "CLI Main", function() {
 		} );
 	} );
 
-	QUnit.module( "seed", function() {
-		QUnit.test( "can properly seed tests", async function( assert ) {
+	QUnit.module( "seed", () => {
+		QUnit.test( "can properly seed tests", async assert => {
 			const command = "qunit --seed 's33d' test single.js 'glob/**/*-test.js'";
 			const execution = await execute( command );
 
@@ -266,10 +265,8 @@ QUnit.module( "CLI Main", function() {
 		} );
 	} );
 
-	QUnit.module( "notrycatch", function() {
-		QUnit.test( "errors if notrycatch is used and a rejection occurs", async function( assert ) {
-			assert.expect( 1 );
-
+	QUnit.module( "notrycatch", () => {
+		QUnit.test( "errors if notrycatch is used and a rejection occurs", async assert => {
 			try {
 				await execute( "qunit notrycatch/returns-rejection.js" );
 			} catch ( e ) {
@@ -283,8 +280,8 @@ QUnit.module( "CLI Main", function() {
 		} );
 	} );
 
-	QUnit.module( "only", function() {
-		QUnit.test( "test", async function( assert ) {
+	QUnit.module( "only", () => {
+		QUnit.test( "test", async assert => {
 
 			const command = "qunit only/test.js";
 			const execution = await execute( command );
@@ -294,7 +291,7 @@ QUnit.module( "CLI Main", function() {
 			assert.equal( execution.stdout, expectedOutput[ command ] );
 		} );
 
-		QUnit.test( "nested modules", async function( assert ) {
+		QUnit.test( "nested modules", async assert => {
 
 			const command = "qunit only/module.js";
 			const execution = await execute( command );
@@ -304,7 +301,7 @@ QUnit.module( "CLI Main", function() {
 			assert.equal( execution.stdout, expectedOutput[ command ] );
 		} );
 
-		QUnit.test( "flat modules", async function( assert ) {
+		QUnit.test( "flat modules", async assert => {
 
 			const command = "qunit only/module-flat.js";
 			const execution = await execute( command );

--- a/test/es2018/async-functions.js
+++ b/test/es2018/async-functions.js
@@ -1,9 +1,9 @@
-QUnit.module( "modules with async hooks", function( hooks ) {
-	hooks.before( async function( assert ) { assert.step( "before" ); } );
-	hooks.beforeEach( async function( assert ) { assert.step( "beforeEach" ); } );
-	hooks.afterEach( async function( assert ) { assert.step( "afterEach" ); } );
+QUnit.module( "modules with async hooks", hooks => {
+	hooks.before( async assert => { assert.step( "before" ); } );
+	hooks.beforeEach( async assert => { assert.step( "beforeEach" ); } );
+	hooks.afterEach( async assert => { assert.step( "afterEach" ); } );
 
-	hooks.after( function( assert ) {
+	hooks.after( assert => {
 		assert.verifySteps( [
 			"before",
 			"beforeEach",
@@ -11,16 +11,16 @@ QUnit.module( "modules with async hooks", function( hooks ) {
 		] );
 	} );
 
-	QUnit.test( "all hooks", function( assert ) {
+	QUnit.test( "all hooks", assert => {
 		assert.expect( 4 );
 	} );
 } );
 
 QUnit.module( "before/beforeEach/afterEach/after", {
-	before: async function( assert ) { assert.step( "before" ); },
-	beforeEach: async function( assert ) { assert.step( "beforeEach" ); },
-	afterEach: async function( assert ) { assert.step( "afterEach" ); },
-	after: async function( assert ) {
+	before: async assert => { assert.step( "before" ); },
+	beforeEach: async assert => { assert.step( "beforeEach" ); },
+	afterEach: async assert => { assert.step( "afterEach" ); },
+	after: async assert => {
 		assert.verifySteps( [
 			"before",
 			"beforeEach",
@@ -29,6 +29,6 @@ QUnit.module( "before/beforeEach/afterEach/after", {
 	}
 } );
 
-QUnit.test( "async hooks order", function( assert ) {
+QUnit.test( "async hooks order", assert => {
 	assert.expect( 4 );
 } );

--- a/test/events.js
+++ b/test/events.js
@@ -185,7 +185,7 @@ QUnit.done( function() {
 
 	done = true;
 
-	QUnit.module( "Events" );
+	QUnit.module( "Events-postdone" );
 	QUnit.test( "verify callback order and data at end of test", function( assert ) {
 		assert.deepEqual( invokedHooks, [
 			"runStart",

--- a/test/main/assert/timeout.js
+++ b/test/main/assert/timeout.js
@@ -49,6 +49,7 @@ QUnit.module( "assert.timeout", function() {
 		assert.timeout( 50 );
 		assert.expect( 1 );
 
+		var done = assert.async();
 		setTimeout( function() {
 			assert.timeout( 10 );
 			var original = assert.test.pushFailure;
@@ -59,7 +60,6 @@ QUnit.module( "assert.timeout", function() {
 				done();
 			};
 		} );
-		var done = assert.async();
 	} );
 
 	QUnit.module( "a value of zero", function() {

--- a/test/main/dump.js
+++ b/test/main/dump.js
@@ -1,4 +1,5 @@
 /* globals Symbol:false */
+/* eslint-disable qunit/no-conditional-assertions */
 
 QUnit.module( "dump", {
 	afterEach: function() {

--- a/test/main/test.js
+++ b/test/main/test.js
@@ -177,11 +177,13 @@ QUnit.module( "test", function() {
 	QUnit.test( "testForPush", function( assert ) {
 		QUnit.log( function( detail ) {
 			if ( detail.message === "should be call pushResult" ) {
+				/* eslint-disable qunit/no-conditional-assertions */
 				assert.equal( detail.result, true );
 				assert.equal( detail.actual, 1 );
 				assert.equal( detail.expected, 1 );
 				assert.equal( detail.message, "should be call pushResult" );
 				assert.equal( detail.negative, false );
+				/* eslint-enable */
 			}
 		} );
 		assert.testForPush( 1, 1, "should be call pushResult" );
@@ -222,6 +224,8 @@ QUnit.module( "test", function() {
 
 	QUnit.test( "QUnit.test without a callback logs a descriptive error", function( assert ) {
 		assert.throws( function() {
+
+			// eslint-disable-next-line qunit/no-nested-tests
 			QUnit.test( "should throw an error" );
 		}, /You must provide a callback to QUnit.test\("should throw an error"\)/ );
 	} );

--- a/test/module-filter.js
+++ b/test/module-filter.js
@@ -1,3 +1,5 @@
+/* eslint-disable qunit/no-identical-names */
+
 QUnit.config.module = "Foo";
 
 QUnit.module( "Foo" );

--- a/test/onerror/outside-test.js
+++ b/test/onerror/outside-test.js
@@ -30,7 +30,7 @@ QUnit.module( "pushFailure outside a test", function( hooks ) {
 		QUnit.config.current.pushResult = originalPushResult;
 	} );
 
-	// Actual test (outside QUnit.test context).
+	// Actual test, outside QUnit.test context.
 	QUnit.onError( {
 		message: "Error message",
 		fileName: "filePath.js",

--- a/test/reorder.js
+++ b/test/reorder.js
@@ -14,9 +14,12 @@ QUnit.test( "Second", function( assert ) {
 	assert.strictEqual( lastTest, "" );
 	lastTest = "Second";
 
+	// For some reason PhantomJS mutates config.reorder
+	QUnit.config.reorder = true;
+
 	// This test is "high priority" so it should execute before test "First"
 	// even though it is added to the queue late
-	QUnit.config.reorder = true; // For some reason PhantomJS mutates config.reorder
+	// eslint-disable-next-line qunit/no-nested-tests
 	QUnit.test( "Third", function( assert ) {
 		assert.strictEqual( lastTest, "Second" );
 		lastTest = "Third";

--- a/test/reporter-html/reporter-html.js
+++ b/test/reporter-html/reporter-html.js
@@ -122,11 +122,12 @@ QUnit.module( "HTML Reporter", function() {
 
 		// Verify QUnit supported stack trace
 		if ( !err.stack ) {
-			assert.equal(
+			assert.false(
 				/(^| )qunit-source( |$)/.test( source.className ),
-				false,
 				"Don't add source information on unsupported environments"
 			);
+
+			// eslint-disable-next-line qunit/no-early-return
 			return;
 		}
 

--- a/test/reporter-html/unhandled-rejection.js
+++ b/test/reporter-html/unhandled-rejection.js
@@ -64,7 +64,7 @@ if ( HAS_UNHANDLED_REJECTION_HANDLER ) {
 			assert.pushResult = originalPushResult;
 		} );
 
-		// Actual test (outside QUnit.test context)
+		// Actual test, outside QUnit.test context.
 		QUnit.onUnhandledRejection( {
 			message: "Error message",
 			fileName: "filePath.js",

--- a/test/reporter-urlparams-hidepassed.js
+++ b/test/reporter-urlparams-hidepassed.js
@@ -3,29 +3,29 @@ if ( !location.search ) {
 }
 
 QUnit.module( "urlParams hidepassed module", function() {
-	QUnit.test( "passed", function( assert ) {
+	QUnit.test( "passed 1", function( assert ) {
 		assert.true( true );
 	} );
-	QUnit.test( "passed", function( assert ) {
+	QUnit.test( "passed 2", function( assert ) {
 		assert.true( true );
 	} );
-	QUnit.test( "passed", function( assert ) {
+	QUnit.test( "passed 3", function( assert ) {
 		assert.true( true );
 	} );
-	QUnit.test( "passed", function( assert ) {
+	QUnit.test( "passed 4", function( assert ) {
 		assert.true( true );
 	} );
-	QUnit.test( "passed", function( assert ) {
+	QUnit.test( "passed 5", function( assert ) {
 		assert.true( true );
 	} );
-	QUnit.test( "passed", function( assert ) {
+	QUnit.test( "passed 6", function( assert ) {
 		assert.true( true );
 	} );
-	QUnit.skip( "skipped", function( assert ) {
+	QUnit.skip( "skipped 1", function( assert ) {
 		assert.true( false, "can't seem to get this working" );
 	} );
 
-	QUnit.test( "passed", function( assert ) {
+	QUnit.test( "passed 7", function( assert ) {
 
 		// we have to set it to 1 because there is currently one item being rendered, this one as it is in progress
 		assert.strictEqual( document.getElementById( "qunit-tests" ).children.length, 1 );

--- a/test/startError.js
+++ b/test/startError.js
@@ -14,19 +14,16 @@ try {
 QUnit.module( "global start unrecoverable errors" );
 
 QUnit.test( "start() throws when QUnit.config.autostart === true", function( assert ) {
-	assert.expect( 1 );
 	assert.equal( window.autostartStartError.message,
 		"Called start() outside of a test context when QUnit.config.autostart was true" );
 } );
 
 QUnit.test( "Throws after calling start() too many times outside of a test context", function( assert ) {
-	assert.expect( 1 );
 	assert.equal( window.tooManyStartsError.message,
 		"Called start() outside of a test context too many times" );
 } );
 
 QUnit.test( "QUnit.start cannot be called inside a test context.", function( assert ) {
-	assert.expect( 1 );
 	assert.throws( function() {
 		// eslint-disable-next-line qunit/no-qunit-start-in-tests
 		QUnit.start();


### PR DESCRIPTION
* Migrate from `qunit/two` to `qunit/recommended`.

* Disable various rules that are not so useful for QUnit's internal tests or have unresolved upstream issues that I think make them not yet worthwhile to enable vs noticing those issues ourselves during code review.

https://github.com/platinumazure/eslint-plugin-qunit/blob/v6.0.0/CHANGELOG.md