### PR TITLE
Doc: Fixing typo and cleaning up code snippets

### DIFF
--- a/docs/QUnit/module.md
+++ b/docs/QUnit/module.md
@@ -418,4 +418,3 @@ QUnit.module.todo( "Robot", hooks => {
   // ...
 });
 ```
-

--- a/docs/QUnit/module.md
+++ b/docs/QUnit/module.md
@@ -372,7 +372,7 @@ QUnit.module( "Robot", hooks => {
 });
 
 // Skip this module's tests.
-// For example if the android tests are failling due to unsolved problems.
+// For example if the android tests are failing due to unsolved problems.
 QUnit.module.skip( "Android", hooks => {
   let android;
   hooks.beforeEach( () => {
@@ -398,27 +398,24 @@ QUnit.module.skip( "Android", hooks => {
 Use `QUnit.module.todo()` to denote a feature that is still under development, and is known to not yet be passing all its tests. This treats an entire module's tests as if they used [`QUnit.test.todo`](./test.todo.md) instead of [`QUnit.test`](./test.md).
 
 ```js
-QUnit.module.todo( "Robot", function( hooks ) {
-  hooks.beforeEach( function() {
-    this.robot = new Robot();
+QUnit.module.todo( "Robot", hooks => {
+  let robot;
+  hooks.beforeEach( () => {
+    robot = new Robot();
   });
 
   QUnit.test( "Say", assert => {
     // Currently, it returns undefined
-    assert.strictEqual( this.robot.say(), "I'm Robot FN-2187" );
+    assert.strictEqual( robot.say(), "I'm Robot FN-2187" );
   });
 
-  QUnit.test( "Move arm", function ( assert ) {
-    // Move the arm to point (75, 80). Currently, it throws a NotImplementedError
-    assert.throws( function() {
-      this.robot.moveArmTo(75, 80);
-    }, /Not yet implemented/ );
-
-    assert.throws( function() {
-      assert.deepEqual( this.robot.getPosition(), { x: 75, y: 80 });
-    }, /Not yet implemented/ );
+  QUnit.test( "Move arm", assert => {
+    // Move the arm to point (75, 80). Currently, each throws a NotImplementedError
+    robot.moveArmTo( 75, 80 );
+    assert.deepEqual( robot.getPosition(), { x: 75, y: 80 } );
   });
 
   // ...
 });
 ```
+

--- a/docs/QUnit/test.todo.md
+++ b/docs/QUnit/test.todo.md
@@ -13,7 +13,7 @@ version_added: "2.2.0"
 `QUnit.test.todo( name, callback )`<br>
 `QUnit.todo( name, callback )`
 
-Add a test which expects at least one failing assertion during its run.
+Add a test which expects at least one failing assertion or exception during its run.
 
 | parameter | description |
 |-----------|-------------|
@@ -26,7 +26,7 @@ Add a test which expects at least one failing assertion during its run.
 |-----------|-------------|
 | `assert` (object) | A new instance object with the [assertion methods](../assert/index.md) |
 
-Use this method to test a unit of code that is still under development (in a "todo" state). The "todo" test will pass as long as there is at least one assertion still failing.
+Use this method to test a unit of code that is still under development (in a "todo" state). The "todo" test will pass as long as there is at least one assertion still failing, or if an exception is thrown.
 
 When all assertions are passing, the "todo" test will fail, thus signaling that `QUnit.test.todo()` should be changed to [`QUnit.test()`](./test.md).
 


### PR DESCRIPTION
Started fixing a typo ("failling").

Then I saw the `this`/arrow functions being mismatched in the example. It still "passes" (as a todo), but maybe cryptically ("wait, it throws because the method isn't implemented, but that... fails, and makes... the todo pass?"). Streamlined those to read like well-formed tests should they start passing.

I had to confirm that `todo` tests pass even with exceptions, and noted that that detail was lacking in the todo-docs.

Wordsmithing welcomed