### PR TITLE
HTML Reporter: Internally use `runStart` and `runEnd` events

### DIFF
--- a/test/reporter-html/reporter-html.js
+++ b/test/reporter-html/reporter-html.js
@@ -46,7 +46,7 @@ QUnit.module( "HTML Reporter", function() {
 	QUnit.test( "run progress", function( assert ) {
 		var display = document.getElementById( "qunit-testresult" );
 
-		var expected = /\d+ \/ \d+ tests completed in \d+ milliseconds, with \d+ failed, \d+ skipped, and \d+ todo./;
+		var expected = /\d+ \/ \d+ tests completed/;
 		assert.true(
 			expected.test( display.innerHTML ),
 			"progress found in displayed text"


### PR DESCRIPTION
Switch from `QUnit.begin()` to `QUnit.done()` to the `runStart` and `runEnd` events, as well as the data these provide, such as the test counts and runtime.

As part of making the interface less cluttered, I propose we remove the runtime and status-specific counts from the real-time progress text, as these were rapidly changing and are hard to read.

These changes, together, would allow removal of a number of things:

* Remove internal dependency on Test class (in favour of runStart data).
* Remove local counting of test by status (in favour of runEnd data).
* Remove local time measuring.

I've moved the progress line from being the third line in the testresult-display element, to be the first line. This way, the number of completed tests will be in the same place as where it is displayed when the run has ended.

I've also removed the line break between "Running" and the name of the currently running tests. This way the testresult display will generally have the same visual height during and after the test run. (Previously, there was jump ump after the test run, since there are only two lines in the final state, but with the linebreak we had three lines when tests are running.)

Preview of test suite with this PR applied:

| Running... | Done
|--|--
| <img width="414" alt="after-running" src="https://user-images.githubusercontent.com/156867/127788165-c4491ff7-3b30-41e5-af4a-9d40fca9a5f9.png"> | <img width="414" alt="after-done" src="https://user-images.githubusercontent.com/156867/127788163-5dbdb721-572f-4c00-a652-c563ebf0d2c8.png">


Ref https://github.com/qunitjs/qunit/issues/1486.