### PR TITLE
Core: Add new `failOnZeroTests` configuration option

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -14,6 +14,10 @@ const config = {
 	// Block until document ready
 	blocking: true,
 
+	// whether or not to fail when there are zero tests
+	// defaults to `true`
+	failOnZeroTests: true,
+
 	// By default, run previously failed tests first
 	// very useful in combination with "Hide passed tests" checked
 	reorder: true,

--- a/src/core/processing-queue.js
+++ b/src/core/processing-queue.js
@@ -164,7 +164,7 @@ function done() {
 	const runtime = now() - config.started;
 	const passed = config.stats.all - config.stats.bad;
 
-	if ( config.stats.testCount === 0 ) {
+	if ( config.stats.testCount === 0 && config.failOnZeroTests === true ) {
 
 		if ( config.filter && config.filter.length ) {
 			throw new Error( `No tests matched the filter "${config.filter}".` );

--- a/test/cli/fixtures/assert-expect/no-tests.js
+++ b/test/cli/fixtures/assert-expect/no-tests.js
@@ -1,0 +1,2 @@
+// no tests
+QUnit.config.failOnZeroTests = false;

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -400,5 +400,13 @@ not ok 1 times out before scheduled done is called
 # pass 0
 # skip 0
 # todo 0
-# fail 1`
+# fail 1`,
+
+	"qunit assert-expect/no-tests.js":
+`TAP version 13
+1..0
+# pass 0
+# skip 0
+# todo 0
+# fail 0`
 };

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -108,9 +108,12 @@ QUnit.module( "CLI Main", () => {
 	} );
 
 	QUnit.test( "exit code is 0 when no tests are run and failOnZeroTests is `false`", async assert => {
-		assert.expect( 0 );
 		const command = "qunit assert-expect/no-tests.js";
-		await execute( command );
+		const execution = await execute( command );
+
+		assert.equal( execution.code, 0 );
+		assert.equal( execution.stderr, "" );
+		assert.equal( execution.stdout, expectedOutput[ command ] );
 	} );
 
 	QUnit.test( "exit code is 1 when no tests exit before done", async assert => {

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -107,6 +107,12 @@ QUnit.module( "CLI Main", () => {
 		}
 	} );
 
+	QUnit.test( "exit code is 0 when no tests are run and failOnZeroTests is `false`", async assert => {
+		assert.expect( 0 );
+		const command = "qunit assert-expect/no-tests.js";
+		await execute( command );
+	} );
+
 	QUnit.test( "exit code is 1 when no tests exit before done", async assert => {
 		const command = "qunit hanging-test";
 		try {


### PR DESCRIPTION
This PR adds an optional `failOnZeroTests` configuration that defaults to `true`.

Some context:

For apps using `ember exam` throwing errors when no tests are run can cause issues, since there are cases when running a small number of tests in parallel with multiple browsers where some browsers may not get any tests; however, the test-suite as a whole does have tests. In this case, we prefer to only error when there are no tests at all, not in the case where an individual browsers gets no tests.