### PR TITLE
Better ESM support

### DIFF
--- a/src/export.js
+++ b/src/export.js
@@ -21,7 +21,7 @@ export default function exportQUnit (QUnit) {
 
     // For consistency with CommonJS environments' exports
     module.exports.QUnit = QUnit;
-    // For allowing a CJS-compatible ESM imports
+    // For allowing ESM imports
     module.exports.todo = QUnit.todo;
     module.exports.skip = QUnit.skip;
     module.exports.test = QUnit.test;

--- a/src/export.js
+++ b/src/export.js
@@ -21,6 +21,11 @@ export default function exportQUnit (QUnit) {
 
     // For consistency with CommonJS environments' exports
     module.exports.QUnit = QUnit;
+    // For allowing a CJS-compatible ESM imports
+    module.exports.todo = QUnit.todo;
+    module.exports.skip = QUnit.skip;
+    module.exports.test = QUnit.test;
+    module.exports.module = QUnit.module;
 
     exportedModule = true;
   }

--- a/test/es2018/explicit-imports.mjs
+++ b/test/es2018/explicit-imports.mjs
@@ -1,0 +1,7 @@
+import { module, test } from 'qunit';
+
+module('ESM test suite', () => {
+  test('imports worked', function (assert) {
+    assert.true(true, 'an assertion');
+  });
+});


### PR DESCRIPTION
Resolves: https://github.com/qunitjs/qunit/issues/1724

(however, I can't run tests locally, because the browser launcher is puppeteer, and some ancient browser that I don't have installed :sweat_smile: 
```
>> There was an error with headless chrome
Fatal error: Could not find browser revision 818858. Run "PUPPETEER_PRODUCT=firefox npm install" or "PUPPETEER_PRODUCT=firefox yarn install" to download a supported Firefox browser binary.
```
)



I had started with an esm.html file to test with, but `script.type=module` doesn't allow the file protocol when loading modules, so we'd have to use an http server, but then the relative file paths for the link / importmap / script.src wouldn't work the same.