### PR TITLE
Core: add type checking for assert.async

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -77,7 +77,7 @@ class Assert {
     return this.test.internalStop(requiredCalls);
   }
 
-  // goExports test.push() to the user API
+  // Exports test.push() to the user API
   // Alias of pushResult.
   push (result, actual, expected, message, negative) {
     Logger.warn('assert.push is deprecated and will be removed in QUnit 3.0.' +

--- a/src/assert.js
+++ b/src/assert.js
@@ -68,11 +68,16 @@ class Assert {
 
   // Create a new async pause and return a new function that can release the pause.
   async (count) {
-    const requiredCalls = count === undefined ? 1 : count;
+    if (count === undefined) {
+      count = 1;
+    } else if (typeof count !== 'number') {
+      throw new TypeError('async takes number as an input');
+    }
+    const requiredCalls = count;
     return this.test.internalStop(requiredCalls);
   }
 
-  // Exports test.push() to the user API
+  // goExports test.push() to the user API
   // Alias of pushResult.
   push (result, actual, expected, message, negative) {
     Logger.warn('assert.push is deprecated and will be removed in QUnit 3.0.' +


### PR DESCRIPTION
Added type checking for assert.async, so for an invalid input like string, the page would not hang indefinitely.

Fixes #1721 