### PR TITLE
Core: Optimize strictEquality checks

### DIFF
--- a/src/equiv.js
+++ b/src/equiv.js
@@ -9,19 +9,11 @@ export default (function () {
   let pairs = [];
 
   function useStrictEquality (a, b) {
-    // This only gets called if a and b are not strict equal, and is used to compare on
-    // the primitive values inside object wrappers. For example:
-    // `var i = 1;`
-    // `var j = new Number(1);`
-    // Neither a nor b can be null, as a !== b and they have the same type.
-    if (typeof a === 'object') {
-      a = a.valueOf();
-    }
-    if (typeof b === 'object') {
-      b = b.valueOf();
-    }
-
     return a === b;
+  }
+
+  function useDateStrictEquality (a, b) {
+    return a.valueOf() === b.valueOf();
   }
 
   function compareConstructors (a, b) {
@@ -89,7 +81,7 @@ export default (function () {
     null: useStrictEquality,
     undefined: useStrictEquality,
     symbol: useStrictEquality,
-    date: useStrictEquality,
+    date: useDateStrictEquality,
 
     nan: function () {
       return true;


### PR DESCRIPTION
Removes extra if checks, variable mutations and .valueOf() calls from values that dont need it.

After seeing the test results, it seems to be this is an intentional "feature" rather than a bug. What would be the consequences if we remove this feature for v3? Are there really a lot of libraries/apps that depend on this feature? 