### PR TITLE
Core: Remove inArray with native array.includes()

### DIFF
--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -55,9 +55,9 @@ export function diff (a, b) {
  * @param {Array} array
  * @return {boolean}
  */
-export function inArray (elem, array) {
-  return array.indexOf(elem) !== -1;
-}
+export const inArray = Array.prototype.includes
+  ? (elem, array) => array.includes(elem)
+  : (elem, array) => array.indexOf(elem) !== -1;
 
 /**
  * Recursively clone an object into a plain array or object, taking only the


### PR DESCRIPTION
While reading the source code I realized this internal function isn't needed anymore if we drop the IE support:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes#browser_compatibility