### PR TITLE
Core: Fix compatibility with sinon.useFakeTimers in IE

### DIFF
--- a/lib/promise-polyfill.js
+++ b/lib/promise-polyfill.js
@@ -373,16 +373,18 @@ Promise.race = function(arr) {
 };
 
 // Use polyfill for setImmediate for performance gains
-Promise._immediateFn =
+// @ts-ignore
+if (typeof setImmediate === 'function') {
   // @ts-ignore
-  (typeof setImmediate === 'function' &&
-    function(fn) {
-      // @ts-ignore
-      setImmediate(fn);
-    }) ||
-  function(fn) {
+  var setImmediateFunc = setImmediate;
+  Promise._immediateFn = function(fn) {
+    setImmediateFunc(fn);
+  };
+} else {
+  Promise._immediateFn = function(fn) {
     setTimeoutFunc(fn, 0);
   };
+}
 
 Promise._unhandledRejectionFn = function _unhandledRejectionFn(err) {
   if (typeof console !== 'undefined' && console) {

--- a/lib/promise-polyfill.js
+++ b/lib/promise-polyfill.js
@@ -26,8 +26,6 @@ THE SOFTWARE.
 
 Patches for use in QUnit:
 
-- 2024-02-07: Save umodified setImmediate to avoid conflicts with fake timers.
-
 - 2021-01-09: Export as module only, don't change global scope as QUnit must not
   affect the host context (e.g. people may test their application intentionally
   with different or no polyfills and we must not affect that).
@@ -37,6 +35,8 @@ Patches for use in QUnit:
   (it has native support for Promise), instead of building an unused polyfill.
 
 - 2021-01-10: Add 'globalThis' to globalNS implementation to support SpiderMonkey.
+
+- 2024-02-07: Save unmodified setImmediate to avoid conflicts with Sinon fake timers.
 
 */
 

--- a/lib/promise-polyfill.js
+++ b/lib/promise-polyfill.js
@@ -26,6 +26,8 @@ THE SOFTWARE.
 
 Patches for use in QUnit:
 
+- 2024-02-07: Save umodified setImmediate to avoid conflicts with fake timers.
+
 - 2021-01-09: Export as module only, don't change global scope as QUnit must not
   affect the host context (e.g. people may test their application intentionally
   with different or no polyfills and we must not affect that).

--- a/test/main/promise.js
+++ b/test/main/promise.js
@@ -270,14 +270,18 @@ QUnit.module('Support for Promise', function () {
     beforeEach: function (assert) {
       this.setTimeout = globalNS.setTimeout;
       globalNS.setTimeout = function () {};
-      this.setImmediate = globalNS.setImmediate;
-      globalNS.setImmediate = function () {};
+      if (globalNS.setImmediate) {
+        this.setImmediate = globalNS.setImmediate;
+        globalNS.setImmediate = function () {};
+      }
       // Adds 1 assertion
       return createMockPromise(assert);
     },
     afterEach: function (assert) {
       globalNS.setTimeout = this.setTimeout;
-      globalNS.setImmediate = this.setImmediate;
+      if (this.setImmediate) {
+        globalNS.setImmediate = this.setImmediate;
+      }
       // Adds 1 assertion
       return createMockPromise(assert);
     }

--- a/test/main/promise.js
+++ b/test/main/promise.js
@@ -8,19 +8,22 @@ var defer = typeof setTimeout !== 'undefined'
     Promise.resolve().then(fn);
   };
 
-// Get the global namespace the same way
-// as the Promise polyfill.
-var globalNS = (function() {
+// Get the global namespace the same way as the Promise polyfill.
+var globalNS = (function () {
   if (typeof globalThis !== 'undefined') {
+    // eslint-disable-next-line no-undef
     return globalThis;
   }
   if (typeof self !== 'undefined') {
+    // eslint-disable-next-line no-undef
     return self;
   }
   if (typeof window !== 'undefined') {
+    // eslint-disable-next-line no-undef
     return window;
   }
   if (typeof global !== 'undefined') {
+    // eslint-disable-next-line no-undef
     return global;
   }
   throw new Error('unable to locate global object');

--- a/test/main/promise.js
+++ b/test/main/promise.js
@@ -8,6 +8,24 @@ var defer = typeof setTimeout !== 'undefined'
     Promise.resolve().then(fn);
   };
 
+// Get the global namespace the same way
+// as the Promise polyfill.
+var globalNS = (function() {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+  throw new Error('unable to locate global object');
+})();
+
 // NOTE: Adds 1 assertion
 function createMockPromise (assert, reject, value) {
   if (arguments.length < 3) {
@@ -246,5 +264,26 @@ QUnit.module('Support for Promise', function () {
     };
 
     return createMockPromise(assert, true, new Error('this is an error'));
+  });
+
+  QUnit.module('compatible with fake timers', {
+    beforeEach: function (assert) {
+      this.setTimeout = globalNS.setTimeout;
+      globalNS.setTimeout = function () {};
+      this.setImmediate = globalNS.setImmediate;
+      globalNS.setImmediate = function () {};
+      // Adds 1 assertion
+      return createMockPromise(assert);
+    },
+    afterEach: function (assert) {
+      globalNS.setTimeout = this.setTimeout;
+      globalNS.setImmediate = this.setImmediate;
+      // Adds 1 assertion
+      return createMockPromise(assert);
+    }
+  });
+
+  QUnit.test('test', function (assert) {
+    assert.expect(2);
   });
 });


### PR DESCRIPTION
The Promise polyfill needed to save the unmodified setImmediate function in IE to use for Promise._immediateFn