### PR TITLE
Fix unittest failures in Node14 under coverage mode

### DIFF
--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -78,7 +78,10 @@ async function run( args, options ) {
 			try {
 				require( filePath );
 			} catch ( e ) {
-				if ( e.code === "ERR_REQUIRE_ESM" && ( !nodeVint || nodeVint >= 72 ) ) {
+				if ( ( e.code === "ERR_REQUIRE_ESM" ||
+					( e instanceof SyntaxError &&
+						e.message === "Cannot use import statement outside a module" ) ) &&
+					( !nodeVint || nodeVint >= 72 ) ) {
 					await import( filePath ); // eslint-disable-line node/no-unsupported-features/es-syntax
 				} else {
 					throw e;

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -164,16 +164,18 @@ QUnit.module( "CLI Main", () => {
 			}
 		} );
 
-		QUnit.test( "mapped trace with native source map", async assert => {
-			const command = "NODE_OPTIONS='--enable-source-maps' qunit sourcemap/source.min.js";
-			try {
-				await execute( command );
-			} catch ( e ) {
-				assert.equal( e.code, 1 );
-				assert.equal( e.stderr, "" );
-				assert.equal( e.stdout, expectedOutput[ command ] );
-			}
-		} );
+		// skip if running in code coverage mode - that leads to conflicting maps-on-maps that invalidate this test
+		QUnit[ process.env.NYC_PROCESS_ID ? "skip" : "test" ](
+			"mapped trace with native source map", async function( assert ) {
+				const command = "NODE_OPTIONS='--enable-source-maps' qunit sourcemap/source.min.js";
+				try {
+					await execute( command );
+				} catch ( e ) {
+					assert.equal( e.code, 1 );
+					assert.equal( e.stderr, "" );
+					assert.equal( e.stdout, expectedOutput[ command ] );
+				}
+			} );
 	}
 
 	QUnit.test( "timeouts correctly recover", async assert => {


### PR DESCRIPTION
Resolves #1593.

The failing unittests for the ESM support lead to repairs in `src/cli/run.js`. I was observing different errors than just the one we were sniffing for, so I added another check with as much granularity as possible. This passes in both coverage and non-coverage runs now.

The other failing unittest was regarding source-maps; here we were simply getting different stack traces based on maps, and from what I could gather, the codecoverage mode was already doing mapping, and then `--enable-source-maps` does more, and seemed to be conflicting. I filtered this test under code coverage mode by inspecting the `NYC_PROCESS_ID` env var. I wanted to use `BUILD_TARGET=coverage`, but that is being set in a different process from what ultimately runs this test.