### PR TITLE
HTML Reporter: Faster and fuzzier module dropdown filter

### DIFF
--- a/src/html-reporter/html.js
+++ b/src/html-reporter/html.js
@@ -466,7 +466,7 @@ export function escapeText (s) {
       if (searchText === '') {
         items = moduleSearchCache.map(obj => obj.item);
       } else {
-        items = fuzzysort.go(searchText, moduleSearchCache, { key: 'name', threshold: -10000 })
+        items = fuzzysort.go(searchText, moduleSearchCache, { key: 'name', allowTypo: true })
           .map(result => result.obj.item);
       }
       const fragment = document.createDocumentFragment();
@@ -479,11 +479,15 @@ export function escapeText (s) {
     // Processes module search box input
     let searchInputTimeout;
     function searchInput () {
+      // Use a debounce with a ~0ms timeout. This is effectively instantaneous,
+      // but is better than undebounced because it avoids an ever-growing
+      // backlog of unprocessed now-outdated input events if fuzzysearch or
+      // drodown DOM is slow (e.g. very large test suite).
       window.clearTimeout(searchInputTimeout);
       searchInputTimeout = window.setTimeout(() => {
         dropDownList.innerHTML = '';
         dropDownList.appendChild(filterModules(moduleSearch.value));
-      }, 200);
+      });
     }
 
     // Processes selection changes


### PR DESCRIPTION
### Threshold

| Before | After
|--|--
| ![Before: No results for "support for pomise"](https://user-images.githubusercontent.com/156867/162635139-3f3bd458-e322-4479-b5a2-cab8cff22751.png) | ![After: Various results even for "suortprose eachwhit"](https://user-images.githubusercontent.com/156867/162635233-70105acc-114e-4e9b-a9b3-d7d7ffcf68e0.png)

I love the super fast [fuzzysort.js](https://github.com/farzher/fuzzysort) library. Previously we ommitted results with a score lower than `-10000`. fuzzysort does not return results that don't contain the input characters, so names that don't match the input at excluded no matter what. The previous threshold more or less correlated with allowing some letters to be skipped in the first word, and leaving off letters from the end of later words. For example, `suort for promise` matched `support for promise`. But `support for pomise` already yielded zero results, despite only missing one letter! I've simply removed the threshold. More details in the commit message.

### Debounce

| Before | After
|--|--
| ![Kapture before](https://user-images.githubusercontent.com/156867/162635920-a167c006-0130-4a42-a903-0a6d70e464d9.gif) | ![Kapture after](https://user-images.githubusercontent.com/156867/162635924-ddaacfc5-4817-46ea-81a8-024048954668.gif)

Previously there was a debounce of 200ms. The fuzzysearch algo takes ~1ms even when there are hundreds of test modules in the dataset. I considered removing the debounce entirely, but what would risk at least in theory an ever-growing backlog of old events with both the input field and the results very far behind. [Debounce demo on Codepen](https://codepen.io/Krinkle/pen/wvpXxwM?editors=0010). More details in the commit message.
