### PR TITLE
Docs: Minor improvements to `assert.timeout()` description

### DIFF
--- a/docs/assert/async.md
+++ b/docs/assert/async.md
@@ -18,7 +18,7 @@ Instruct QUnit to wait for an asynchronous operation.
 
 | name | description |
 |------|-------------|
-| `acceptCallCount` (Number) | Number of expected callbacks before the test is done. Defaults to `1`. |
+| `acceptCallCount` (number) | Number of expected callbacks before the test is done. Defaults to `1`. |
 
 ### Description
 

--- a/docs/assert/timeout.md
+++ b/docs/assert/timeout.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: assert.timeout()
-excerpt: Set the length of time to wait for async operations before failing the test.
+excerpt: Set how long to wait for async operations.
 categories:
   - assert
   - async
@@ -10,19 +10,19 @@ version_added: "2.4.0"
 
 `timeout( duration )`
 
-Set the length of time to wait for async operations before failing the test.
+Set how long to wait for async operations to complete before failing the test.
 
 | name | description |
 |------|-------------|
-| `duration` (Number) | The length of time, in milliseconds, to wait for async operations. |
+| `duration` (number) | The length of time, in milliseconds, to wait for async operations. |
 
 ### Description
 
-`assert.timeout()` sets the length of time, in milliseconds, to wait for async operations in the current test. This is equivalent to setting `config.testTimeout` on a per-test basis. The timeout length only applies when performing async operations.
+`assert.timeout()` defines how long to wait (at most) in the current test. It overrides [`QUnit.config.testTimeout`](../config/QUnit.config.md) on a per-test basis.
 
-If `assert.timeout()` is called after a timeout has already been set, the old timeout will be cleared and the new duration will be used for the new timer.
+The timeout length only applies when performing async operations. If `0` is passed, then any asynchronous task may fail the test.
 
-If `0` is passed, then the test will be assumed to be completely synchronous. If a non-numeric value is passed as an argument, the function will throw an error.
+If `assert.timeout()` is called after a timeout has already been set, the old timeout will be cleared and the new duration will be used for a new timer. If a non-numeric value is passed as an argument, the function will throw an error.
 
 ### Examples
 

--- a/docs/config/QUnit.config.md
+++ b/docs/config/QUnit.config.md
@@ -1,8 +1,9 @@
 ---
 layout: default
-categories: [config]
 title: QUnit.config
 excerpt: General configuration for QUnit. Check the description of each option for details.
+categories:
+  - config
 redirect_from:
   - "/QUnit.config/"
 ---

--- a/docs/config/QUnit.extend.md
+++ b/docs/config/QUnit.extend.md
@@ -1,11 +1,10 @@
 ---
 layout: default
+title: QUnit.extend()
+excerpt: Copy the properties from one object into a target object.
 categories:
 - config
 - deprecated
-title: QUnit.extend()
-status: deprecated
-excerpt: Copy the properties from one object into a target object.
 version_added: "1.0.0"
 version_deprecated: "2.12"
 ---

--- a/docs/config/QUnit.push.md
+++ b/docs/config/QUnit.push.md
@@ -1,11 +1,10 @@
 ---
 layout: default
+title: QUnit.push()
+excerpt: Report the result of a custom assertion.
 categories:
 - config
 - deprecated
-title: QUnit.push()
-status: deprecated
-excerpt: Report the result of a custom assertion.
 version_added: "1.0.0"
 version_deprecated: "2.1"
 ---

--- a/docs/config/QUnit.stack.md
+++ b/docs/config/QUnit.stack.md
@@ -1,14 +1,15 @@
 ---
 layout: default
-categories: [config]
 title: QUnit.stack()
 excerpt: Return a single line string representing the stacktrace.
+categories:
+- config
 version_added: "1.19.0"
 ---
 
 `QUnit.stack( [ offset = 0 ] )`
 
-Return a single line string representing the stacktrace (call stack)
+Return a single line string representing the stacktrace (call stack).
 
 | name | description |
 |------|-------------|

--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -58,7 +58,7 @@ export function diff( a, b ) {
  * Determines whether an element exists in a given array or not.
  *
  * @method inArray
- * @param {Any} elem
+ * @param {any} elem
  * @param {Array} array
  * @return {boolean}
  */


### PR DESCRIPTION
* Consistently use lowercase for primitive types and `any`.
* Consistently use YAML syntax for `categorie` front matter.
* Consistently order the front matter of config pages.
* Remove `status: deprecated` front matter, which is no longer used (we use categories and version_deprecated instead.)