### PR TITLE
CLI: Upgrade `node-watch` to 0.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "commander": "7.2.0",
-        "node-watch": "0.7.3",
+        "node-watch": "0.7.4",
         "tiny-glob": "0.2.9"
       },
       "bin": {
@@ -6798,9 +6798,9 @@
       "dev": true
     },
     "node_modules/node-watch": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
-      "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.4.tgz",
+      "integrity": "sha512-RinNxoz4W1cep1b928fuFhvAQ5ag/+1UlMDV7rbyGthBIgsiEouS4kvRayvvboxii4m8eolKOIBo3OjDqbc+uQ==",
       "engines": {
         "node": ">=6"
       }
@@ -14270,9 +14270,9 @@
       "dev": true
     },
     "node-watch": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
-      "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ=="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.4.tgz",
+      "integrity": "sha512-RinNxoz4W1cep1b928fuFhvAQ5ag/+1UlMDV7rbyGthBIgsiEouS4kvRayvvboxii4m8eolKOIBo3OjDqbc+uQ=="
     },
     "nopt": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "commander": "7.2.0",
-    "node-watch": "0.7.3",
+    "node-watch": "0.7.4",
     "tiny-glob": "0.2.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Update `node-watch` from 0.7.3 to 0.7.4  (latest).

<https://github.com/yuanchuan/node-watch/releases/tag/0.7.4>
<https://github.com/yuanchuan/node-watch/commits/master>

* [x] Verify npm publisher.
* [x] Review package diffs.
* [x] Stage update in PR and confirm releated features: CLI file watching.

Previously [at https://github.com/qunitjs/qunit/issues/1522.](https://github.com/qunitjs/qunit/issues/1524)