### PR TITLE
Filter queued modules based on `ignored` bit to handle nested-modules issue

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -10,7 +10,9 @@ import { globalSuite } from "./core";
 const moduleStack = [];
 
 function isParentModuleInQueue() {
-	const modulesInQueue = config.modules.map( module => module.moduleId );
+	const modulesInQueue = config.modules
+		.filter( module => !module.ignored )
+		.map( module => module.moduleId );
 	return moduleStack.some( module => modulesInQueue.includes( module.moduleId ) );
 }
 

--- a/test/cli/fixtures/only/module.js
+++ b/test/cli/fixtures/only/module.js
@@ -45,6 +45,14 @@ QUnit.module.only( "module D", function() {
 	} );
 } );
 
+QUnit.module( "module D1", function() {
+	QUnit.module( "module D2", function() {
+		QUnit.test( "test D3", function( assert ) {
+			assert.true( false, "this test should not run" );
+		} );
+	} );
+} );
+
 QUnit.module.only( "module E", function() {
 	QUnit.module( "module F", function() {
 		QUnit.test( "test F", function( assert ) {


### PR DESCRIPTION
Resolves #1610.

The `isParentModuleInQueue` routine wasn't looking at the `ignored` bit on the modules; yes, the parent module is technically in the queue, but it's been filtered and we need to honor that so more modules aren't added into the queue if a prior module used the `only` affordance.

Qualification: Added a small portion into an existing unittest that exercises this fix, and also manually bashed in CLI and browser regarding other "nested" and "flat" scenarios with `only` workflows.