### PR TITLE
Indicate which test drooling assert.async callbacks came from

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -88,14 +88,14 @@ class Assert {
 		return function done() {
 
 			if ( config.current === undefined ) {
-				throw new Error( "`assert.async` callback from test '" +
-					test.testName + "' called after tests finished." );
+				throw new Error( "`assert.async` callback from test \"" +
+					test.testName + "\" called after tests finished." );
 			}
 
 			if ( config.current !== test ) {
 				config.current.pushFailure(
-					"`assert.async` callback from test '" +
-					test.testName + "' was called during this test." );
+					"`assert.async` callback from test \"" +
+					test.testName + "\" was called during this test." );
 				return;
 			}
 

--- a/src/assert.js
+++ b/src/assert.js
@@ -86,8 +86,17 @@ class Assert {
 		const resume = internalStop( test );
 
 		return function done() {
+
+			if ( config.current === undefined ) {
+				throw new Error( "`assert.async` callback from test '" +
+					test.testName + "' called after tests finished." );
+			}
+
 			if ( config.current !== test ) {
-				throw Error( "assert.async callback called after test finished." );
+				config.current.pushFailure(
+					"`assert.async` callback from test '" +
+					test.testName + "' was called during this test." );
+				return;
 			}
 
 			if ( popped ) {

--- a/test/cli/fixtures/done-after-timeout.js
+++ b/test/cli/fixtures/done-after-timeout.js
@@ -1,0 +1,6 @@
+QUnit.test( "times out before scheduled done is called", assert => {
+	assert.timeout( 10 );
+	const done = assert.async();
+	assert.true( true );
+	setTimeout( done, 20 );
+} );

--- a/test/cli/fixtures/drooling-done.js
+++ b/test/cli/fixtures/drooling-done.js
@@ -1,0 +1,14 @@
+QUnit.config.reorder = false;
+
+let done;
+
+QUnit.test( "Test A", assert => {
+	assert.ok( true );
+	done = assert.async();
+	throw new Error( "this is an intentional error" );
+} );
+
+QUnit.test( "Test B", assert => {
+	assert.ok( true );
+	done();
+} );

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -340,5 +340,22 @@ ok 1 module providing hooks > module not providing hooks > has a test
 # pass 1
 # skip 0
 # todo 0
-# fail 0`
+# fail 0`,
+
+	"qunit done-after-timeout.js":
+`TAP version 13
+not ok 1 times out before scheduled done is called
+  ---
+  message: Test took longer than 10ms; test timed out.
+  severity: failed
+  actual  : null
+  expected: undefined
+  stack: |
+        at internal
+  ...
+1..1
+# pass 0
+# skip 0
+# todo 0
+# fail 1`
 };

--- a/test/cli/fixtures/too-many-done-calls.js
+++ b/test/cli/fixtures/too-many-done-calls.js
@@ -1,0 +1,6 @@
+QUnit.test( "Test A", assert => {
+	assert.ok( true );
+	const done = assert.async();
+	done();
+	done();
+} );

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -293,8 +293,9 @@ QUnit.module( "CLI Main", () => {
 
 				// These are both undesirable, but at least confirm what the current state is.
 				// TDD should break these and update when possible.
-				assert.notEqual( e.code, 0 ); // should be 1, but is sometimes 7 in different envs
 				assert.true( e.stderr.includes( "TypeError: Cannot read property 'length' of undefined" ), e.stderr );
+
+				// e.code should be 1, but is sometimes 0, 1, or 7 in different envs
 			}
 		} );
 

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -312,7 +312,7 @@ QUnit.module( "CLI Main", () => {
 				assert.true( e.stdout.includes(
 					"not ok 2 Test B\n" +
 					"  ---\n" +
-					"  message: \"`assert.async` callback from test 'Test A' was called during this test.\"" ), e.stdout );
+					"  message: \"`assert.async` callback from test \\\"Test A\\\" was called during this test.\"" ), e.stdout );
 			}
 		} );
 

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -293,7 +293,7 @@ QUnit.module( "CLI Main", () => {
 
 				// These are both undesirable, but at least confirm what the current state is.
 				// TDD should break these and update when possible.
-				assert.equal( e.code, 7 );
+				assert.notEqual( e.code, 0 ); // should be 1, but is sometimes 7 in different envs
 				assert.true( e.stderr.includes( "TypeError: Cannot read property 'length' of undefined" ), e.stderr );
 			}
 		} );

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -282,6 +282,58 @@ QUnit.module( "CLI Main", () => {
 		} );
 	} );
 
+	QUnit.module( "assert.async", () => {
+
+		QUnit.test( "assert.async callback after tests timeout", async assert => {
+			const command = "qunit done-after-timeout.js";
+			try {
+				await execute( command );
+			} catch ( e ) {
+				assert.equal( e.stdout, expectedOutput[ command ] );
+
+				// These are both undesirable, but at least confirm what the current state is.
+				// TDD should break these and update when possible.
+				assert.equal( e.code, 7 );
+				assert.true( e.stderr.includes( "TypeError: Cannot read property 'length' of undefined" ), e.stderr );
+			}
+		} );
+
+		QUnit.test( "drooling calls across tests to assert.async callback", async assert => {
+			const command = "qunit drooling-done.js";
+			try {
+				await execute( command );
+			} catch ( e ) {
+				assert.equal( e.code, 1 );
+				assert.equal( e.stderr, "" );
+
+				// code coverage and various Node versions can alter the stacks,
+				// so we can't compare exact strings, but we can spot-check
+				assert.true( e.stdout.includes(
+					"not ok 2 Test B\n" +
+					"  ---\n" +
+					"  message: \"`assert.async` callback from test 'Test A' was called during this test.\"" ), e.stdout );
+			}
+		} );
+
+		QUnit.test( "too many calls to assert.async callback", async assert => {
+			const command = "qunit too-many-done-calls.js";
+			try {
+				await execute( command );
+			} catch ( e ) {
+				assert.equal( e.code, 1 );
+				assert.equal( e.stderr, "" );
+
+				// code coverage and various Node versions can alter the stacks,
+				// so we can't compare exact strings, but we can spot-check
+				assert.true( e.stdout.includes(
+					"not ok 1 Test A\n" +
+					"  ---\n" +
+					"  message: Too many calls to the `assert.async` callback" ), e.stdout );
+			}
+		} );
+
+	} );
+
 	QUnit.module( "only", () => {
 		QUnit.test( "test", async assert => {
 

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -168,7 +168,7 @@ QUnit.module( "assert.async", function() {
 			assert.test.pushFailure = function( msg ) {
 				throw new Error( msg );
 			};
-			assert.throws( previousTestDone, /Error: `assert.async` callback from test 'errors if called after test finishes - part 1' was called during this test./ );
+			assert.throws( previousTestDone, /Error: `assert\.async` callback from test "errors if called after test finishes - part 1" was called during this test./ );
 		} );
 	}() );
 

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -163,7 +163,12 @@ QUnit.module( "assert.async", function() {
 		} );
 
 		QUnit.test( "errors if called after test finishes - part 2", function( assert ) {
-			assert.throws( previousTestDone, /assert.async callback called after test finished./ );
+
+			// Duck-punch to force an Error to be thrown instead of a `pushFailure` call
+			assert.test.pushFailure = function( msg ) {
+				throw new Error( msg );
+			};
+			assert.throws( previousTestDone, /Error: `assert.async` callback from test 'errors if called after test finishes - part 1' was called during this test./ );
 		} );
 	}() );
 


### PR DESCRIPTION
This is a more tightly scoped version of #1595, tackling only the `assert.async` callback error handling. The remainder (handling the `onError` and `global failure` scenarios) grew larger than expected, so I'd like to slice this part off for iterative improvements, and circle back on the more generic issues.

The source change is straightforward.
Whenever a "done" callback is fired outside of the originating test, we currently see this:
```
assert.async callback called after test finished.
```

We can tease that apart for 2 distinct use cases.
If we're in another test, we can use `pushFailure` to show:
```
`assert.async` callback from test 'foobar' was called during this test.
```

Or if we're outside of the tests, we can `throw`:
```
`assert.async` callback from test 'foobar' called after tests finished.
```

I added a handful of tests - some to exercise these new paths, and some for related workflows by simply validating current behavior to avoid any unexpected changes, even if the current behavior is less than ideal.