### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/assert/notPropEqual.md
+++ b/docs/assert/notPropEqual.md
@@ -47,7 +47,7 @@ QUnit.test('example', assert => {
   const foo = new Foo();
 
   // succeeds, only own property values are compared (using strict equality),
-  // and propery "x" is indeed not equal (string instead of number).
+  // and property "x" is indeed not equal (string instead of number).
   assert.notPropEqual(foo, {
     x: 1,
     y: 2

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -18,7 +18,7 @@ const config = {
   // defaults to `true`
   failOnZeroTests: true,
 
-  // Select by pattern or case-insenstive substring match against "moduleName: testName"
+  // Select by pattern or case-insensitive substring match against "moduleName: testName"
   filter: undefined,
 
   // Depth up-to which object will be dumped

--- a/src/html-reporter/html.js
+++ b/src/html-reporter/html.js
@@ -379,7 +379,7 @@ export function escapeText (str) {
       //
       // We don't reference `config.moduleId` directly after this and keep our own
       // copy because:
-      // 1. This naturaly filters out unknown moduleIds.
+      // 1. This naturally filters out unknown moduleIds.
       // 2. Gives us a place to manage and remember unsubmitted checkbox changes.
       // 3. Gives us an efficient way to map a selected moduleId to module name
       //    during rendering.

--- a/test/cli/helpers/execute.js
+++ b/test/cli/helpers/execute.js
@@ -40,7 +40,7 @@ function normalize (actual) {
 
     // Convert /bin/qunit and /src/cli to internal as well
     // Because there are differences between Node 10 and Node 12 in terms
-    // of how much back and forth ocurrs, so by mapping both to internal
+    // of how much back and forth occurs, so by mapping both to internal
     // we can flatten and normalize across.
     .replace(/^(\s+at ).*\/qunit\/bin\/qunit\.js.*$/gm, '$1internal')
     .replace(/^(\s+at ).*\/qunit\/src\/cli\/.*$/gm, '$1internal')


### PR DESCRIPTION
There are small typos in:
- docs/assert/notPropEqual.md
- src/core/config.js
- src/html-reporter/html.js
- test/cli/helpers/execute.js

Fixes:
- Should read `property` rather than `propery`.
- Should read `occurs` rather than `ocurrs`.
- Should read `naturally` rather than `naturaly`.
- Should read `insensitive` rather than `insenstive`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md