### PR TITLE
Core: ensure skipped modules' hooks don't leak

### DIFF
--- a/test/cli/cli-main.js
+++ b/test/cli/cli-main.js
@@ -434,6 +434,15 @@ CALLBACK: done`;
 			assert.equal( execution.stderr, "" );
 			assert.equal( execution.stdout, expectedOutput[ command ] );
 		} );
+
+		QUnit.test( "callbacks and hooks from filtered-out modules are properly released for garbage collection", async assert => {
+			const command = "node --expose-gc ../../../bin/qunit.js --filter '!child' memory-leak/*.js";
+			const execution = await execute( command );
+
+			assert.equal( execution.code, 0 );
+			assert.equal( execution.stderr, "" );
+			assert.equal( execution.stdout, expectedOutput[ command ] );
+		} );
 	}
 
 	QUnit.module( "filter", () => {

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -267,6 +267,17 @@ ok 1 Single > has a test
 	"node --expose-gc ../../../bin/qunit.js memory-leak/*.js":
 `TAP version 13
 ok 1 some nested module > can call method on foo
+ok 2 some nested module > child module > child test
+ok 3 later thing > has released all foos
+1..3
+# pass 3
+# skip 0
+# todo 0
+# fail 0`,
+
+	"node --expose-gc ../../../bin/qunit.js --filter '!child' memory-leak/*.js":
+`TAP version 13
+ok 1 some nested module > can call method on foo
 ok 2 later thing > has released all foos
 1..2
 # pass 2

--- a/test/cli/fixtures/memory-leak/index.js
+++ b/test/cli/fixtures/memory-leak/index.js
@@ -44,6 +44,17 @@ QUnit.module( "some nested module", function( hooks ) {
 		assert.equal( foo1.getId(), "FooNum" );
 	} );
 
+	QUnit.module( "child module", function( hooks ) {
+		let foo3;
+
+		hooks.beforeEach( function() {
+			foo3 = foo1;
+		} );
+
+		QUnit.test( "child test", function( assert ) {
+			assert.ok( foo3 );
+		} );
+	} );
 } );
 
 QUnit.module( "later thing", function() {
@@ -58,10 +69,10 @@ QUnit.module( "later thing", function() {
 
 		let snapshot = await streamToString( v8.getHeapSnapshot() );
 		let matches = snapshot.match( reHeap ) || [];
-		assert.strictEqual( matches.length, 2, "the before heap" );
+		assert.notEqual( matches.length, 0, "the before heap" );
 
 		snapshot = matches = null;
-		assert.strictEqual( foos.size, 2, "foos in Set" );
+		assert.notEqual( foos.size, 0, "foos in Set" );
 
 		// Comment out the below to test the failure mode
 		foos.clear();


### PR DESCRIPTION
Make sure that even if a module is entirely skipped, its hooks are deleted out of the global config so that they don't cause data they reference to leak.

Fixes #1649