### PR TITLE
Core: Add type checking for assert.async

### DIFF
--- a/src/assert.js
+++ b/src/assert.js
@@ -68,7 +68,12 @@ class Assert {
 
   // Create a new async pause and return a new function that can release the pause.
   async (count) {
-    const requiredCalls = count === undefined ? 1 : count;
+    if (count === undefined) {
+      count = 1;
+    } else if (typeof count !== 'number') {
+      throw new TypeError('async takes number as an input');
+    }
+    const requiredCalls = count;
     return this.test.internalStop(requiredCalls);
   }
 

--- a/test/main/async.js
+++ b/test/main/async.js
@@ -121,6 +121,15 @@ QUnit.module('assert.async', function () {
     done();
   });
 
+  QUnit.test('fails if using non-numeric as an input', function (assert) {
+    assert.throws(
+      function () {
+        assert.async('an invalid string input');
+      },
+      new TypeError('async takes number as an input')
+    );
+  });
+
   QUnit.test('fails if called more than specified count', function (assert) {
     // Having an outer async flow in this test avoids the need to manually modify QUnit internals
     // in order to avoid post-`done` assertions causing additional failures


### PR DESCRIPTION
Added type checking for assert.async, so for an invalid input like string, the page would not hang indefinitely.
Fixes [#1721](https://github.com/qunitjs/qunit/issues/1721)