### PR TITLE
HTML Reporter: Fix reversed order after clicking "Hide passed"

### DIFF
--- a/src/html-reporter/html.js
+++ b/src/html-reporter/html.js
@@ -215,10 +215,8 @@ const stats = {
             tests.removeChild(hiddenTest);
           }
         } else {
-          let test;
-          // eslint-disable-next-line eqeqeq
-          while ((test = hiddenTests.pop()) != null) {
-            tests.appendChild(test);
+          while (hiddenTests.length) {
+            tests.appendChild(hiddenTests.shift());
           }
         }
       }


### PR DESCRIPTION
Follows-up https://github.com/qunitjs/qunit/pull/1311.

This fixes a regression in QUnit 2.7.0. Since then, when viewing a finished test run and turning on "Hide passed" and then turning it off again, displays the results in reversed order.

This was because we hide each test from top to bottom (and push into the array), but then upon re-inserting them we used `pop()`, which means we first append the last test to the end of the page, and then the before-last is popped after that and appended to what is now the end of the page, etc. The end result is the tests originally display from A-Z, and are stored in the array from A-Z as well, but then after toggling on/off, get rendered Z-A.