### PR TITLE
Tests: Add tests covering callback failures

### DIFF
--- a/src/core/on-uncaught-exception.js
+++ b/src/core/on-uncaught-exception.js
@@ -47,6 +47,9 @@ export default function onUncaughtException( error ) {
 		// emitted after "runEnd" and before the process exits.
 		// The HTML Reporter can use this to renmder it on the page in a test-like
 		// block for easy discovery.
-		Logger.warn( `${message}\n${source}` );
+		//
+		// Avoid printing "Error: foo" twice if the environment's native stack trace
+		// already includes that in its format.
+		Logger.warn( source.indexOf( source ) !== -1 ? source : `${message}\n${source}` );
 	}
 }

--- a/test/cli/fixtures/bad-callbacks/begin-throw.js
+++ b/test/cli/fixtures/bad-callbacks/begin-throw.js
@@ -1,0 +1,9 @@
+QUnit.begin( () => {
+	throw new Error( "No dice" );
+} );
+
+QUnit.module( "module1", () => {
+	QUnit.test( "test1", assert => {
+		assert.true( true );
+	} );
+} );

--- a/test/cli/fixtures/bad-callbacks/done-throw.js
+++ b/test/cli/fixtures/bad-callbacks/done-throw.js
@@ -1,0 +1,9 @@
+QUnit.done( () => {
+	throw new Error( "No dice" );
+} );
+
+QUnit.module( "module1", () => {
+	QUnit.test( "test1", assert => {
+		assert.true( true );
+	} );
+} );

--- a/test/cli/fixtures/bad-callbacks/moduleDone-throw.js
+++ b/test/cli/fixtures/bad-callbacks/moduleDone-throw.js
@@ -1,0 +1,15 @@
+QUnit.moduleDone( details => {
+	throw new Error( "No dice for " + details.name );
+} );
+
+QUnit.module( "module1", () => {
+	QUnit.test( "test1", assert => {
+		assert.true( true );
+	} );
+} );
+
+QUnit.module( "module2", () => {
+	QUnit.test( "test2", assert => {
+		assert.true( true );
+	} );
+} );

--- a/test/cli/fixtures/bad-callbacks/testStart-throw.js
+++ b/test/cli/fixtures/bad-callbacks/testStart-throw.js
@@ -1,0 +1,15 @@
+QUnit.testStart( details => {
+	throw new Error( "No dice for " + details.name );
+} );
+
+QUnit.module( "module1", () => {
+	QUnit.test( "test1", assert => {
+		assert.true( true );
+	} );
+} );
+
+QUnit.module( "module2", () => {
+	QUnit.test( "test2", assert => {
+		assert.true( true );
+	} );
+} );

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -61,7 +61,7 @@ not ok 1 Throws match > bad
   actual  : Error: Match me with a pattern
   expected: "/incorrect pattern/"
   stack: |
-        at Object.<anonymous> (/qunit/test/cli/fixtures/fail/throws-match.js:3:10)
+        at /qunit/test/cli/fixtures/fail/throws-match.js:3:10
   ...
 1..1
 # pass 0
@@ -98,16 +98,13 @@ ok 5 A-Test > derp
 	"qunit --reporter npm-reporter": "Run ended!",
 	"qunit --reporter does-not-exist": `No reporter found matching "does-not-exist".
 Built-in reporters: console, tap
-Extra reporters found among package dependencies: npm-reporter
-`,
+Extra reporters found among package dependencies: npm-reporter`,
 
 	"qunit --reporter": `Built-in reporters: console, tap
-Extra reporters found among package dependencies: npm-reporter
-`,
+Extra reporters found among package dependencies: npm-reporter`,
 
 	"qunit hanging-test": `Error: Process exited before tests finished running
-Last test to run (hanging) has an async hold. Ensure all assert.async() callbacks are invoked and Promises resolve. You should also set a standard timeout via QUnit.config.testTimeout.
-`,
+Last test to run (hanging) has an async hold. Ensure all assert.async() callbacks are invoked and Promises resolve. You should also set a standard timeout via QUnit.config.testTimeout.`,
 	/* eslint-enable max-len */
 	"qunit unhandled-rejection.js":
 `TAP version 13
@@ -130,10 +127,10 @@ not ok 2 global failure
   expected: undefined
   stack: |
     Error: outside of a test context
-        at Object.<anonymous> (/qunit/test/cli/fixtures/unhandled-rejection.js:17:18)
+        at /qunit/test/cli/fixtures/unhandled-rejection.js:17:18
         at processModule (/qunit/qunit/qunit.js)
         at Object.module$1 [as module] (/qunit/qunit/qunit.js)
-        at Object.<anonymous> (/qunit/test/cli/fixtures/unhandled-rejection.js:3:7)
+        at /qunit/test/cli/fixtures/unhandled-rejection.js:3:7
         at internal
   ...
 1..2
@@ -175,7 +172,7 @@ not ok 2 Example > bad
   actual  : false
   expected: true
   stack: |
-        at Object.<anonymous> (/qunit/test/cli/fixtures/sourcemap/source.js:7:14)
+        at /qunit/test/cli/fixtures/sourcemap/source.js:7:14
   ...
 1..2
 # pass 1
@@ -193,7 +190,7 @@ not ok 2 Example > bad
   actual  : false
   expected: true
   stack: |
-        at Object.<anonymous> (/qunit/test/cli/fixtures/sourcemap/sourcemap/source.js:7:10)
+        at /qunit/test/cli/fixtures/sourcemap/sourcemap/source.js:7:10
   ...
 1..2
 # pass 1
@@ -299,7 +296,7 @@ not ok 1 # TODO module B > Only this module should run > a todo test
   actual  : false
   expected: true
   stack: |
-        at Object.<anonymous> (/qunit/test/cli/fixtures/only/module.js:17:15)
+        at /qunit/test/cli/fixtures/only/module.js:17:15
   ...
 ok 2 # SKIP module B > Only this module should run > implicitly skipped test
 ok 3 module B > Only this module should run > normal test
@@ -321,7 +318,7 @@ not ok 1 # TODO module B > test B
   actual  : false
   expected: true
   stack: |
-        at Object.<anonymous> (/qunit/test/cli/fixtures/only/module-flat.js:9:13)
+        at /qunit/test/cli/fixtures/only/module-flat.js:9:13
   ...
 ok 2 # SKIP module B > test C
 ok 3 module B > test D

--- a/test/cli/helpers/execute.js
+++ b/test/cli/helpers/execute.js
@@ -13,7 +13,17 @@ function normalize( actual ) {
 
 	return actual
 		.replace( reDir, "/qunit" )
+
+		// Convert "at processModule (/qunit/qunit/qunit.js:1:2)" to "at processModule (/qunit/qunit/qunit.js)"
 		.replace( /(\/qunit\/qunit\/qunit\.js):\d+:\d+\)/g, "$1)" )
+
+		// Convert "at /qunit/qunit/qunit.js:1:2" to "at /qunit/qunit/qunit.js"
+		.replace( /( {2}at \/qunit\/qunit\/qunit\.js):\d+:\d+/g, "$1" )
+
+		// Strip inferred names for anonymous test closures (as Node 10 did),
+		// to match the output of Node 12+.
+		// Convert "at QUnit.done (/qunit/test/foo.js:1:2)" to "at /qunit/test/foo.js:1:2"
+		.replace( /\b(at )\S+ \((\/qunit\/test\/[^:]+:\d+:\d+)\)/g, "$1$2" )
 
 		// convert sourcemap'ed traces from Node 14 and earlier to the
 		// standard format used by Node 15+.
@@ -62,6 +72,7 @@ module.exports = async function execute( command, execaOptions, hook ) {
 		return result;
 	} catch ( e ) {
 		e.stdout = normalize( String( e.stdout ).trimEnd() );
+		e.stderr = normalize( String( e.stderr ).trimEnd() );
 		throw e;
 	}
 };


### PR DESCRIPTION
Capture the status quo before changing it.

Minor changes:

* Switch remaining notEquals/indexOf uses to the preferred `assert.true( str.includes() )` idiom.

* Fix duplicate printing of error message due to V8's `Error#stack`, as used by onUncaughtException.
  Ref https://github.com/qunitjs/qunit/pull/1629.

* Start normalizing stderror in tests like we do with stdout.

* Account for qunit.js stack frames from native Promise in V8, which doesn't include a function name or paranthesis.

Ref https://github.com/qunitjs/qunit/issues/1446.
Ref https://github.com/qunitjs/qunit/issues/1633.