### PR TITLE
Core: correct flat module.only usage by marking currentModule as ignored

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -136,11 +136,13 @@ module.only = function( ...args ) {
 	if ( !focused ) {
 		config.modules.length = 0;
 		config.queue.length = 0;
+
+		// aggressively ignore any direct tests in "outer" nested modules
+		config.currentModule.ignored = true;
 	}
 
-	processModule( ...args );
-
 	focused = true;
+	processModule( ...args );
 };
 
 module.skip = function( name, options, executeNow ) {

--- a/test/cli/fixtures/only/module.js
+++ b/test/cli/fixtures/only/module.js
@@ -26,6 +26,10 @@ QUnit.module( "module B", function() {
 		} );
 	} );
 
+	QUnit.test( "test with the only-module as its peer", function( assert ) {
+		assert.true( false, "this test should not run" );
+	} );
+
 	QUnit.module( "This also should not run", function() {
 		QUnit.test( "normal test", function( assert ) {
 			assert.true( false, "this test should not run" );


### PR DESCRIPTION
Resolves #1645.

The first time we process a `module.only` call, we chop the list of tests that have accumulated so far, and then mark everything after that as an early-return to not even process it. But there's the edge-case where we're currently within a nested module, which might add more tests as "siblings" to that module.only usage. By forcefully marking the `currentTest` as `ignored`, we are sure to accurately filter other trailing cases.

Added a unittest by squeezing in a new test case to a prior test for `module.only`. That is admittedly growing in complexity, but I think still serves as a great integration-level test to really stress the combinations.