### PR TITLE
Core: QUnit.equiv inner refactors [Step 1]

### DIFF
--- a/src/core/utilities.js
+++ b/src/core/utilities.js
@@ -3,6 +3,7 @@ import Logger from '../logger';
 
 export const toString = Object.prototype.toString;
 export const hasOwn = Object.prototype.hasOwnProperty;
+export const slice = Array.prototype.slice;
 
 const nativePerf = getNativePerf();
 

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -253,8 +253,7 @@ const callbacks = {
       bProperties.push(i);
     }
 
-    // Ensures identical properties name
-    return typeEquiv(aProperties.sort(), bProperties.sort());
+    return callbacks.array(aProperties.sort(), bProperties.sort());
   }
 };
 

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -1,4 +1,4 @@
-import { objectType } from './core/utilities';
+import { objectType, slice } from './core/utilities';
 
 // Value pairs queued for comparison. Used for breadth-first processing order, recursion
 // detection and avoiding repeated comparison (see below for details).
@@ -298,7 +298,7 @@ function innerEquiv (a, b) {
   }
 
   // ...across all consecutive argument pairs
-  return arguments.length === 2 || innerEquiv.apply(this, [].slice.call(arguments, 1));
+  return arguments.length === 2 || innerEquiv.apply(this, slice.call(arguments, 1));
 }
 
 export default function equiv (...args) {

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -70,9 +70,7 @@ function breadthFirstCompareChild (a, b) {
   if (!isContainer(a)) {
     return typeEquiv(a, b);
   }
-  if (pairs.every(function (pair) {
-    return pair.a !== a || pair.b !== b;
-  })) {
+  if (pairs.every((pair) => pair.a !== a || pair.b !== b)) {
     // Not yet started comparing this pair
     pairs.push({ a: a, b: b });
   }
@@ -88,11 +86,11 @@ const callbacks = {
   symbol: useStrictEquality,
   date: useStrictEquality,
 
-  nan: function () {
+  nan () {
     return true;
   },
 
-  regexp: function (a, b) {
+  regexp (a, b) {
     return a.source === b.source &&
 
       // Include flags in the comparison
@@ -100,11 +98,11 @@ const callbacks = {
   },
 
   // abort (identical references / instance methods were skipped earlier)
-  function: function () {
+  function () {
     return false;
   },
 
-  array: function (a, b) {
+  array (a, b) {
     const len = a.length;
     if (len !== b.length) {
       // Safe and faster
@@ -125,7 +123,7 @@ const callbacks = {
   // repetitions are not counted, so these are equivalent:
   // a = new Set( [ {}, [], [] ] );
   // b = new Set( [ {}, {}, [] ] );
-  set: function (a, b) {
+  set (a, b) {
     if (a.size !== b.size) {
       // This optimization has certain quirks because of the lack of
       // repetition counting. For instance, adding the same
@@ -136,7 +134,7 @@ const callbacks = {
 
     let outerEq = true;
 
-    a.forEach(function (aVal) {
+    a.forEach((aVal) => {
       // Short-circuit if the result is already known. (Using for...of
       // with a break clause would be cleaner here, but it would cause
       // a syntax error on older JavaScript implementations even if
@@ -147,7 +145,7 @@ const callbacks = {
 
       let innerEq = false;
 
-      b.forEach(function (bVal) {
+      b.forEach((bVal) => {
         // Likewise, short-circuit if the result is already known
         if (innerEq) {
           return;
@@ -178,7 +176,7 @@ const callbacks = {
   // counted, so these are equivalent:
   // a = new Map( [ [ {}, 1 ], [ {}, 1 ], [ [], 1 ] ] );
   // b = new Map( [ [ {}, 1 ], [ [], 1 ], [ [], 1 ] ] );
-  map: function (a, b) {
+  map (a, b) {
     if (a.size !== b.size) {
       // This optimization has certain quirks because of the lack of
       // repetition counting. For instance, adding the same
@@ -189,7 +187,7 @@ const callbacks = {
 
     let outerEq = true;
 
-    a.forEach(function (aVal, aKey) {
+    a.forEach((aVal, aKey) => {
       // Short-circuit if the result is already known. (Using for...of
       // with a break clause would be cleaner here, but it would cause
       // a syntax error on older JavaScript implementations even if
@@ -200,7 +198,7 @@ const callbacks = {
 
       let innerEq = false;
 
-      b.forEach(function (bVal, bKey) {
+      b.forEach((bVal, bKey) => {
         // Likewise, short-circuit if the result is already known
         if (innerEq) {
           return;
@@ -225,7 +223,7 @@ const callbacks = {
     return outerEq;
   },
 
-  object: function (a, b) {
+  object (a, b) {
     if (compareConstructors(a, b) === false) {
       return false;
     }
@@ -307,7 +305,7 @@ function innerEquiv (a, b) {
   return arguments.length === 2 || innerEquiv.apply(this, [].slice.call(arguments, 1));
 }
 
-export default function equiv(...args) {
+export default function equiv (...args) {
   const result = innerEquiv(...args);
 
   // Release any retained objects

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -22,13 +22,12 @@ function useStrictEquality (a, b) {
 }
 
 function compareConstructors (a, b) {
-  let protoA = Object.getPrototypeOf(a);
-  let protoB = Object.getPrototypeOf(b);
-
-  // Comparing constructors is more strict than using `instanceof`
   if (a.constructor === b.constructor) {
     return true;
   }
+
+  let protoA = Object.getPrototypeOf(a);
+  let protoB = Object.getPrototypeOf(b);
 
   // Ref #851
   // If the obj prototype descends from a null constructor, treat it

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -1,320 +1,316 @@
 import { objectType } from './core/utilities';
 
-// Test for equality any JavaScript type.
-// Authors: Philippe Rathé <prathe@gmail.com>, David Chan <david@troi.org>
-export default (function () {
-  // Value pairs queued for comparison. Used for breadth-first processing order, recursion
-  // detection and avoiding repeated comparison (see below for details).
-  // Elements are { a: val, b: val }.
-  let pairs = [];
+// Value pairs queued for comparison. Used for breadth-first processing order, recursion
+// detection and avoiding repeated comparison (see below for details).
+// Elements are { a: val, b: val }.
+let pairs = [];
 
-  function useStrictEquality (a, b) {
-    // This only gets called if a and b are not strict equal, and is used to compare on
-    // the primitive values inside object wrappers. For example:
-    // `var i = 1;`
-    // `var j = new Number(1);`
-    // Neither a nor b can be null, as a !== b and they have the same type.
-    if (typeof a === 'object') {
-      a = a.valueOf();
-    }
-    if (typeof b === 'object') {
-      b = b.valueOf();
-    }
-
-    return a === b;
+function useStrictEquality (a, b) {
+  // This only gets called if a and b are not strict equal, and is used to compare on
+  // the primitive values inside object wrappers. For example:
+  // `var i = 1;`
+  // `var j = new Number(1);`
+  // Neither a nor b can be null, as a !== b and they have the same type.
+  if (typeof a === 'object') {
+    a = a.valueOf();
+  }
+  if (typeof b === 'object') {
+    b = b.valueOf();
   }
 
-  function compareConstructors (a, b) {
-    let protoA = Object.getPrototypeOf(a);
-    let protoB = Object.getPrototypeOf(b);
+  return a === b;
+}
 
-    // Comparing constructors is more strict than using `instanceof`
-    if (a.constructor === b.constructor) {
-      return true;
-    }
+function compareConstructors (a, b) {
+  let protoA = Object.getPrototypeOf(a);
+  let protoB = Object.getPrototypeOf(b);
 
-    // Ref #851
-    // If the obj prototype descends from a null constructor, treat it
-    // as a null prototype.
-    if (protoA && protoA.constructor === null) {
-      protoA = null;
-    }
-    if (protoB && protoB.constructor === null) {
-      protoB = null;
-    }
-
-    // Allow objects with no prototype to be equivalent to
-    // objects with Object as their constructor.
-    if (
-      (protoA === null && protoB === Object.prototype) ||
-      (protoB === null && protoA === Object.prototype)
-    ) {
-      return true;
-    }
-
-    return false;
-  }
-
-  function getRegExpFlags (regexp) {
-    return 'flags' in regexp ? regexp.flags : regexp.toString().match(/[gimuy]*$/)[0];
-  }
-
-  function isContainer (val) {
-    return ['object', 'array', 'map', 'set'].indexOf(objectType(val)) !== -1;
-  }
-
-  function breadthFirstCompareChild (a, b) {
-    // If a is a container not reference-equal to b, postpone the comparison to the
-    // end of the pairs queue -- unless (a, b) has been seen before, in which case skip
-    // over the pair.
-    if (a === b) {
-      return true;
-    }
-    if (!isContainer(a)) {
-      return typeEquiv(a, b);
-    }
-    if (pairs.every(function (pair) {
-      return pair.a !== a || pair.b !== b;
-    })) {
-      // Not yet started comparing this pair
-      pairs.push({ a: a, b: b });
-    }
+  // Comparing constructors is more strict than using `instanceof`
+  if (a.constructor === b.constructor) {
     return true;
   }
 
-  const callbacks = {
-    string: useStrictEquality,
-    boolean: useStrictEquality,
-    number: useStrictEquality,
-    null: useStrictEquality,
-    undefined: useStrictEquality,
-    symbol: useStrictEquality,
-    date: useStrictEquality,
+  // Ref #851
+  // If the obj prototype descends from a null constructor, treat it
+  // as a null prototype.
+  if (protoA && protoA.constructor === null) {
+    protoA = null;
+  }
+  if (protoB && protoB.constructor === null) {
+    protoB = null;
+  }
 
-    nan: function () {
-      return true;
-    },
+  // Allow objects with no prototype to be equivalent to
+  // objects with Object as their constructor.
+  if (
+    (protoA === null && protoB === Object.prototype) ||
+    (protoB === null && protoA === Object.prototype)
+  ) {
+    return true;
+  }
 
-    regexp: function (a, b) {
-      return a.source === b.source &&
+  return false;
+}
 
-        // Include flags in the comparison
-        getRegExpFlags(a) === getRegExpFlags(b);
-    },
+function getRegExpFlags (regexp) {
+  return 'flags' in regexp ? regexp.flags : regexp.toString().match(/[gimuy]*$/)[0];
+}
 
-    // abort (identical references / instance methods were skipped earlier)
-    function: function () {
+function isContainer (val) {
+  return ['object', 'array', 'map', 'set'].indexOf(objectType(val)) !== -1;
+}
+
+function breadthFirstCompareChild (a, b) {
+  // If a is a container not reference-equal to b, postpone the comparison to the
+  // end of the pairs queue -- unless (a, b) has been seen before, in which case skip
+  // over the pair.
+  if (a === b) {
+    return true;
+  }
+  if (!isContainer(a)) {
+    return typeEquiv(a, b);
+  }
+  if (pairs.every(function (pair) {
+    return pair.a !== a || pair.b !== b;
+  })) {
+    // Not yet started comparing this pair
+    pairs.push({ a: a, b: b });
+  }
+  return true;
+}
+
+const callbacks = {
+  string: useStrictEquality,
+  boolean: useStrictEquality,
+  number: useStrictEquality,
+  null: useStrictEquality,
+  undefined: useStrictEquality,
+  symbol: useStrictEquality,
+  date: useStrictEquality,
+
+  nan: function () {
+    return true;
+  },
+
+  regexp: function (a, b) {
+    return a.source === b.source &&
+
+      // Include flags in the comparison
+      getRegExpFlags(a) === getRegExpFlags(b);
+  },
+
+  // abort (identical references / instance methods were skipped earlier)
+  function: function () {
+    return false;
+  },
+
+  array: function (a, b) {
+    const len = a.length;
+    if (len !== b.length) {
+      // Safe and faster
       return false;
-    },
+    }
 
-    array: function (a, b) {
-      const len = a.length;
-      if (len !== b.length) {
-        // Safe and faster
+    for (let i = 0; i < len; i++) {
+      // Compare non-containers; queue non-reference-equal containers
+      if (!breadthFirstCompareChild(a[i], b[i])) {
         return false;
       }
+    }
+    return true;
+  },
 
-      for (let i = 0; i < len; i++) {
-        // Compare non-containers; queue non-reference-equal containers
-        if (!breadthFirstCompareChild(a[i], b[i])) {
-          return false;
-        }
+  // Define sets a and b to be equivalent if for each element aVal in a, there
+  // is some element bVal in b such that aVal and bVal are equivalent. Element
+  // repetitions are not counted, so these are equivalent:
+  // a = new Set( [ {}, [], [] ] );
+  // b = new Set( [ {}, {}, [] ] );
+  set: function (a, b) {
+    if (a.size !== b.size) {
+      // This optimization has certain quirks because of the lack of
+      // repetition counting. For instance, adding the same
+      // (reference-identical) element to two equivalent sets can
+      // make them non-equivalent.
+      return false;
+    }
+
+    let outerEq = true;
+
+    a.forEach(function (aVal) {
+      // Short-circuit if the result is already known. (Using for...of
+      // with a break clause would be cleaner here, but it would cause
+      // a syntax error on older JavaScript implementations even if
+      // Set is unused)
+      if (!outerEq) {
+        return;
       }
-      return true;
-    },
 
-    // Define sets a and b to be equivalent if for each element aVal in a, there
-    // is some element bVal in b such that aVal and bVal are equivalent. Element
-    // repetitions are not counted, so these are equivalent:
-    // a = new Set( [ {}, [], [] ] );
-    // b = new Set( [ {}, {}, [] ] );
-    set: function (a, b) {
-      if (a.size !== b.size) {
-        // This optimization has certain quirks because of the lack of
-        // repetition counting. For instance, adding the same
-        // (reference-identical) element to two equivalent sets can
-        // make them non-equivalent.
-        return false;
-      }
+      let innerEq = false;
 
-      let outerEq = true;
-
-      a.forEach(function (aVal) {
-        // Short-circuit if the result is already known. (Using for...of
-        // with a break clause would be cleaner here, but it would cause
-        // a syntax error on older JavaScript implementations even if
-        // Set is unused)
-        if (!outerEq) {
+      b.forEach(function (bVal) {
+        // Likewise, short-circuit if the result is already known
+        if (innerEq) {
           return;
         }
 
-        let innerEq = false;
-
-        b.forEach(function (bVal) {
-          // Likewise, short-circuit if the result is already known
-          if (innerEq) {
-            return;
-          }
-
-          // Swap out the global pairs list, as the nested call to
-          // innerEquiv will clobber its contents
-          const parentPairs = pairs;
-          if (innerEquiv(bVal, aVal)) {
-            innerEq = true;
-          }
-
-          // Replace the global pairs list
-          pairs = parentPairs;
-        });
-
-        if (!innerEq) {
-          outerEq = false;
+        // Swap out the global pairs list, as the nested call to
+        // innerEquiv will clobber its contents
+        const parentPairs = pairs;
+        if (innerEquiv(bVal, aVal)) {
+          innerEq = true;
         }
+
+        // Replace the global pairs list
+        pairs = parentPairs;
       });
 
-      return outerEq;
-    },
+      if (!innerEq) {
+        outerEq = false;
+      }
+    });
 
-    // Define maps a and b to be equivalent if for each key-value pair (aKey, aVal)
-    // in a, there is some key-value pair (bKey, bVal) in b such that
-    // [ aKey, aVal ] and [ bKey, bVal ] are equivalent. Key repetitions are not
-    // counted, so these are equivalent:
-    // a = new Map( [ [ {}, 1 ], [ {}, 1 ], [ [], 1 ] ] );
-    // b = new Map( [ [ {}, 1 ], [ [], 1 ], [ [], 1 ] ] );
-    map: function (a, b) {
-      if (a.size !== b.size) {
-        // This optimization has certain quirks because of the lack of
-        // repetition counting. For instance, adding the same
-        // (reference-identical) key-value pair to two equivalent maps
-        // can make them non-equivalent.
-        return false;
+    return outerEq;
+  },
+
+  // Define maps a and b to be equivalent if for each key-value pair (aKey, aVal)
+  // in a, there is some key-value pair (bKey, bVal) in b such that
+  // [ aKey, aVal ] and [ bKey, bVal ] are equivalent. Key repetitions are not
+  // counted, so these are equivalent:
+  // a = new Map( [ [ {}, 1 ], [ {}, 1 ], [ [], 1 ] ] );
+  // b = new Map( [ [ {}, 1 ], [ [], 1 ], [ [], 1 ] ] );
+  map: function (a, b) {
+    if (a.size !== b.size) {
+      // This optimization has certain quirks because of the lack of
+      // repetition counting. For instance, adding the same
+      // (reference-identical) key-value pair to two equivalent maps
+      // can make them non-equivalent.
+      return false;
+    }
+
+    let outerEq = true;
+
+    a.forEach(function (aVal, aKey) {
+      // Short-circuit if the result is already known. (Using for...of
+      // with a break clause would be cleaner here, but it would cause
+      // a syntax error on older JavaScript implementations even if
+      // Map is unused)
+      if (!outerEq) {
+        return;
       }
 
-      let outerEq = true;
+      let innerEq = false;
 
-      a.forEach(function (aVal, aKey) {
-        // Short-circuit if the result is already known. (Using for...of
-        // with a break clause would be cleaner here, but it would cause
-        // a syntax error on older JavaScript implementations even if
-        // Map is unused)
-        if (!outerEq) {
+      b.forEach(function (bVal, bKey) {
+        // Likewise, short-circuit if the result is already known
+        if (innerEq) {
           return;
         }
 
-        let innerEq = false;
-
-        b.forEach(function (bVal, bKey) {
-          // Likewise, short-circuit if the result is already known
-          if (innerEq) {
-            return;
-          }
-
-          // Swap out the global pairs list, as the nested call to
-          // innerEquiv will clobber its contents
-          const parentPairs = pairs;
-          if (innerEquiv([bVal, bKey], [aVal, aKey])) {
-            innerEq = true;
-          }
-
-          // Replace the global pairs list
-          pairs = parentPairs;
-        });
-
-        if (!innerEq) {
-          outerEq = false;
+        // Swap out the global pairs list, as the nested call to
+        // innerEquiv will clobber its contents
+        const parentPairs = pairs;
+        if (innerEquiv([bVal, bKey], [aVal, aKey])) {
+          innerEq = true;
         }
+
+        // Replace the global pairs list
+        pairs = parentPairs;
       });
 
-      return outerEq;
-    },
-
-    object: function (a, b) {
-      if (compareConstructors(a, b) === false) {
-        return false;
+      if (!innerEq) {
+        outerEq = false;
       }
+    });
 
-      const aProperties = [];
-      const bProperties = [];
+    return outerEq;
+  },
 
-      // Be strict: don't ensure hasOwnProperty and go deep
-      for (const i in a) {
-        // Collect a's properties
-        aProperties.push(i);
-
-        // Skip OOP methods that look the same
-        if (
-          a.constructor !== Object &&
-          typeof a.constructor !== 'undefined' &&
-          typeof a[i] === 'function' &&
-          typeof b[i] === 'function' &&
-          a[i].toString() === b[i].toString()
-        ) {
-          continue;
-        }
-
-        // Compare non-containers; queue non-reference-equal containers
-        if (!breadthFirstCompareChild(a[i], b[i])) {
-          return false;
-        }
-      }
-
-      for (const i in b) {
-        // Collect b's properties
-        bProperties.push(i);
-      }
-
-      // Ensures identical properties name
-      return typeEquiv(aProperties.sort(), bProperties.sort());
-    }
-  };
-
-  function typeEquiv (a, b) {
-    const type = objectType(a);
-
-    // Callbacks for containers will append to the pairs queue to achieve breadth-first
-    // search order. The pairs queue is also used to avoid reprocessing any pair of
-    // containers that are reference-equal to a previously visited pair (a special case
-    // this being recursion detection).
-    //
-    // Because of this approach, once typeEquiv returns a false value, it should not be
-    // called again without clearing the pair queue else it may wrongly report a visited
-    // pair as being equivalent.
-    return objectType(b) === type && callbacks[type](a, b);
-  }
-
-  function innerEquiv (a, b) {
-    // We're done when there's nothing more to compare
-    if (arguments.length < 2) {
-      return true;
+  object: function (a, b) {
+    if (compareConstructors(a, b) === false) {
+      return false;
     }
 
-    // Clear the global pair queue and add the top-level values being compared
-    pairs = [{ a: a, b: b }];
+    const aProperties = [];
+    const bProperties = [];
 
-    for (let i = 0; i < pairs.length; i++) {
-      const pair = pairs[i];
+    // Be strict: don't ensure hasOwnProperty and go deep
+    for (const i in a) {
+      // Collect a's properties
+      aProperties.push(i);
 
-      // Perform type-specific comparison on any pairs that are not strictly
-      // equal. For container types, that comparison will postpone comparison
-      // of any sub-container pair to the end of the pair queue. This gives
-      // breadth-first search order. It also avoids the reprocessing of
-      // reference-equal siblings, cousins etc, which can have a significant speed
-      // impact when comparing a container of small objects each of which has a
-      // reference to the same (singleton) large object.
-      if (pair.a !== pair.b && !typeEquiv(pair.a, pair.b)) {
+      // Skip OOP methods that look the same
+      if (
+        a.constructor !== Object &&
+        typeof a.constructor !== 'undefined' &&
+        typeof a[i] === 'function' &&
+        typeof b[i] === 'function' &&
+        a[i].toString() === b[i].toString()
+      ) {
+        continue;
+      }
+
+      // Compare non-containers; queue non-reference-equal containers
+      if (!breadthFirstCompareChild(a[i], b[i])) {
         return false;
       }
     }
 
-    // ...across all consecutive argument pairs
-    return arguments.length === 2 || innerEquiv.apply(this, [].slice.call(arguments, 1));
+    for (const i in b) {
+      // Collect b's properties
+      bProperties.push(i);
+    }
+
+    // Ensures identical properties name
+    return typeEquiv(aProperties.sort(), bProperties.sort());
+  }
+};
+
+function typeEquiv (a, b) {
+  const type = objectType(a);
+
+  // Callbacks for containers will append to the pairs queue to achieve breadth-first
+  // search order. The pairs queue is also used to avoid reprocessing any pair of
+  // containers that are reference-equal to a previously visited pair (a special case
+  // this being recursion detection).
+  //
+  // Because of this approach, once typeEquiv returns a false value, it should not be
+  // called again without clearing the pair queue else it may wrongly report a visited
+  // pair as being equivalent.
+  return objectType(b) === type && callbacks[type](a, b);
+}
+
+function innerEquiv (a, b) {
+  // We're done when there's nothing more to compare
+  if (arguments.length < 2) {
+    return true;
   }
 
-  return (...args) => {
-    const result = innerEquiv(...args);
+  // Clear the global pair queue and add the top-level values being compared
+  pairs = [{ a: a, b: b }];
 
-    // Release any retained objects
-    pairs.length = 0;
-    return result;
-  };
-}());
+  for (let i = 0; i < pairs.length; i++) {
+    const pair = pairs[i];
+
+    // Perform type-specific comparison on any pairs that are not strictly
+    // equal. For container types, that comparison will postpone comparison
+    // of any sub-container pair to the end of the pair queue. This gives
+    // breadth-first search order. It also avoids the reprocessing of
+    // reference-equal siblings, cousins etc, which can have a significant speed
+    // impact when comparing a container of small objects each of which has a
+    // reference to the same (singleton) large object.
+    if (pair.a !== pair.b && !typeEquiv(pair.a, pair.b)) {
+      return false;
+    }
+  }
+
+  // ...across all consecutive argument pairs
+  return arguments.length === 2 || innerEquiv.apply(this, [].slice.call(arguments, 1));
+}
+
+export default function equiv(...args) {
+  const result = innerEquiv(...args);
+
+  // Release any retained objects
+  pairs.length = 0;
+  return result;
+};

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -66,13 +66,11 @@ function breadthFirstCompareChild (a, b) {
   // over the pair.
   if (a === b) {
     return true;
-  }
-  if (!isContainer(a)) {
+  } else if (!isContainer(a)) {
     return typeEquiv(a, b);
-  }
-  if (pairs.every((pair) => pair.a !== a || pair.b !== b)) {
+  } else if (pairs.every((pair) => pair.a !== a || pair.b !== b)) {
     // Not yet started comparing this pair
-    pairs.push({ a: a, b: b });
+    pairs.push({ a, b });
   }
   return true;
 }
@@ -103,13 +101,12 @@ const callbacks = {
   },
 
   array (a, b) {
-    const len = a.length;
-    if (len !== b.length) {
+    if (a.length !== b.length) {
       // Safe and faster
       return false;
     }
 
-    for (let i = 0; i < len; i++) {
+    for (let i = 0; i < a.length; i++) {
       // Compare non-containers; queue non-reference-equal containers
       if (!breadthFirstCompareChild(a[i], b[i])) {
         return false;
@@ -284,7 +281,7 @@ function innerEquiv (a, b) {
   }
 
   // Clear the global pair queue and add the top-level values being compared
-  pairs = [{ a: a, b: b }];
+  pairs = [{ a, b }];
 
   for (let i = 0; i < pairs.length; i++) {
     const pair = pairs[i];
@@ -311,4 +308,4 @@ export default function equiv (...args) {
   // Release any retained objects
   pairs.length = 0;
   return result;
-};
+}

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -24,34 +24,14 @@ function useStrictEquality (a, b) {
   return a === b;
 }
 
+function getConstructor (obj) {
+  const proto = Object.getPrototypeOf(obj);
+
+  return !proto || proto.constructor === null ? Object : proto.constructor;
+}
+
 function compareConstructors (a, b) {
-  if (a.constructor === b.constructor) {
-    return true;
-  }
-
-  let protoA = Object.getPrototypeOf(a);
-  let protoB = Object.getPrototypeOf(b);
-
-  // Ref #851
-  // If the obj prototype descends from a null constructor, treat it
-  // as a null prototype.
-  if (protoA && protoA.constructor === null) {
-    protoA = null;
-  }
-  if (protoB && protoB.constructor === null) {
-    protoB = null;
-  }
-
-  // Allow objects with no prototype to be equivalent to
-  // objects with Object as their constructor.
-  if (
-    (protoA === null && protoB === Object.prototype) ||
-    (protoB === null && protoA === Object.prototype)
-  ) {
-    return true;
-  }
-
-  return false;
+  return getConstructor(a) === getConstructor(b);
 }
 
 function getRegExpFlags (regexp) {

--- a/src/equiv.js
+++ b/src/equiv.js
@@ -1,4 +1,7 @@
 import { objectType, slice } from './core/utilities';
+import { StringSet } from './globals';
+
+const CONTAINER_TYPES = new StringSet(['object', 'array', 'map', 'set']);
 
 // Value pairs queued for comparison. Used for breadth-first processing order, recursion
 // detection and avoiding repeated comparison (see below for details).
@@ -55,17 +58,13 @@ function getRegExpFlags (regexp) {
   return 'flags' in regexp ? regexp.flags : regexp.toString().match(/[gimuy]*$/)[0];
 }
 
-function isContainer (val) {
-  return ['object', 'array', 'map', 'set'].indexOf(objectType(val)) !== -1;
-}
-
 function breadthFirstCompareChild (a, b) {
   // If a is a container not reference-equal to b, postpone the comparison to the
   // end of the pairs queue -- unless (a, b) has been seen before, in which case skip
   // over the pair.
   if (a === b) {
     return true;
-  } else if (!isContainer(a)) {
+  } else if (!CONTAINER_TYPES.has(objectType(a))) {
     return typeEquiv(a, b);
   } else if (pairs.every((pair) => pair.a !== a || pair.b !== b)) {
     // Not yet started comparing this pair

--- a/src/globals.js
+++ b/src/globals.js
@@ -112,3 +112,25 @@ export const StringMap = typeof g.Map === 'function' &&
       });
     }
   };
+
+export const StringSet = g.Set || function (input) {
+  const set = Object.create(null);
+
+  if (Array.isArray(input)) {
+    input.forEach(item => {
+      set[item] = true;
+    });
+  }
+
+  return {
+    add (value) {
+      set[value] = true;
+    },
+    has (value) {
+      return value in set;
+    },
+    get size () {
+      return Object.keys(set).length;
+    }
+  };
+};


### PR DESCRIPTION
This makes QUnit.equiv code more readable/maintainable and probably faster due to 2 changes:

- inner private functions moved to ES Module cache instead of being registered on initial IIFE call.
- removal of len variable allocation for array checks.

We can also utilize JS `Set` and remove/inline `isContainer` function altogether here to do faster checks, I left this out from this PR because linter gives a warning telling me `compat/compat: Set is not supported in iOS Safari 7.0-7.1, IE 9`:
https://github.com/qunitjs/qunit/blob/main/src/equiv.js#L63

Also JIT compiler might be able to do further optimizations based on other small changes but unlikely. 

I suggest reviewing per commit ;)