### PR TITLE
Assert: Improve detection of bad calls to `assert.async()` callbacks

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -72,47 +72,10 @@ class Assert {
 		}
 	}
 
-	// Put a hold on processing and return a function that will release it a maximum of once.
+	// Create a new async pause and return a new function that can release the pause.
 	async( count ) {
-		const test = this.test;
-
-		let popped = false,
-			acceptCallCount = count;
-
-		if ( typeof acceptCallCount === "undefined" ) {
-			acceptCallCount = 1;
-		}
-
-		const resume = internalStop( test );
-
-		return function done() {
-
-			if ( config.current === undefined ) {
-				throw new Error( "`assert.async` callback from test \"" +
-					test.testName + "\" called after tests finished." );
-			}
-
-			if ( config.current !== test ) {
-				config.current.pushFailure(
-					"`assert.async` callback from test \"" +
-					test.testName + "\" was called during this test." );
-				return;
-			}
-
-			if ( popped ) {
-				test.pushFailure( "Too many calls to the `assert.async` callback",
-					sourceFromStacktrace( 2 ) );
-				return;
-			}
-
-			acceptCallCount -= 1;
-			if ( acceptCallCount > 0 ) {
-				return;
-			}
-
-			popped = true;
-			resume();
-		};
+		const requiredCalls = count === undefined ? 1 : count;
+		return internalStop( this.test, requiredCalls );
 	}
 
 	// Exports test.push() to the user API

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -109,7 +109,7 @@ async function run( args, options ) {
 			console.error( "Error: Process exited before tests finished running" );
 
 			const currentTest = QUnit.config.current;
-			if ( currentTest && currentTest.asyncPauses.size ) {
+			if ( currentTest && currentTest.asyncPauses.size > 0 ) {
 				const name = currentTest.testName;
 				console.error( "Last test to run (" + name + ") has an async hold. " +
 					"Ensure all assert.async() callbacks are invoked and Promises resolve. " +

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -109,7 +109,7 @@ async function run( args, options ) {
 			console.error( "Error: Process exited before tests finished running" );
 
 			const currentTest = QUnit.config.current;
-			if ( currentTest && currentTest.semaphore ) {
+			if ( currentTest && currentTest.asyncPauses.size ) {
 				const name = currentTest.testName;
 				console.error( "Last test to run (" + name + ") has an async hold. " +
 					"Ensure all assert.async() callbacks are invoked and Promises resolve. " +

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -109,7 +109,7 @@ async function run( args, options ) {
 			console.error( "Error: Process exited before tests finished running" );
 
 			const currentTest = QUnit.config.current;
-			if ( currentTest && currentTest.asyncPauses.size > 0 ) {
+			if ( currentTest && currentTest.pauses.size > 0 ) {
 				const name = currentTest.testName;
 				console.error( "Last test to run (" + name + ") has an async hold. " +
 					"Ensure all assert.async() callbacks are invoked and Promises resolve. " +

--- a/src/html-reporter/es6-map.js
+++ b/src/html-reporter/es6-map.js
@@ -1,14 +1,35 @@
-// Support IE 9-10, PhantomJS: Fallback for fuzzysort.js used by ./html.js
+// Support IE 9-10, Safari 7, PhantomJS: Partial Map fallback.
+// Used by html.js (via fuzzysort.js), and test.js.
+//
+// FIXME: This check is broken. This file is embedded in the qunit.js closure,
+// thus the Map var is hoisted in that scope, and starts undefined (not a function).
 var Map = typeof Map === "function" ? Map : function StringMap() {
 	var store = Object.create( null );
+	var hasOwn = Object.prototype.hasOwnProperty;
 	this.get = function( strKey ) {
 		return store[ strKey ];
 	};
 	this.set = function( strKey, val ) {
+		if ( !hasOwn.call( store, strKey ) ) {
+			this.size++;
+		}
 		store[ strKey ] = val;
 		return this;
 	};
+	this.delete = function( strKey ) {
+		if ( hasOwn.call( store, strKey ) ) {
+			delete store[ strKey ];
+			this.size--;
+		}
+	};
+	this.forEach = function( callback ) {
+		for ( var strKey in store ) {
+			callback( store[ strKey ], strKey );
+		}
+	};
 	this.clear = function() {
 		store = Object.create( null );
+		this.size = 0;
 	};
+	this.size = 0;
 };

--- a/src/test.js
+++ b/src/test.js
@@ -902,6 +902,7 @@ export function internalStop( test, requiredCalls = 1 ) {
 		internalStart( test );
 	}
 
+	// Set a recovery timeout, if so configured.
 	if ( setTimeout ) {
 		let timeoutDuration;
 		if ( typeof test.timeout === "number" ) {
@@ -910,7 +911,6 @@ export function internalStop( test, requiredCalls = 1 ) {
 			timeoutDuration = config.testTimeout;
 		}
 
-		// Set a recovery timeout, if so configured.
 		if ( typeof timeoutDuration === "number" && timeoutDuration > 0 ) {
 			config.timeoutHandler = function( timeout ) {
 				return function() {

--- a/src/test.js
+++ b/src/test.js
@@ -864,7 +864,7 @@ export function resetTestTimeout( timeoutDuration ) {
 //
 // * Pause release() is called too often, during the same test.
 //
-//   This is simply throws an error, after which uncaught error handling picks it up
+//   This simply throws an error, after which uncaught error handling picks it up
 //   and processing resumes.
 export function internalStop( test, requiredCalls = 1 ) {
 	config.blocking = true;

--- a/src/test.js
+++ b/src/test.js
@@ -915,13 +915,13 @@ export function internalStop( test, requiredCalls = 1 ) {
 			config.timeoutHandler = function( timeout ) {
 				return function() {
 					config.timeout = null;
+					pause.cancelled = true;
+					test.asyncPauses.delete( pauseId );
+
 					pushFailure(
 						`Test took longer than ${timeout}ms; test timed out.`,
 						sourceFromStacktrace( 2 )
 					);
-
-					pause.cancelled = true;
-					test.asyncPauses.delete( pauseId );
 					internalStart( test );
 				};
 			};

--- a/src/test.js
+++ b/src/test.js
@@ -869,7 +869,7 @@ export function resetTestTimeout( timeoutDuration ) {
 export function internalStop( test, requiredCalls = 1 ) {
 	config.blocking = true;
 
-	const pauseId = `#${test.asyncNextPauseId++}`;
+	const pauseId = test.asyncNextPauseId++;
 	const pause = {
 		cancelled: false,
 		remaining: requiredCalls
@@ -882,15 +882,15 @@ export function internalStop( test, requiredCalls = 1 ) {
 		}
 		if ( config.current === undefined ) {
 			throw new Error( "Unexpected release of async pause after tests finished.\n" +
-				`> Test: ${test.testName} [async ${pauseId}]` );
+				`> Test: ${test.testName} [async #${pauseId}]` );
 		}
 		if ( config.current !== test ) {
 			throw new Error( "Unexpected release of async pause during a different test.\n" +
-				`> Test: ${test.testName} [async ${pauseId}]` );
+				`> Test: ${test.testName} [async #${pauseId}]` );
 		}
 		if ( pause.remaining <= 0 ) {
 			throw new Error( "Tried to release async pause that was already released.\n" +
-				`> Test: ${test.testName} [async ${pauseId}]` );
+				`> Test: ${test.testName} [async #${pauseId}]` );
 		}
 
 		// The `requiredCalls` parameter exists to support `assert.async(count)`

--- a/src/test.js
+++ b/src/test.js
@@ -918,7 +918,7 @@ export function internalStop( test, requiredCalls = 1 ) {
 					pause.cancelled = true;
 					test.asyncPauses.delete( pauseId );
 
-					pushFailure(
+					test.pushFailure(
 						`Test took longer than ${timeout}ms; test timed out.`,
 						sourceFromStacktrace( 2 )
 					);

--- a/test/cli/fixtures/drooling-done.js
+++ b/test/cli/fixtures/drooling-done.js
@@ -10,5 +10,8 @@ QUnit.test( "Test A", assert => {
 
 QUnit.test( "Test B", assert => {
 	assert.ok( true );
-	done(); // Silently ignored since "Test A" already failed and we killed its async pauses.
+
+	// This bad call is silently ignored because "Test A" already failed
+	// and we cancelled the async pauses.
+	done();
 } );

--- a/test/cli/fixtures/drooling-extra-done-outside.js
+++ b/test/cli/fixtures/drooling-extra-done-outside.js
@@ -1,0 +1,11 @@
+QUnit.test( "extra done scheduled outside any test", assert => {
+	assert.timeout( 10 );
+	const done = assert.async();
+	assert.true( true );
+
+	// Later, boom!
+	setTimeout( done, 100 );
+
+	// Passing, end of test
+	done();
+} );

--- a/test/cli/fixtures/drooling-extra-done.js
+++ b/test/cli/fixtures/drooling-extra-done.js
@@ -5,10 +5,14 @@ let done;
 QUnit.test( "Test A", assert => {
 	assert.ok( true );
 	done = assert.async();
-	throw new Error( "this is an intentional error" );
+
+	// Passing.
+	done();
 } );
 
 QUnit.test( "Test B", assert => {
 	assert.ok( true );
-	done(); // Silently ignored since "Test A" already failed and we killed its async pauses.
+
+	// Boom
+	done();
 } );

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -426,16 +426,88 @@ not ok 1 times out before scheduled done is called
 # pass 0
 # skip 0
 # todo 0
-# fail 1
-Bail out! Error: \`assert.async\` callback from test "times out before scheduled done is called" called after tests finished.
+# fail 1`,
+
+	"qunit drooling-done.js":
+`TAP version 13
+not ok 1 Test A
   ---
-  message: "Error: \`assert.async\` callback from test \\"times out before scheduled done is called\\" called after tests finished."
+  message: "Died on test #2     at Object.test (/qunit/qunit/qunit.js): this is an intentional error"
+  severity: failed
+  actual  : null
+  expected: undefined
+  stack: |
+    Error: this is an intentional error
+        at /qunit/test/cli/fixtures/drooling-done.js:8:8
+  ...
+ok 2 Test B
+1..2
+# pass 1
+# skip 0
+# todo 0
+# fail 1`,
+
+	"qunit drooling-extra-done.js":
+`TAP version 13
+ok 1 Test A
+not ok 2 Test B
+  ---
+  message: |+
+    Died on test #2     at Object.test (/qunit/qunit/qunit.js): Unexpected release of async pause during a different test.
+    > Test: Test A [async #1]
+  severity: failed
+  actual  : null
+  expected: undefined
+  stack: |
+    Error: Unexpected release of async pause during a different test.
+    > Test: Test A [async #1]
+  ...
+1..2
+# pass 1
+# skip 0
+# todo 0
+# fail 1`,
+
+	"qunit drooling-extra-done-outside.js":
+`TAP version 13
+ok 1 extra done scheduled outside any test
+1..1
+# pass 1
+# skip 0
+# todo 0
+# fail 0
+Bail out! Error: Unexpected release of async pause after tests finished.
+  ---
+  message: |+
+    Error: Unexpected release of async pause after tests finished.
+    > Test: extra done scheduled outside any test [async #1]
   severity: failed
   stack: |
-    Error: \`assert.async\` callback from test "times out before scheduled done is called" called after tests finished.
-        at Timeout.done [as _onTimeout] (/qunit/qunit/qunit.js)
+    Error: Unexpected release of async pause after tests finished.
+    > Test: extra done scheduled outside any test [async #1]
+        at Timeout.release [as _onTimeout] (/qunit/qunit/qunit.js)
         at internal
   ...`,
+
+	"qunit too-many-done-calls.js":
+`TAP version 13
+not ok 1 Test A
+  ---
+  message: |+
+    Died on test #2     at Object.test (/qunit/qunit/qunit.js): Tried to release async pause that was already released.
+    > Test: Test A [async #1]
+  severity: failed
+  actual  : null
+  expected: undefined
+  stack: |
+    Error: Tried to release async pause that was already released.
+    > Test: Test A [async #1]
+  ...
+1..1
+# pass 0
+# skip 0
+# todo 0
+# fail 1`,
 
 	"qunit assert-expect/no-tests.js":
 `TAP version 13

--- a/test/cli/fixtures/semaphore/nan.js
+++ b/test/cli/fixtures/semaphore/nan.js
@@ -1,5 +1,0 @@
-QUnit.test( "semaphore is set to NaN", assert => {
-	assert.test.semaphore = "not a number";
-	assert.async();
-	return Promise.resolve();
-} );

--- a/test/cli/fixtures/semaphore/restart.js
+++ b/test/cli/fixtures/semaphore/restart.js
@@ -1,4 +1,0 @@
-QUnit.test( "tries to 'restart' the test", assert => {
-	assert.test.semaphore = -1;
-	return Promise.resolve();
-} );

--- a/test/cli/main.js
+++ b/test/cli/main.js
@@ -571,33 +571,9 @@ CALLBACK: done`;
 		} );
 	} );
 
-	QUnit.module( "semaphore", () => {
-		QUnit.test( "invalid value", async assert => {
-			try {
-				await execute( "qunit semaphore/nan.js" );
-			} catch ( e ) {
-				assert.pushResult( {
-					result: e.stdout.includes( "message: Invalid value on test.semaphore" ),
-					actual: e.stdout + "\n" + e.stderr
-				} );
-			}
-		} );
-
-		QUnit.test( "try to restart ", async assert => {
-			try {
-				await execute( "qunit semaphore/restart.js" );
-			} catch ( e ) {
-				assert.pushResult( {
-					result: e.stdout.includes( "message: \"Tried to restart test while already started (test's semaphore was 0 already)" ),
-					actual: e.stdout + "\n" + e.stderr
-				} );
-			}
-		} );
-	} );
-
 	QUnit.module( "assert.async", () => {
 
-		QUnit.test( "assert.async callback after tests timeout", async assert => {
+		QUnit.test( "call after tests timeout", async assert => {
 			const command = "qunit done-after-timeout.js";
 			try {
 				await execute( command );
@@ -607,37 +583,43 @@ CALLBACK: done`;
 			}
 		} );
 
-		QUnit.test( "drooling calls across tests to assert.async callback", async assert => {
+		QUnit.test( "drooling call to callback across tests", async assert => {
 			const command = "qunit drooling-done.js";
 			try {
 				await execute( command );
 			} catch ( e ) {
 				assert.equal( e.code, 1 );
-				assert.equal( e.stderr, "" );
-
-				// code coverage and various Node versions can alter the stacks,
-				// so we can't compare exact strings, but we can spot-check
-				assert.true( e.stdout.includes(
-					"not ok 2 Test B\n" +
-					"  ---\n" +
-					"  message: \"`assert.async` callback from test \\\"Test A\\\" was called during this test.\"" ), e.stdout );
+				assert.equal( e.stdout, expectedOutput[ command ] );
 			}
 		} );
 
-		QUnit.test( "too many calls to assert.async callback", async assert => {
+		QUnit.test( "extra call to callback across tests", async assert => {
+			const command = "qunit drooling-extra-done.js";
+			try {
+				await execute( command );
+			} catch ( e ) {
+				assert.equal( e.code, 1 );
+				assert.equal( e.stdout, expectedOutput[ command ] );
+			}
+		} );
+
+		QUnit.test( "extra call to callback outside tests", async assert => {
+			const command = "qunit drooling-extra-done-outside.js";
+			try {
+				await execute( command );
+			} catch ( e ) {
+				assert.equal( e.code, 1 );
+				assert.equal( e.stdout, expectedOutput[ command ] );
+			}
+		} );
+
+		QUnit.test( "too many calls to callback", async assert => {
 			const command = "qunit too-many-done-calls.js";
 			try {
 				await execute( command );
 			} catch ( e ) {
 				assert.equal( e.code, 1 );
-				assert.equal( e.stderr, "" );
-
-				// code coverage and various Node versions can alter the stacks,
-				// so we can't compare exact strings, but we can spot-check
-				assert.true( e.stdout.includes(
-					"not ok 1 Test A\n" +
-					"  ---\n" +
-					"  message: Too many calls to the `assert.async` callback" ), e.stdout );
+				assert.equal( e.stdout, expectedOutput[ command ] );
 			}
 		} );
 

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -113,17 +113,12 @@ QUnit.module( "assert.async", function() {
 
 		assert.expect( 1 );
 
-		// Duck-punch to force an Error to be thrown instead of a `pushFailure` call
-		assert.test.pushFailure = function( msg ) {
-			throw new Error( msg );
-		};
-
 		var overDone = assert.async();
 		overDone();
 
 		assert.throws( function() {
 			overDone();
-		}, new RegExp( "Too many calls to the `assert.async` callback" ) );
+		}, /Tried to release async pause that was already released/ );
 
 		done();
 	} );
@@ -136,11 +131,6 @@ QUnit.module( "assert.async", function() {
 
 		assert.expect( 1 );
 
-		// Duck-punch to force an Error to be thrown instead of a `pushFailure` call
-		assert.test.pushFailure = function( msg ) {
-			throw new Error( msg );
-		};
-
 		var overDone = assert.async( 3 );
 		overDone();
 		overDone();
@@ -148,7 +138,7 @@ QUnit.module( "assert.async", function() {
 
 		assert.throws( function() {
 			overDone();
-		}, new RegExp( "Too many calls to the `assert.async` callback" ) );
+		}, /Tried to release async pause that was already released/ );
 
 		done();
 	} );
@@ -163,12 +153,10 @@ QUnit.module( "assert.async", function() {
 		} );
 
 		QUnit.test( "errors if called after test finishes - part 2", function( assert ) {
-
-			// Duck-punch to force an Error to be thrown instead of a `pushFailure` call
-			assert.test.pushFailure = function( msg ) {
-				throw new Error( msg );
-			};
-			assert.throws( previousTestDone, /Error: `assert\.async` callback from test "errors if called after test finishes - part 1" was called during this test./ );
+			assert.throws(
+				previousTestDone,
+				/Unexpected release of async pause during a different test.\n> Test: errors if called after test finishes - part 1/
+			);
 		} );
 	}() );
 
@@ -179,17 +167,12 @@ QUnit.module( "assert.async", function() {
 			// internals in order to avoid post-`done` assertions causing additional failures
 			var done = assert.async();
 
-			// Duck-punch to force an Error to be thrown instead of a `pushFailure` call
-			assert.test.pushFailure = function( msg ) {
-				throw new Error( msg );
-			};
-
 			var overDone = assert.async();
 			overDone();
 
 			assert.throws( function() {
 				overDone();
-			}, new RegExp( "Too many calls to the `assert.async` callback" ) );
+			}, /Tried to release async pause that was already released/ );
 
 			done();
 		}
@@ -204,17 +187,12 @@ QUnit.module( "assert.async", function() {
 			// internals in order to avoid post-`done` assertions causing additional failures
 			var done = assert.async();
 
-			// Duck-punch to force an Error to be thrown instead of a `pushFailure` call
-			assert.test.pushFailure = function( msg ) {
-				throw new Error( msg );
-			};
-
 			var overDone = assert.async();
 			overDone();
 
 			assert.throws( function() {
 				overDone();
-			}, new RegExp( "Too many calls to the `assert.async` callback" ) );
+			}, /Tried to release async pause that was already released/ );
 
 			done();
 		}
@@ -229,17 +207,12 @@ QUnit.module( "assert.async", function() {
 			// internals in order to avoid post-`done` assertions causing additional failures
 			var done = assert.async();
 
-			// Duck-punch to force an Error to be thrown instead of a `pushFailure` call
-			assert.test.pushFailure = function( msg ) {
-				throw new Error( msg );
-			};
-
 			var overDone = assert.async();
 			overDone();
 
 			assert.throws( function() {
 				overDone();
-			}, new RegExp( "Too many calls to the `assert.async` callback" ) );
+			}, /Tried to release async pause that was already released/ );
 
 			done();
 		}
@@ -254,17 +227,12 @@ QUnit.module( "assert.async", function() {
 			// internals in order to avoid post-`done` assertions causing additional failures
 			var done = assert.async();
 
-			// Duck-punch to force an Error to be thrown instead of a `pushFailure` call
-			assert.test.pushFailure = function( msg ) {
-				throw new Error( msg );
-			};
-
 			var overDone = assert.async();
 			overDone();
 
 			assert.throws( function() {
 				overDone();
-			}, new RegExp( "Too many calls to the `assert.async` callback" ) );
+			}, /Tried to release async pause that was already released/ );
 
 			done();
 		}

--- a/test/main/promise.js
+++ b/test/main/promise.js
@@ -204,16 +204,16 @@ QUnit.module( "Support for Promise", function() {
 		return createMockPromise( assert, true, "this is an error" );
 	} );
 
-	QUnit.test( "rejected Promise with async lock", function( assert ) {
+	QUnit.test( "rejected Promise with async pause", function( assert ) {
 		assert.expect( 2 );
 
-		assert.async(); // Important! We don't explicitly release the async lock
+		assert.async(); // Important! We don't explicitly release the async pause
 
 		this.pushFailure = assert.test.pushFailure;
 		assert.test.pushFailure = function( message ) {
 			assert.strictEqual(
 				message,
-				"Promise rejected during \"rejected Promise with async lock\": this is an error"
+				"Promise rejected during \"rejected Promise with async pause\": this is an error"
 			);
 		};
 


### PR DESCRIPTION
### Background

When creating two async pauses in a test, it was possible for a test to pass by invoking one of them twice, and the other not at all.

Easy scenario (though perhaps not realistic):

> Use `assert.async()` twice, assigned as done1 and done2 in the same `QUnit.test()` case, and then simulate the failure scenario such that you wrongly call done1 two times, and forget to call done2.

Complex scenario across `QUnit.test()` and "afterEach" hooks, since these previously shared a single semaphore:

> Use `assert.async()` once in a simple test, and schedule the resume call in the future, but then fail with an uncaught error. The uncaught error is found and `Test.run()` would internally kill the pause by resetting the semaphore to zero (this make sense since we shouldn't wait for the release once the test is known to have failed).
> After this reset, we proceed to the "afterEach" hook. Suppose this hook is also async, and during its execution, the originally scheduled resume call happens. This would effectively end up releasing the afterEach's async pause despite not being finished yet, and then we proceed to the next test. That test would then fail when the afterEach's own release call happens, failing as "release during a different test".

This is the scenario of https://github.com/qunitjs/qunit/issues/1432.

Fix this and numerous other edge cases by making the returned callbacks from `assert.async()` strict about which locks they release.

Each lock now adds a unique token to a map, and invoking the release function decrements/removes this token from the map.

### Notes

* es6-map.js assigns the fallback in all browsers.
  This is a bug, to be fixed later.

* The `isNaN(semaphore)` logic was originally added in 2015 by ea3e350f.
  At the time, the internal resume function was public, and NaN could emerge through `QUnit.start("bla")` as result of `semaphore += "bla"`. This has not been possible for a while. During PR #1590, I did not trace the origin of this code, and thus did not realize that it was already obsolete (the semaphore itself is not publicly supported).

* The "during different test" error is now almost impossible to trigger since we now kill pending locks during test failures and
  tolerate all late calls equally. This meant the `drooling-done.js` test case now fails in a more limited way.

  I added a new test case for coverage, that reproduces it still, but it's a lot more obscure – it requires the original test to pass and then also have an unexpected call during a different test.

* I considered using the phrase "async lock" in the public-facing error messages, but found this perhaps too internal/technical when coming from the perspective of `var done = assert.async();`.

  In order to keep the code shared between handling of async-await, Promise, and assert.async, but remain friendly and understandable, I went for the phrase "async pause".

Fixes https://github.com/qunitjs/qunit/issues/1432.