### PR TITLE
Core: Only pass internal argument to test callback when using each()

### DIFF
--- a/test/main/each.js
+++ b/test/main/each.js
@@ -21,6 +21,26 @@ QUnit.module( "test.each", function() {
 			QUnit.test.each( "test.each 1D", value, function() { } );
 		} );
 	} );
+
+	QUnit.module( "arguments", function( hooks ) {
+		var todoArgs;
+		hooks.after( function( assert ) {
+			assert.strictEqual( todoArgs, 2, "test.each.todo() callback args" );
+		} );
+
+		QUnit.test.each( "test.each() callback", [ 1 ], function( assert ) {
+			assert.strictEqual( arguments.length, 2 );
+		} );
+		QUnit.test.each( "test.each() callback with undefined", [ undefined ], function( assert ) {
+			assert.strictEqual( arguments.length, 2 );
+		} );
+		QUnit.test.todo.each( "test.each.todo() callback", [ 1 ], function( assert ) {
+
+			// Captured and asserted later since todo() is expected to fail
+			todoArgs = arguments.length;
+			assert.true( false );
+		} );
+	} );
 } );
 QUnit.module( "test.skip.each", function() {
 	QUnit.test( "do run", function( assert ) { assert.true( true ); } );

--- a/test/main/test.js
+++ b/test/main/test.js
@@ -153,6 +153,26 @@ QUnit.module( "test", function() {
 		} );
 	} );
 
+	QUnit.module( "arguments", function( hooks ) {
+		var testArgs;
+		var todoArgs;
+		hooks.after( function( assert ) {
+			assert.strictEqual( testArgs, 1, "test() callback args" );
+			assert.strictEqual( todoArgs, 1, "test.todo() callback args" );
+		} );
+
+		QUnit.test( "test() callback", function( assert ) {
+			testArgs = arguments.length;
+			assert.true( true );
+		} );
+		QUnit.test.todo( "test.todo() callback", function( assert ) {
+
+			// Captured and asserted later since todo() is expected to fail
+			todoArgs = arguments.length;
+			assert.true( false );
+		} );
+	} );
+
 	QUnit.module( "custom assertions" );
 
 	QUnit.assert.mod2 = function( value, expected, message ) {


### PR DESCRIPTION
This restores previous behaviour to avoid breaking plugins that might
already extend or monkey-patch QUnit to add additional parameters to
the test callback.

Also:

* Declare the params setting in the Test class for added clarity, and to ensure a consistent object shape.

* Make more use of the new `addTest()` function that was added in https://github.com/qunitjs/qunit/pull/1569, this reduces a lot of duplication. Thanks @ventuno!

  While at it, I shifted the abstraction slightly to expose the Test class settings directly, thus making the `addTest()` mainly
  be responsible for the queuing and filtering, and no longer responsible for formatting the Test class settings.

  With the added use of ES2015 shorthand property name syntax, this feels almost identical using function parameters.