### PR TITLE
Core: improve warning for incorrect module hook usage

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -112,8 +112,10 @@ function processModule( name, options, executeNow, modifiers = {} ) {
 	function setHookFunction( module, hookName ) {
 		return function setHook( callback ) {
 			if ( config.currentModule !== module ) {
-				Logger.warn( "The `" + hookName + "` hook was called inside the wrong module. " +
-					"Instead, use hooks provided by the callback to the containing module. " +
+				Logger.warn( "The `" + hookName + "` hook was called inside the wrong module (`" +
+					config.currentModule.name + "`). " +
+					"Instead, use hooks provided by the callback to the containing module (`" +
+					module.name + "`). " +
 					"This will become an error in QUnit 3.0." );
 			}
 			module.hooks[ hookName ].push( callback );

--- a/test/cli/cli-main.js
+++ b/test/cli/cli-main.js
@@ -671,7 +671,7 @@ CALLBACK: done`;
 		const execution = await execute( command );
 
 		assert.equal( execution.code, 0 );
-		assert.equal( execution.stderr, "The `beforeEach` hook was called inside the wrong module. Instead, use hooks provided by the callback to the containing module. This will become an error in QUnit 3.0.", "The warning shows" );
+		assert.equal( execution.stderr, "The `beforeEach` hook was called inside the wrong module (`module providing hooks > module not providing hooks`). Instead, use hooks provided by the callback to the containing module (`module providing hooks`). This will become an error in QUnit 3.0.", "The warning shows" );
 		assert.equal( execution.stdout, expectedOutput[ command ] );
 	} );
 


### PR DESCRIPTION
Add the names of the relevant modules so the message is more actionable for users who encounter it.

Fixes #1647

@Krinkle, this is failing tests locally (and presumably on CI here!) for `CLI Main > mapped trace with native source map`, presumably because it needs the fixture regenerated. I’m happy to update the fixture given guidance to that end!