### PR TITLE
Core: Restore fake test for "No tests were run" message

### DIFF
--- a/src/html-reporter/html.js
+++ b/src/html-reporter/html.js
@@ -1,5 +1,4 @@
 import QUnit from "../core";
-import Logger from "../logger";
 import { extend, errorString } from "../core/utilities";
 import { window, document, navigator, console } from "../globals";
 import "./urlparams";
@@ -1035,8 +1034,6 @@ export function escapeText( s ) {
 		if ( !testItem ) {
 
 			// HTML Reporter is probably disabled or not yet initialized.
-			Logger.warn( "global failure" );
-			Logger.warn( error );
 			return;
 		}
 

--- a/src/test.js
+++ b/src/test.js
@@ -76,6 +76,13 @@ export default function Test( settings ) {
 
 	++Test.count;
 	this.errorForStack = new Error();
+	if ( this.callback && this.callback.validTest ) {
+
+		// Omit the test-level trace for the internal "No tests" test failure,
+		// There is already an assertion-level trace, and that's noisy enough
+		// as it is.
+		this.errorForStack.stack = undefined;
+	}
 	this.testReport = new TestReport( this.testName, this.module.suiteReport, {
 		todo: this.todo,
 		skip: this.skip,

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -143,8 +143,10 @@ not ok 2 Unhandled Rejections > test passes just fine, but has a rejected promis
 `TAP version 13
 not ok 1 global failure
   ---
-  message: Error: No tests were run.
+  message: No tests were run.
   severity: failed
+  actual  : undefined
+  expected: undefined
   stack: |
     Error: No tests were run.
         at done (/qunit/qunit/qunit.js)
@@ -153,7 +155,6 @@ not ok 1 global failure
         at unblockAndAdvanceQueue (/qunit/qunit/qunit.js)
         at internal
   ...
-Bail out! Error: No tests were run.
 1..1
 # pass 0
 # skip 0
@@ -236,8 +237,10 @@ ok 1 Zero assertions > has a test
 `TAP version 13
 not ok 1 global failure
   ---
-  message: "Error: No tests matched the filter \\"no matches\\"."
+  message: "No tests matched the filter \\"no matches\\"."
   severity: failed
+  actual  : undefined
+  expected: undefined
   stack: |
     Error: No tests matched the filter "no matches".
         at done (/qunit/qunit/qunit.js)
@@ -246,7 +249,6 @@ not ok 1 global failure
         at unblockAndAdvanceQueue (/qunit/qunit/qunit.js)
         at internal
   ...
-Bail out! Error: No tests matched the filter "no matches".
 1..1
 # pass 0
 # skip 0


### PR DESCRIPTION
Historically, the "No tests were run" message was thrown as a real uncaught error by us, recieved by the native error handler in the browser or Node.js, and we then listened to that to generate a failing test case to show in the UI for extra visibility. The use of fake tests in this way wasn't great and caused problems when they happened after a "skip" module, or if there error came from QUnit.begin, runStart, testStart, or beforeEach hooks, since that would prevent the test from coming through and left internals in a broken state.

We fixed that in QUnit 2.17 by rendering uncaught errors directly to the UI instead of queueing them up as a fake test that may or may not make it to the UI.

To preserve API compatibility, we still count this as a failed test and still make it flip "status" to "failed" in the `QUnit.done()` and `runEnd` event. Thus, just as before, all uncaught errors are reported to the browser/Node handler, result in a failing test run, and shown in the UI.

### Problem

1. I wrongly changed the "No tests" message after 07de3c6fde and  8f5e7ed658a16 to be passed directly to our `onUncaughtError`  function, thus not it is not seen by the browser/Node as a real  uncaught error. A good reporter will still fail their build based  on our failing test count or "status" field from done/runEnd, but  they could no longer find out why (e.g. the "No tests" message).

2. There are reporters, including grunt-contirb-qunit and testem,  which use neither the`runEnd` event nor the `QUnit.done()` callback  to find out the test counts, or the overall "status". Instead, they rely solely on "testDone" to discover all failures.

In the case of testem, it does listen to QUnit.done but only to get the test duration and stop the browser, it uses its own test counts to determine the run status. [a]

In the case of grunt-contrib-qunit, it did utilize the QUnit.done data to find the number of failed assertions, but had its own logic for counting the number of tests, and it used the test count to decide the outcome of the test run. [b] Also, the Puppeteer pageerror event in grunt-contrib-qunit is not printed and not used to fail the task.

### Change

Per problem 1, let's re-instate the old behaviour. Before QUnit 2.17 the "No tests" message was both an uncaught error *and* a fake test. With the new safeguards in place we have to choose which one we want.

I went for a fake test because that seems most rebust for reporters, since evidently some reporters do not report not uncaught errors.

I've also removed the `Logger.warn()` fallback in the HTML Reporter. I added this in 8f5e7ed658a16, not realizing that uncaught errors are already rendered in the browser console by default, so this caused it to show up twice.

There was however once case of an error being passed to `onUncaughtException` directly without actually being recieved by
window.onerror, and that was the "No tests" message which would otherwise not be visible anywhere if the UI was disabled. However this is no longer an issue since this message is now reported as a fake test.

[a] https://github.com/gruntjs/grunt-contrib-qunit/blob/v5.1.0/tasks/qunit.js#L197-L236
[b] https://github.com/testem/testem/blob/v3.5.0/public/testem/qunit_adapter.js

Ref https://github.com/qunitjs/qunit/issues/1651.