### PR TITLE
Support objects as input to test.each

### DIFF
--- a/docs/QUnit/test.each.md
+++ b/docs/QUnit/test.each.md
@@ -14,7 +14,7 @@ Add a parameterized test to run.
 | parameter | description |
 |-----------|-------------|
 | `name` (string) | Title of unit being tested |
-| `data` (Array) | Array of arrays of parameters to be passed as input to each test. This can also be specified as a 1D array of primitives |
+| `data` (Array | Object) | Array of arrays of parameters to be passed as input to each test. This can also be specified as a 1D array of primitives or an object with each key representing a test case |
 | `callback` (function) | Function to close over assertions |
 
 #### Callback parameters: `callback( assert, args )`:
@@ -58,11 +58,15 @@ function isAsyncEven( x ) {
 }
 
 QUnit.test.each( "square()", [ [ 2, 4 ], [ 3, 9 ] ], ( assert, [ value, expected ] ) => {
-  assert.equal( square( value ), expected, `square(${value})` );
+  assert.strictEqual( square( value ), expected, `square(${value})` );
 });
 
 QUnit.test.each( "isEven()", [ 2, 4 ], ( assert, value ) => {
   assert.true( isEven( value ), `isEven(${value})` );
+});
+
+QUnit.test.each( "isEven()", { caseEven: [ 2, true ], caseNotEven: [ 3, false ] }, ( assert, [ value, expected ] ) => {
+  assert.strictEqual( isEven( value ), expected, `isEven(${value})` );
 });
 
 QUnit.test.each( "isAsyncEven()", [ 2, 4 ], ( assert, value ) => {

--- a/docs/QUnit/test.each.md
+++ b/docs/QUnit/test.each.md
@@ -69,6 +69,12 @@ QUnit.test.each( "square()", [
 });
 ```
 
+##### Example: Object data provider
+
+QUnit.test.each( "isEven()", { caseEven: [ 2, true ], caseNotEven: [ 3, false ] }, ( assert, [ value, expected ] ) => {
+  assert.strictEqual( isEven( value ), expected, `isEven(${value})` );
+});
+
 ##### Example: Async functions with `each()`
 
 ```js
@@ -99,10 +105,6 @@ function isAsyncEven( x ) {
     resolve( isEven( x ) );
   } );
 }
-
-QUnit.test.each( "isEven()", { caseEven: [ 2, true ], caseNotEven: [ 3, false ] }, ( assert, [ value, expected ] ) => {
-  assert.strictEqual( isEven( value ), expected, `isEven(${value})` );
-});
 
 QUnit.test.each( "isAsyncEven()", [ 2, 4 ], ( assert, value ) => {
   return isAsyncEven( value ).then( ( result ) => {

--- a/docs/QUnit/test.each.md
+++ b/docs/QUnit/test.each.md
@@ -17,7 +17,7 @@ Add tests using a data provider.
 | parameter | description |
 |-----------|-------------|
 | `name` (string) | Title of unit being tested |
-| `dataset` (array) | List of data values passed to each test case |
+| `dataset` (array) | Array or object of data values passed to each test case |
 | `callback` (function) | Function to close over assertions |
 
 #### Callback parameters: `callback( assert, data )`:

--- a/docs/QUnit/test.each.md
+++ b/docs/QUnit/test.each.md
@@ -71,9 +71,14 @@ QUnit.test.each( "square()", [
 
 ##### Example: Object data provider
 
-QUnit.test.each( "isEven()", { caseEven: [ 2, true ], caseNotEven: [ 3, false ] }, ( assert, [ value, expected ] ) => {
-  assert.strictEqual( isEven( value ), expected, `isEven(${value})` );
+```js
+QUnit.test.each( "isEven()", {
+  caseEven: [ 2, true ],
+  caseNotEven: [ 3, false ]
+}, ( assert, [ value, expected ] ) => {
+  assert.strictEqual( isEven( value ), expected );
 });
+```
 
 ##### Example: Async functions with `each()`
 

--- a/src/test.js
+++ b/src/test.js
@@ -746,10 +746,15 @@ function makeEachTestName( testName, argument ) {
 function runEach( data, eachFn ) {
 	if ( Array.isArray( data ) ) {
 		data.forEach( eachFn );
+	} else if ( typeof data === "object" && data !== null ) {
+		const keys = Object.keys( data );
+		keys.forEach( ( key ) => {
+			eachFn( data[ key ], key );
+		} );
 	} else {
 		throw new Error(
-			`test.each expects an array of arrays or an array of primitives as the expected input.
-${typeof data} was found instead.`
+			`test.each expects an array of arrays, an array of primitives, or an object 
+ as the expected input. ${typeof data} was found instead.`
 		);
 	}
 }
@@ -763,9 +768,9 @@ extend( test, {
 		only( testName, undefined, callback );
 	},
 	each: function( testName, data, callback ) {
-		runEach( data, ( datum, i ) => {
+		runEach( data, ( datum, testKey ) => {
 			addTestWithData( {
-				testName: makeEachTestName( testName, i ),
+				testName: makeEachTestName( testName, testKey ),
 				callback: callback,
 				params: datum
 			} );
@@ -774,19 +779,19 @@ extend( test, {
 } );
 
 test.todo.each = function( testName, data, callback ) {
-	runEach( data, ( datum, i ) => {
-		todo( makeEachTestName( testName, i ), datum, callback );
+	runEach( data, ( datum, testKey ) => {
+		todo( makeEachTestName( testName, testKey ), datum, callback );
 	} );
 };
 test.skip.each = function( testName, data ) {
-	runEach( data, ( _, i ) => {
-		skip( makeEachTestName( testName, i ) );
+	runEach( data, ( _, testKey ) => {
+		skip( makeEachTestName( testName, testKey ) );
 	} );
 };
 
 test.only.each = function( testName, data, callback ) {
-	runEach( data, ( datum, i ) => {
-		only( makeEachTestName( testName, i ), datum, callback );
+	runEach( data, ( datum, testKey ) => {
+		only( makeEachTestName( testName, testKey ), datum, callback );
 	} );
 };
 

--- a/src/test.js
+++ b/src/test.js
@@ -753,8 +753,8 @@ function runEach( data, eachFn ) {
 		} );
 	} else {
 		throw new Error(
-			`test.each expects an array of arrays, an array of primitives, or an object 
- as the expected input. ${typeof data} was found instead.`
+			`test.each() expects an array or an object as input, but
+found ${typeof data} instead.`
 		);
 	}
 }

--- a/src/test.js
+++ b/src/test.js
@@ -753,7 +753,7 @@ function runEach( data, eachFn ) {
 		} );
 	} else {
 		throw new Error(
-			`test.each() expects an array or an object as input, but
+			`test.each() expects an array or object as input, but
 found ${typeof data} instead.`
 		);
 	}

--- a/test/main/each.js
+++ b/test/main/each.js
@@ -13,7 +13,10 @@ QUnit.module( "test.each", function() {
 	QUnit.test.each( "test.each 1D", [ 1, [], "some" ], function( assert, value ) {
 		assert.true( Boolean( value ) );
 	} );
-	QUnit.test.each( "test.each fails with non-array input", [ "something", 1, undefined, null, {} ], function( assert, value ) {
+	QUnit.test.each( "test.each with object", { caseFoo: [ 1, 2, 3 ], caseBar: [ 1, 1, 2 ] }, function( assert, data ) {
+		assert.strictEqual( data[ 0 ] + data[ 1 ], data[ 2 ] );
+	} );
+	QUnit.test.each( "test.each fails with non-array input", [ "something", 1, undefined, null ], function( assert, value ) {
 		assert.throws( function() {
 			QUnit.test.each( "test.each 1D", value, function() { } );
 		} );


### PR DESCRIPTION
Follow up on https://github.com/qunitjs/qunit/issues/1568#issuecomment-835627337 to add support for objects as input to `test.each`.

<img width="406" alt="Screen Shot 2021-05-16 at 7 09 04 PM" src="https://user-images.githubusercontent.com/5890858/118416070-de324080-b67b-11eb-848e-7f9a8132faa5.png">

@Krinkle, @smcclure15 let me know what your thoughts are on this change.