### PR TITLE
Fix memory leaks in due to timeout/timeoutHandler

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -341,6 +341,13 @@ Test.prototype = {
   finish: function () {
     config.current = this;
 
+    // Release the timeout and timeout callback references
+    // to be garbage collected.
+    if (setTimeout) {
+      clearTimeout(this.timeout);
+      config.timeoutHandler = null;
+    }
+
     // Release the test callback to ensure that anything referenced has been
     // released to be garbage collected.
     this.callback = undefined;


### PR DESCRIPTION
disclaimer: I'm not sure if `Test.finish` is the best place to put such logic, however it seemed most logic place for me.

The problem description:
In Ember.js we have `ember-qunit` package that assigns reference to the currently running application instance to `this.owner`, where `this` is the reference to `testEnvironment` property in `Test` class.

During test execution (here https://github.com/qunitjs/qunit/blob/2.19.3/src/test.js#L752), we persist references to the `timeoutHandler` in the shared `config` object.

After the test execution, `config.timeoutHandler` keeps reference to the last test that was executed (as it's closure created in https://github.com/qunitjs/qunit/blob/2.19.3/src/test.js#L738).

As a result, after tests execution there is a reference to the application instance persisted in heap, which makes it harder to find memory leaks in the application code.

I'm not sure if there is a need/way to write test for this, so please advice.