### PR TITLE
HTML Reporter: Fix `display: none` regression on global error message

### DIFF
--- a/src/html-reporter/html.js
+++ b/src/html-reporter/html.js
@@ -1054,6 +1054,9 @@ export function escapeText( s ) {
 		assertLi.className = "fail";
 		assertLi.innerHTML = message;
 		assertList.appendChild( assertLi );
+
+		// Make it visible
+		testItem.className = "fail";
 	} );
 
 	// Avoid readyState issue with phantomjs


### PR DESCRIPTION
Follows-up 8f5e7ed, which fixed the bug where in the "No tests" error (or indeed any global error after tests are done running) could cause the test runner to get stuck.

That change maintained backward compatibility by continuing to count these global errors as "failed tests", so that CI reporters listening for `QUnit.done()` on `QUnit.on("runEnd")` continue to get the same negative signal. And, it continued to visually render them as a failed test if they happen during test execution or as the last/only event.

But... it inserted the element into the DOM without making visible, which fooled our internal unit tests.

Fix https://github.com/qunitjs/qunit/issues/1651.