### PR TITLE
Fix docs generation with patch version

### DIFF
--- a/docs/QUnit/module.md
+++ b/docs/QUnit/module.md
@@ -7,7 +7,7 @@ categories:
 redirect_from:
   - "/QUnit.module/"
   - "/module/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `QUnit.module( name [, options] [, nested ] )`<br>

--- a/docs/QUnit/start.md
+++ b/docs/QUnit/start.md
@@ -7,7 +7,7 @@ categories:
   - async
 redirect_from:
   - "/start/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `QUnit.start()` must be used to start a test run that has [`QUnit.config.autostart`](../config/QUnit.config.md) set to `false`.

--- a/docs/QUnit/test.md
+++ b/docs/QUnit/test.md
@@ -10,7 +10,7 @@ redirect_from:
   - "/QUnit.test/"
   - "/asyncTest/"
   - "/test/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `QUnit.test( name, callback )`

--- a/docs/QUnit/test.only.md
+++ b/docs/QUnit/test.only.md
@@ -7,7 +7,7 @@ categories:
 redirect_from:
   - "/QUnit.only/"
   - "/QUnit/only/"
-version_added: "1.20"
+version_added: "1.20.0"
 ---
 
 `QUnit.test.only( name, callback )`<br>

--- a/docs/QUnit/test.skip.md
+++ b/docs/QUnit/test.skip.md
@@ -7,7 +7,7 @@ categories:
 redirect_from:
   - "/QUnit.skip/"
   - "/QUnit/skip/"
-version_added: "1.16"
+version_added: "1.16.0"
 ---
 
 `QUnit.test.skip( name, callback )`<br/>

--- a/docs/QUnit/test.todo.md
+++ b/docs/QUnit/test.todo.md
@@ -7,7 +7,7 @@ categories:
 redirect_from:
   - "/QUnit.todo/"
   - "/QUnit/todo/"
-version_added: "2.2"
+version_added: "2.2.0"
 ---
 
 `QUnit.test.todo( name, callback )`<br>

--- a/docs/_includes/version.html
+++ b/docs/_includes/version.html
@@ -8,7 +8,7 @@
 {%- endcomment -%}
 {%- assign _old_releases = " v1.9.0 v1.10.0 v1.11.0 v1.12.0 " -%}
 
-{%- assign _full_version = include.version | append: ".0" -%}
+{%- assign _full_version = include.version -%}
 {%- assign _old_version = _full_version | prepend: "v" -%}
 {%- if _old_releases contains _old_version -%}
     {%- assign _full_version = _old_version -%}

--- a/docs/assert/async.md
+++ b/docs/assert/async.md
@@ -9,7 +9,7 @@ redirect_from:
   - "/QUnit.stop/"
   - "/QUnit/stop/"
   - "/stop/"
-version_added: "1.16"
+version_added: "1.16.0"
 ---
 
 `async( [ acceptCallCount = 1 ] )`

--- a/docs/assert/deepEqual.md
+++ b/docs/assert/deepEqual.md
@@ -6,7 +6,7 @@ categories:
   - assert
 redirect_from:
   - "/deepEqual/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `deepEqual( actual, expected [, message ] )`

--- a/docs/assert/equal.md
+++ b/docs/assert/equal.md
@@ -8,7 +8,7 @@ redirect_from:
   - "/equal/"
   - "/equals/"
   - "/assert/equals/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `equal( actual, expected [, message ] )`

--- a/docs/assert/expect.md
+++ b/docs/assert/expect.md
@@ -6,7 +6,7 @@ categories:
   - assert
 redirect_from:
   - "/expect/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `expect( amount )`

--- a/docs/assert/false.md
+++ b/docs/assert/false.md
@@ -4,7 +4,7 @@ title: assert.false()
 excerpt: A strict boolean false comparison.
 categories:
   - assert
-version_added: "2.11"
+version_added: "2.11.0"
 ---
 
 `false( actual [, message ] )`

--- a/docs/assert/notDeepEqual.md
+++ b/docs/assert/notDeepEqual.md
@@ -6,7 +6,7 @@ categories:
   - assert
 redirect_from:
   - "/notDeepEqual/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `notDeepEqual( actual, expected [, message ] )`

--- a/docs/assert/notEqual.md
+++ b/docs/assert/notEqual.md
@@ -6,7 +6,7 @@ categories:
   - assert
 redirect_from:
   - "/notEqual/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `notEqual( actual, expected [, message ] )`

--- a/docs/assert/notOk.md
+++ b/docs/assert/notOk.md
@@ -4,7 +4,7 @@ title: assert.notOk()
 excerpt: Check if the first argument is falsy.
 categories:
   - assert
-version_added: "1.18"
+version_added: "1.18.0"
 ---
 
 `notOk( state [, message ] )`

--- a/docs/assert/notPropEqual.md
+++ b/docs/assert/notPropEqual.md
@@ -6,7 +6,7 @@ categories:
   - assert
 redirect_from:
   - "/notPropEqual/"
-version_added: "1.11"
+version_added: "1.11.0"
 ---
 
 `notPropEqual( actual, expected [, message ] )`

--- a/docs/assert/notStrictEqual.md
+++ b/docs/assert/notStrictEqual.md
@@ -6,7 +6,7 @@ categories:
   - assert
 redirect_from:
   - "/notStrictEqual/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `notStrictEqual( actual, expected [, message ] )`

--- a/docs/assert/ok.md
+++ b/docs/assert/ok.md
@@ -6,7 +6,7 @@ categories:
   - assert
 redirect_from:
   - "/ok/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `ok( state [, message ] )`

--- a/docs/assert/propEqual.md
+++ b/docs/assert/propEqual.md
@@ -6,7 +6,7 @@ categories:
   - assert
 redirect_from:
   - "/propEqual/"
-version_added: "1.11"
+version_added: "1.11.0"
 ---
 
 `propEqual( actual, expected [, message ] )`

--- a/docs/assert/pushResult.md
+++ b/docs/assert/pushResult.md
@@ -4,7 +4,7 @@ title: assert.pushResult()
 excerpt: Report the result of a custom assertion.
 categories:
   - assert
-version_added: "1.22"
+version_added: "1.22.0"
 ---
 
 `pushResult( data )`

--- a/docs/assert/rejects.md
+++ b/docs/assert/rejects.md
@@ -4,7 +4,7 @@ title: assert.rejects()
 excerpt: Test if the provided promise rejects.
 categories:
   - assert
-version_added: "2.5"
+version_added: "2.5.0"
 ---
 
 `rejects( promise[, expectedMatcher][, message ] )`

--- a/docs/assert/step.md
+++ b/docs/assert/step.md
@@ -4,7 +4,7 @@ title: assert.step()
 excerpt: A marker for progress in a given test.
 categories:
   - assert
-version_added: "2.2"
+version_added: "2.2.0"
 ---
 
 `step( [ message ] )`

--- a/docs/assert/strictEqual.md
+++ b/docs/assert/strictEqual.md
@@ -8,7 +8,7 @@ redirect_from:
   - "/same/"
   - "/strictEqual/"
   - "/assert/same/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `strictEqual( actual, expected [, message ] )`

--- a/docs/assert/throws.md
+++ b/docs/assert/throws.md
@@ -7,7 +7,7 @@ categories:
 redirect_from:
   - "/assert/raises/"
   - "/throws/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `throws( blockFn[, expectedMatcher][, message ] )`<br>

--- a/docs/assert/timeout.md
+++ b/docs/assert/timeout.md
@@ -5,7 +5,7 @@ excerpt: Set the length of time to wait for async operations before failing the 
 categories:
   - assert
   - async
-version_added: "2.4"
+version_added: "2.4.0"
 ---
 
 `timeout( duration )`

--- a/docs/assert/true.md
+++ b/docs/assert/true.md
@@ -4,7 +4,7 @@ title: assert.true()
 excerpt: A strict boolean true comparison.
 categories:
   - assert
-version_added: "2.11"
+version_added: "2.11.0"
 ---
 
 `true( actual [, message ] )`

--- a/docs/assert/verifySteps.md
+++ b/docs/assert/verifySteps.md
@@ -4,7 +4,7 @@ title: assert.verifySteps()
 excerpt: A helper assertion to verify the order and number of steps in a test.
 categories:
   - assert
-version_added: "2.2"
+version_added: "2.2.0"
 ---
 
 `verifySteps( steps [, message ] )`

--- a/docs/callbacks/QUnit.begin.md
+++ b/docs/callbacks/QUnit.begin.md
@@ -6,7 +6,7 @@ categories:
   - callbacks
 redirect_from:
   - "/QUnit.begin/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `QUnit.begin( callback )`

--- a/docs/callbacks/QUnit.done.md
+++ b/docs/callbacks/QUnit.done.md
@@ -6,7 +6,7 @@ categories:
   - callbacks
 redirect_from:
   - "/QUnit.done/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `QUnit.done( callback )`

--- a/docs/callbacks/QUnit.log.md
+++ b/docs/callbacks/QUnit.log.md
@@ -6,7 +6,7 @@ categories:
   - callbacks
 redirect_from:
   - "/QUnit.log/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `QUnit.log( callback )`

--- a/docs/callbacks/QUnit.moduleDone.md
+++ b/docs/callbacks/QUnit.moduleDone.md
@@ -6,7 +6,7 @@ categories:
   - callbacks
 redirect_from:
   - "/QUnit.moduleDone/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `QUnit.moduleDone( callback )`

--- a/docs/callbacks/QUnit.moduleStart.md
+++ b/docs/callbacks/QUnit.moduleStart.md
@@ -6,7 +6,7 @@ categories:
   - callbacks
 redirect_from:
   - "/QUnit.moduleStart/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `QUnit.moduleStart( callback )`

--- a/docs/callbacks/QUnit.on.md
+++ b/docs/callbacks/QUnit.on.md
@@ -4,7 +4,7 @@ title: QUnit.on()
 excerpt: Register a callback to fire whenever the specified event is emitted.
 categories:
   - callbacks
-version_added: "2.2"
+version_added: "2.2.0"
 ---
 
 `QUnit.on( eventName, callback )`

--- a/docs/callbacks/QUnit.testDone.md
+++ b/docs/callbacks/QUnit.testDone.md
@@ -6,7 +6,7 @@ categories:
   - callbacks
 redirect_from:
   - "/QUnit.testDone/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `QUnit.testDone( callback )`

--- a/docs/callbacks/QUnit.testStart.md
+++ b/docs/callbacks/QUnit.testStart.md
@@ -6,7 +6,7 @@ categories:
   - callbacks
 redirect_from:
   - "/QUnit.testStart/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `QUnit.testStart( callback )`

--- a/docs/config/QUnit.assert.md
+++ b/docs/config/QUnit.assert.md
@@ -4,7 +4,7 @@ title: QUnit.assert
 excerpt: Namespace for QUnit assertion methods.
 categories:
   - config
-version_added: "1.7"
+version_added: "1.7.0"
 ---
 
 Namespace for QUnit assertion methods. This object is the prototype for the internal Assert class of which instances are passed as the argument to [`QUnit.test()`](../QUnit/test.md) callbacks.

--- a/docs/config/QUnit.config.md
+++ b/docs/config/QUnit.config.md
@@ -33,7 +33,7 @@ Whether to fail the test run if no tests were run.
 
 By default, it is considered an error if no tests were loaded, or if no tests matched the current filter. Turning this option off means an empty test run will result in a success instead.
 
-* Version added: 2.16.0.
+* Version added: [2.16.0](https://github.com/qunitjs/qunit/releases/tag/2.16.0).
 
 ### `QUnit.config.filter` (string) | default: `undefined`
 

--- a/docs/config/QUnit.dump.parse.md
+++ b/docs/config/QUnit.dump.parse.md
@@ -7,7 +7,7 @@ categories:
 redirect_from:
   - "/QUnit.dump.parse/"
   - "/QUnit.jsDump.parse/"
-version_added: "1.0"
+version_added: "1.0.0"
 ---
 
 `QUnit.dump.parse( data )`

--- a/docs/config/QUnit.extend.md
+++ b/docs/config/QUnit.extend.md
@@ -6,7 +6,7 @@ categories:
 title: QUnit.extend()
 status: deprecated
 excerpt: Copy the properties from one object into a target object.
-version_added: "1.0"
+version_added: "1.0.0"
 version_deprecated: "2.12"
 ---
 

--- a/docs/config/QUnit.push.md
+++ b/docs/config/QUnit.push.md
@@ -6,7 +6,7 @@ categories:
 title: QUnit.push()
 status: deprecated
 excerpt: Report the result of a custom assertion.
-version_added: "1.0"
+version_added: "1.0.0"
 version_deprecated: "2.1"
 ---
 

--- a/docs/config/QUnit.stack.md
+++ b/docs/config/QUnit.stack.md
@@ -3,7 +3,7 @@ layout: default
 categories: [config]
 title: QUnit.stack()
 excerpt: Return a single line string representing the stacktrace.
-version_added: "1.19"
+version_added: "1.19.0"
 ---
 
 `QUnit.stack( [ offset = 0 ] )`


### PR DESCRIPTION
Follow up on [@Krinkle's comment to PR 1621](https://github.com/qunitjs/qunit/pull/1621#issuecomment-855522462).

Filtered out docs to append `.0` to:
```bash
grep -El 'version_added: "\d+\.\d+"' docs/**/*.md
```
Tested by building [api.qunitjs.com](https://api.qunitjs.com/) locally.

<img width="772" alt="Screen Shot 2021-06-12 at 5 15 19 PM" src="https://user-images.githubusercontent.com/5890858/121789185-d2b23680-cba1-11eb-84a5-5b84f78b2311.png">
<img width="777" alt="Screen Shot 2021-06-12 at 5 15 26 PM" src="https://user-images.githubusercontent.com/5890858/121789187-d776ea80-cba1-11eb-9514-b8dd309eb3ff.png">

