### PR TITLE
Core: Fix hanging `assert.async()` after `assert.timeout()`

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -752,7 +752,7 @@ Test.prototype = {
               `Test took longer than ${timeout}ms; test timed out.`,
               sourceFromStacktrace(2)
             );
-            internalStart(test);
+            internalRecover(test);
           };
         };
         clearTimeout(config.timeout);

--- a/test/cli/cli-main.js
+++ b/test/cli/cli-main.js
@@ -25,6 +25,7 @@ const fixtureCases = {
 
   'test with failing assertion': ['qunit', 'fail/failure.js'],
   'test that hangs': ['qunit', 'hanging-test'],
+  'test with pending async after timeout': ['qunit', 'pending-async-after-timeout.js'],
   'two tests with one timeout': ['qunit', 'timeout'],
   'test with zero assertions': ['qunit', 'zero-assertions.js'],
 

--- a/test/cli/fixtures/expected/tap-outputs.js
+++ b/test/cli/fixtures/expected/tap-outputs.js
@@ -193,6 +193,25 @@ Last test to run (hanging) has an async hold. Ensure all assert.async() callback
 
 # exit code: 1`,
 
+  'qunit pending-async-after-timeout.js':
+`TAP version 13
+not ok 1 example
+  ---
+  message: Test took longer than 10ms; test timed out.
+  severity: failed
+  actual  : null
+  expected: undefined
+  stack: |
+        at internal
+  ...
+1..1
+# pass 0
+# skip 0
+# todo 0
+# fail 1
+
+# exit code: 1`,
+
   'qunit unhandled-rejection.js':
 `not ok 1 global failure
   ---

--- a/test/cli/fixtures/pending-async-after-timeout.js
+++ b/test/cli/fixtures/pending-async-after-timeout.js
@@ -1,6 +1,7 @@
 // Regression test for https://github.com/qunitjs/qunit/issues/1705
-QUnit.test( "example", async assert => {
-  assert.timeout( 10 );
+QUnit.test('example', async assert => {
+  assert.timeout(10);
+  // eslint-disable-next-line no-unused-vars
   const done = assert.async();
-  assert.true( true );
-} );
+  assert.true(true);
+});

--- a/test/cli/fixtures/pending-async-after-timeout.js
+++ b/test/cli/fixtures/pending-async-after-timeout.js
@@ -1,0 +1,6 @@
+// Regression test for https://github.com/qunitjs/qunit/issues/1705
+QUnit.test( "example", async assert => {
+  assert.timeout( 10 );
+  const done = assert.async();
+  assert.true( true );
+} );


### PR DESCRIPTION
Follows-up 163c9bcf60 (https://github.com/qunitjs/qunit/pull/1642), which changed an internalRecover() to internalStart(), whereas internalStart will (correctly) not resume if there are other pauses still remaining.

Change this back to internalRecover().

Fixes https://github.com/qunitjs/qunit/issues/1705.