### PR TITLE
assert.propContains API Implementation & Tests

### DIFF
--- a/docs/assert/notPropContains.md
+++ b/docs/assert/notPropContains.md
@@ -1,0 +1,79 @@
+---
+layout: page-api
+title: assert.notPropContains()
+excerpt: Check that an object does not contain certain properties.
+groups:
+  - assert
+version_added: "unreleased"
+---
+
+`notPropContains( actual, expected, message = "" )`
+
+Check that an object does not contain certain properties.
+
+| name | description |
+|------|-------------|
+| `actual` | Expression being tested |
+| `expected` | Known comparison value |
+| `message` (string) | Short description of the actual value |
+
+
+The `notPropContains` assertion compares the subset of properties in the expected object, and tests that these keys are either absent or hold a value that is different according to a strict equality comparison.
+
+This method is recursive and allows partial comparison of nested objects as well.
+
+## See also
+
+* Use [`assert.propContains()`](./propContains.md) to test for the presence and equality of properties instead.
+
+## Examples
+
+```js
+QUnit.test( "example", assert => {
+
+  const result = {
+    foo: 0,
+    vehicle: {
+      timeCircuits: "on",
+      fluxCapacitor: "fluxing",
+      engine: "running"
+    },
+    quux: 1
+  };
+
+  // succeeds, property "timeCircuits" is actually "on"
+  assert.notPropContains( result, {
+    vehicle: {
+      timeCircuits: "off"
+    }
+  } );
+
+  // succeeds, property "wings" is not in the object
+  assert.notPropContains( result, {
+    vehicle: {
+      wings: "flapping"
+    }
+  } );
+
+  function Point( x, y ) {
+    this.x = x;
+    this.y = y;
+  }
+
+  assert.notPropContains(
+    new Point( 10, 20 ),
+    { z: 30 }
+  );
+
+  const nested = {
+    north: [ /* ... */ ],
+    east: new Point( 10, 20 ),
+    south: [ /* ... */ ],
+    west: [ /* ... */ ]
+  };
+
+  assert.notPropContains( nested, { east: new Point( 88, 42 ) } );
+  assert.notPropContains( nested, { east: { x: 88 } } );
+
+});
+```

--- a/docs/assert/notPropEqual.md
+++ b/docs/assert/notPropEqual.md
@@ -1,7 +1,7 @@
 ---
 layout: page-api
 title: assert.notPropEqual()
-excerpt: A strict comparison of an object's own properties, checking for inequality.
+excerpt: Compare an object's own properties for inequality.
 groups:
   - assert
 redirect_from:
@@ -11,7 +11,7 @@ version_added: "1.11.0"
 
 `notPropEqual( actual, expected, message = "" )`
 
-A strict comparison of an object's own properties, checking for inequality.
+Compare an object's own properties using a strict inequality comparison.
 
 | name | description |
 |------|-------------|
@@ -19,13 +19,14 @@ A strict comparison of an object's own properties, checking for inequality.
 | `expected` | Known comparison value |
 | `message` (string) | A short description of the assertion |
 
-The `notPropEqual` assertion uses the strict inverted comparison operator (`!==`) to compare the actual and expected arguments as Objects regarding only their properties but not their constructors.
+The `notPropEqual` assertion compares only an object's own properties, using the strict inquality operator (`!==`).
 
-When they aren't equal, the assertion passes; otherwise, it fails. When it fails, both actual and expected values are displayed in the test result, in addition to a given message.
+The test passes if there are properties with different values, or extra properties, or missing properties.
 
-[`assert.equal()`](./equal.md) can be used to test equality.
+## See also
 
-[`assert.propEqual()`](./propEqual.md) can be used to test strict equality of an Object properties.
+* Use [`assert.notPropContains()`](./notPropContains.md) to only check for the absence or inequality of some properties.
+* Use [`assert.propEqual()`](./propEqual.md) to test for equality of properties instead.
 
 ## Examples
 
@@ -49,6 +50,6 @@ QUnit.test( "example", assert => {
   assert.notPropEqual( foo, {
     x: 1,
     y: 2
-  } );
+  });
 });
 ```

--- a/docs/assert/propContains.md
+++ b/docs/assert/propContains.md
@@ -1,0 +1,78 @@
+---
+layout: page-api
+title: assert.propContains()
+excerpt: Check that an object contains certain properties.
+groups:
+  - assert
+version_added: "unreleased"
+---
+
+`propContains( actual, expected, message = "" )`
+
+Check that an object contains certain properties.
+
+| name | description |
+|------|-------------|
+| `actual` | Expression being tested |
+| `expected` | Known comparison value |
+| `message` (string) | Short description of the actual value |
+
+
+The `propContains` assertion compares only the **subset** of properties in the expected object,
+and tests that these keys exist as own properties with strictly equal values.
+
+This method is recursive and allows partial comparison of nested objects as well.
+
+## See also
+
+* Use [`assert.propEqual()`](./propEqual.md) to compare all properties, considering extra properties as unexpected.
+* Use [`assert.notPropContains()`](./notPropContains.md) to test for the absence or inequality of certain properties.
+
+## Examples
+
+```js
+QUnit.test( "example", assert => {
+
+  const result = {
+    foo: 0,
+    vehicle: {
+      timeCircuits: "on",
+      fluxCapacitor: "fluxing",
+      engine: "running"
+    },
+    quux: 1
+  };
+
+  assert.propContains( result, {
+    foo: 0,
+    vehicle: { fluxCapacitor: "fluxing" }
+  } );
+
+  function Point( x, y ) {
+    this.x = x;
+    this.y = y;
+  }
+
+  assert.propContains(
+    new Point( 10, 20 ),
+    { y: 20 }
+  );
+
+  assert.propContains(
+    [ "a", "b" ],
+    { 1: "b" }
+  );
+
+  const nested = {
+    north: [ /* ... */ ],
+    east: new Point( 10, 20 ),
+    south: [ /* ... */ ],
+    west: [ /* ... */ ]
+  };
+
+  assert.propContains( nested, { east: new Point( 10, 20 ) } );
+  assert.propContains( nested, { east: { x: 10, y: 20 } } );
+  assert.propContains( nested, { east: { x: 10 } } );
+
+});
+```

--- a/docs/assert/propEqual.md
+++ b/docs/assert/propEqual.md
@@ -1,7 +1,7 @@
 ---
 layout: page-api
 title: assert.propEqual()
-excerpt: A strict type and value comparison of an object's own properties.
+excerpt: Compare an object's own properties.
 groups:
   - assert
 redirect_from:
@@ -11,7 +11,7 @@ version_added: "1.11.0"
 
 `propEqual( actual, expected, message = "" )`
 
-A strict type and value comparison of an object's own properties.
+Compare an object's own properties using a strict comparison.
 
 | name | description |
 |------|-------------|
@@ -19,15 +19,20 @@ A strict type and value comparison of an object's own properties.
 | `expected` | Known comparison value |
 | `message` (string) | A short description of the assertion |
 
-The `propEqual` assertion provides strictly (`===`) comparison of Object properties. Unlike [`assert.deepEqual()`](./deepEqual.md), this assertion can be used to compare two objects made with different constructors or prototypes.
+The `propEqual` assertion compares only an object's own properties. This means the expected value does not need to be an instance of the same class or otherwise inherit the same prototype, unlike with [`assert.deepEqual()`](./deepEqual.md).
 
-[`assert.strictEqual()`](./strictEqual.md) can be used to test strict equality.
+The assertion fails if values differ, if there are additional properties, or if some properties are missing.
 
-[`assert.notPropEqual()`](./notPropEqual.md) can be used to explicitly test strict inequality of Object properties.
+This method is recursive and can compare any nested or complex object via a plain object.
+
+## See also
+
+* Use [`assert.propContains()`](./propContains.md) to only check a subset of properties.
+* Use [`assert.notPropEqual()`](./notPropEqual.md) to test for the inequality of object properties instead.
 
 ## Examples
 
-Compare the properties values of two objects.
+Compare the property values of two objects.
 
 ```js
 QUnit.test( "example", assert => {
@@ -43,11 +48,11 @@ QUnit.test( "example", assert => {
   const foo = new Foo();
 
   // succeeds, own properties are strictly equal,
-  // and inherited properties (such as which object constructor) are ignored.
+  // and inherited properties (such as which constructor) are ignored.
   assert.propEqual( foo, {
     x: 1,
     y: 2
-  } );
+  });
 });
 ```
 
@@ -63,12 +68,12 @@ QUnit.test( "example", function ( assert ) {
   Foo.prototype.run = function () {};
 
   var foo = new Foo();
+
+  // succeeds, own properties are strictly equal.
   var expected = {
     x: 1,
     y: 2
   };
-
-  // succeeds, own properties are strictly equal.
   assert.propEqual( foo, expected );
 });
 ```

--- a/src/assert.js
+++ b/src/assert.js
@@ -4,7 +4,7 @@ import { internalStop, resetTestTimeout } from "./test";
 import Logger from "./logger";
 
 import config from "./core/config";
-import { objectType, objectValues, errorString } from "./core/utilities";
+import { objectType, objectValues, objectValuesSubset, errorString } from "./core/utilities";
 import { sourceFromStacktrace } from "./core/stacktrace";
 import { clearTimeout } from "./globals";
 
@@ -205,6 +205,36 @@ class Assert {
 
 	notPropEqual( actual, expected, message ) {
 		actual = objectValues( actual );
+		expected = objectValues( expected );
+
+		this.pushResult( {
+			result: !equiv( actual, expected ),
+			actual,
+			expected,
+			message,
+			negative: true
+		} );
+	}
+
+	propContains( actual, expected, message ) {
+		actual = objectValuesSubset( actual, expected );
+
+		// The expected parameter is usually a plain object, but clone it for
+		// consistency with propEqual(), and to make it easy to explain that
+		// inheritence is not considered (on either side), and to support
+		// recursively checking subsets of nested objects.
+		expected = objectValues( expected, false );
+
+		this.pushResult( {
+			result: equiv( actual, expected ),
+			actual,
+			expected,
+			message
+		} );
+	}
+
+	notPropContains( actual, expected, message ) {
+		actual = objectValuesSubset( actual, expected );
 		expected = objectValues( expected );
 
 		this.pushResult( {

--- a/test/main/assert.js
+++ b/test/main/assert.js
@@ -96,8 +96,7 @@ QUnit.test( "propEqual", function( assert ) {
 		this.z = z;
 	}
 	Foo.prototype.doA = function() {};
-	Foo.prototype.doB = function() {};
-	Foo.prototype.bar = "prototype";
+	Foo.prototype.bar = "non-function";
 
 	function Bar() {
 	}
@@ -155,6 +154,156 @@ QUnit.test( "propEqual", function( assert ) {
 			}
 		},
 		"Complex nesting of different types, inheritance and constructors"
+	);
+} );
+
+QUnit.test( "propContains", function( assert ) {
+	function Foo( x, y, z ) {
+		this.x = x;
+		this.y = y;
+		this.z = z;
+	}
+	Foo.prototype.doA = function() {};
+	Foo.prototype.bar = "non-function";
+
+	function Bar( x ) {
+		this.x = x;
+	}
+	Bar.prototype = Object.create( Foo.prototype );
+	Bar.prototype.constructor = Bar;
+
+	assert.propContains(
+		{ a: 0, b: "something", c: true },
+		{ a: 0, b: "something", c: true }
+	);
+	assert.propContains(
+		{ a: 0, b: "something", c: true },
+		{ a: 0, c: true },
+		"match object subset"
+	);
+	assert.propContains(
+		[ "a", "b" ],
+		{ 1: "b" },
+		"match array subset via plain object"
+	);
+	assert.propContains(
+		[],
+		{},
+		"empty array contains empty object"
+	);
+	assert.propContains(
+		{},
+		[],
+		"empty object contains empty array"
+	);
+	assert.propContains(
+		new Foo( 1, "2", [] ),
+		new Foo( 1, "2", [] ),
+		"deeply equal class instances"
+	);
+	assert.propContains(
+		new Foo( 1, "2", [] ),
+		{
+			x: 1,
+			y: "2",
+			z: []
+		},
+		"match different constructor via plain object"
+	);
+	assert.propContains(
+		new Foo( 1, "2", [] ),
+		{
+			x: 1
+		},
+		"match different constructor subset via plain object"
+	);
+	assert.propContains(
+		new Foo( 1, "2", [ "x" ] ),
+		new Foo( 1, "2", { 0: "x" } ),
+		"match nested array via plain object"
+	);
+	assert.propContains(
+		new Foo( 1, [ "a", "b" ], new Foo( [ "c", "d" ], new Bar(), null ) ),
+		{
+			x: 1,
+			y: [ "a", "b" ],
+			z: {
+				x: { 1: "d" }
+			}
+		},
+		"match nested array subset via plain object"
+	);
+	assert.propContains(
+		new Foo( 1, "2" ),
+		new Bar( 1 ),
+		"match subset via different constructor"
+	);
+} );
+
+QUnit.test( "notPropContains", function( assert ) {
+	function Foo( x, y, z ) {
+		this.x = x;
+		this.y = y;
+		this.z = z;
+	}
+	Foo.prototype.doA = function() {};
+	Foo.prototype.bar = "non-function";
+
+	function Bar( x ) {
+		this.x = x;
+	}
+	Bar.prototype = Object.create( Foo.prototype );
+	Bar.prototype.constructor = Bar;
+
+	assert.notPropContains(
+		{ a: 0, b: "something", c: true },
+		{ a: 0, b: "different", c: true }
+	);
+	assert.notPropContains(
+		{ a: 0, b: "something", c: true },
+		{ a: 0, c: false }
+	);
+	assert.notPropContains(
+		{ a: 0, b: "something", c: true },
+		{ e: "missing" }
+	);
+	assert.notPropContains(
+		new Foo( 1, "2", [] ),
+		{
+			x: 1,
+			y: "2",
+			z: [],
+			e: "missing"
+		},
+		"matching and missing properties"
+	);
+	assert.notPropContains(
+		new Foo( 1, "2", [] ),
+		{
+			e: "missing"
+		},
+		"missing property"
+	);
+	assert.notPropContains(
+		new Foo( 1, [], new Foo( [], new Bar(), "something" ) ),
+		new Foo( 1, [], new Foo( [], new Bar(), "different" ) ),
+		"difference in nested value"
+	);
+	assert.notPropContains(
+		new Foo( 1, "2", new Foo( [ 3 ], new Bar(), null ) ),
+		{
+			x: 1,
+			y: "2",
+			z: {
+				e: "missing"
+			}
+		},
+		"nested object with missing property"
+	);
+	assert.notPropContains(
+		new Foo( 1, "2" ),
+		new Bar( 2 ),
+		"different property value via different constructor"
 	);
 } );
 


### PR DESCRIPTION
I think this is a good addition to the existing QUnit public API. It is rather too common that I need to partially check object values. Also includes `notPropContains`.

Example:

```js
assert.propContains(new User({ id: 1, firstName: 'Izel' }), { firstName: 'Izel' });
assert.notPropContains(new User({ id: 1, firstName: 'Izel' }), { firstName: 'Timo' });
```