### PR TITLE
Drop node < 18

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -14,7 +14,7 @@ jobs:
           - name: "Linux: Node 18"
             os: ubuntu-20.04
             node: 18.x
-            script: npm run test-nolint
+            script: npm run test
 
           - name: "Integration"
             os: ubuntu-20.04

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,44 +16,19 @@ jobs:
             node: 18.x
             script: npm run test-nolint
 
-          - name: "Linux: Node 16"
-            # Includes 'firefox', 'chromium', and more.
-            # https://github.com/actions/virtual-environments/blob/ubuntu20/20220410.2/images/linux/Ubuntu2004-Readme.md
-            os: ubuntu-20.04
-            node: 16.x
-            # Run the lint step only once because, in March 2022, GitHub began
-            # automatically extracting ESLint warnings from build logs and turning them into
-            # checks shown inline in PR diffs, but doesn't de-duplicate these.
-            script: npm test
-
-          - name: "Linux: Node 14"
-            os: ubuntu-20.04
-            node: 14.x
-            script: npm run test-nolint
-
-          - name: "Linux: Node 12"
-            os: ubuntu-20.04
-            node: 12.x
-            script: npm run test-nolint
-
-          - name: "Linux: Node 10"
-            os: ubuntu-20.04
-            node: 10.x
-            script: npm run test-nolint
-
           - name: "Integration"
             os: ubuntu-20.04
-            node: 16.x
+            node: 18.x
             script: npm run test-integration
 
-          - name: "Windows: Node 16"
+          - name: "Windows: Node 18"
             os: windows-latest
-            node: 16.x
+            node: 18.x
             script: npm run test-nolint
 
-          - name: "macOS: Node 16"
+          - name: "macOS: Node 18"
             os: macos-latest
-            node: 16.x
+            node: 18.x
             script: npm run test-nolint
 
     name: ${{ matrix.name }}
@@ -112,10 +87,10 @@ jobs:
             ~/.npm
             ${{ github.workspace }}/.puppeteer_download
           key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install mozjs
         run: |
           sudo apt-fast install -y libmozjs-68-dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,8 +51,7 @@
         "proxyquire": "^1.8.0",
         "requirejs": "^2.3.6",
         "rimraf": "^3.0.2",
-        "rollup": "^2.79.1",
-        "semver": "^7.3.8"
+        "rollup": "^2.79.1"
       },
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "main": "qunit/qunit.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "dependencies": {
     "commander": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -80,8 +80,7 @@
     "proxyquire": "^1.8.0",
     "requirejs": "^2.3.6",
     "rimraf": "^3.0.2",
-    "rollup": "^2.79.1",
-    "semver": "^7.3.8"
+    "rollup": "^2.79.1"
   },
   "scripts": {
     "build": "rollup -c && grunt copy:src-css",

--- a/test/cli/cli-main.js
+++ b/test/cli/cli-main.js
@@ -259,67 +259,53 @@ HOOK: BCD1 @ B after`;
     assert.equal(execution.code, 0);
   });
 
-  if (semver.gte(process.versions.node, '12.0.0')) {
-    QUnit.test('run ESM test suite with import statement', async assert => {
-      const command = ['qunit', '../../es2018/esm.mjs'];
-      const execution = await execute(command);
+  QUnit.test('run ESM test suite with import statement', async assert => {
+    const command = ['qunit', '../../es2018/esm.mjs'];
+    const execution = await execute(command);
+    assert.equal(execution.code, 0);
+    assert.equal(execution.stderr, '');
+    assert.equal(execution.stdout, getExpected(command));
+  });
 
-      // Node 12 enabled ESM by default, without experimental flag,
-      // but left the warning in stderr. The warning was removed in Node 14.
-      // Don't bother checking stderr
-      const stderr = semver.gte(process.versions.node, '14.0.0') ? execution.stderr : '';
-      assert.equal(execution.code, 0);
-      assert.equal(stderr, '');
-      assert.equal(execution.stdout, getExpected(command));
-    });
-  }
+  // TODO: Figure out why trace isn't trimmed on Windows. https://github.com/qunitjs/qunit/issues/1359
+  QUnit[skipOnWinTest]('normal trace with native source map', async assert => {
+    const command = ['qunit', 'sourcemap/source.js'];
+    const execution = await execute(command);
 
-  // https://nodejs.org/dist/v12.12.0/docs/api/cli.html#cli_enable_source_maps
-  if (semver.gte(process.versions.node, '14.0.0')) {
-    // TODO: Figure out why trace isn't trimmed on Windows. https://github.com/qunitjs/qunit/issues/1359
-    QUnit[skipOnWinTest]('normal trace with native source map', async assert => {
-      const command = ['qunit', 'sourcemap/source.js'];
-      const execution = await execute(command);
+    assert.equal(execution.snapshot, getExpected(command));
+  });
 
-      assert.equal(execution.snapshot, getExpected(command));
-    });
-
-    // skip if running in code coverage mode,
-    // as that leads to conflicting maps-on-maps that invalidate this test
-    //
-    // TODO: Figure out why trace isn't trimmed on Windows. https://github.com/qunitjs/qunit/issues/1359
-    QUnit[process.env.NYC_PROCESS_ID ? 'skip' : skipOnWinTest](
-      'mapped trace with native source map', async function (assert) {
-        const command = ['qunit', 'sourcemap/source.min.js'];
-        const execution = await execute(command, {
-          env: { NODE_OPTIONS: '--enable-source-maps' }
-        });
-
-        assert.equal(execution.snapshot, getExpected(command));
+  // skip if running in code coverage mode,
+  // as that leads to conflicting maps-on-maps that invalidate this test
+  //
+  // TODO: Figure out why trace isn't trimmed on Windows. https://github.com/qunitjs/qunit/issues/1359
+  QUnit[process.env.NYC_PROCESS_ID ? 'skip' : skipOnWinTest](
+    'mapped trace with native source map', async function (assert) {
+      const command = ['qunit', 'sourcemap/source.min.js'];
+      const execution = await execute(command, {
+        env: { NODE_OPTIONS: '--enable-source-maps' }
       });
-  }
 
-  // https://nodejs.org/docs/v14.0.0/api/v8.html#v8_v8_getheapsnapshot
-  // Created in Node 11.x, but starts working the way we need from Node 14.
-  if (semver.gte(process.versions.node, '14.0.0')) {
-    QUnit.test('memory-leak/module-closure [unfiltered]', async assert => {
-      const command = ['node', '--expose-gc', '../../../bin/qunit.js', 'memory-leak/module-closure.js'];
-      const execution = await execute(command);
       assert.equal(execution.snapshot, getExpected(command));
     });
 
-    QUnit.test('memory-leak/module-closure [filtered module]', async assert => {
-      const command = ['node', '--expose-gc', '../../../bin/qunit.js', '--filter', '!child', 'memory-leak/module-closure.js'];
-      const execution = await execute(command);
-      assert.equal(execution.snapshot, getExpected(command));
-    });
+  QUnit.test('memory-leak/module-closure [unfiltered]', async assert => {
+    const command = ['node', '--expose-gc', '../../../bin/qunit.js', 'memory-leak/module-closure.js'];
+    const execution = await execute(command);
+    assert.equal(execution.snapshot, getExpected(command));
+  });
 
-    QUnit.test('memory-leak/test-object', async assert => {
-      const command = ['node', '--expose-gc', '../../../bin/qunit.js', 'memory-leak/test-object.js'];
-      const execution = await execute(command);
-      assert.equal(execution.snapshot, getExpected(command));
-    });
-  }
+  QUnit.test('memory-leak/module-closure [filtered module]', async assert => {
+    const command = ['node', '--expose-gc', '../../../bin/qunit.js', '--filter', '!child', 'memory-leak/module-closure.js'];
+    const execution = await execute(command);
+    assert.equal(execution.snapshot, getExpected(command));
+  });
+
+  QUnit.test('memory-leak/test-object', async assert => {
+    const command = ['node', '--expose-gc', '../../../bin/qunit.js', 'memory-leak/test-object.js'];
+    const execution = await execute(command);
+    assert.equal(execution.snapshot, getExpected(command));
+  });
 
   // TODO: Workaround fact that child_process.spawn() args array is a lie on Windows.
   // https://github.com/nodejs/node/issues/29532

--- a/test/cli/cli-main.js
+++ b/test/cli/cli-main.js
@@ -2,7 +2,6 @@
 
 const expectedOutput = require('./fixtures/expected/tap-outputs');
 const { execute, prettyPrintCommand, concurrentMapKeys } = require('./helpers/execute');
-const semver = require('semver');
 
 const skipOnWinTest = (process.platform === 'win32' ? 'skip' : 'test');
 


### PR DESCRIPTION
Resolves: https://github.com/qunitjs/qunit/issues/1727

targeting the `next` branch.
Removes all references to node < 18