### PR TITLE
HTML Reporter: Fix `<label>` to wrap `<select>` for multi-value urlConfig item

### DIFF
--- a/src/reporters/HtmlReporter.js
+++ b/src/reporters/HtmlReporter.js
@@ -83,7 +83,7 @@ function getUrlConfigHtml (config) {
       let selection = false;
       urlConfigHtml += "<label for='qunit-urlconfig-" + escaped +
         "' title='" + escapedTooltip + "'>" + val.label +
-        ": </label><select id='qunit-urlconfig-" + escaped +
+        ": <select id='qunit-urlconfig-" + escaped +
         "' name='" + escaped + "' title='" + escapedTooltip + "'><option></option>";
 
       if (Array.isArray(val.value)) {
@@ -111,7 +111,7 @@ function getUrlConfigHtml (config) {
         urlConfigHtml += "<option value='" + escaped +
           "' selected='selected' disabled='disabled'>" + escaped + '</option>';
       }
-      urlConfigHtml += '</select>';
+      urlConfigHtml += '</select></label>';
     }
   }
 


### PR DESCRIPTION
https://qunitjs.com/api/config/urlConfig/

Demonstrated by <http://localhost:4000/test/reporter-urlparams.html> fixture.

This creates consistency with how we render label/input checkboxes, and improves spacing in the design.

Before (top), After (bottom).

<img width="883" alt="Screenshot 2024-07-02 at 20 31 35" src="https://github.com/qunitjs/qunit/assets/156867/77242d80-ad87-4dd2-9a15-e7be8248ee58">
