### PR TITLE
Assert: Exclude `assert.step()` calls from `assert.expect()` count

### DIFF
--- a/docs/api/assert/expect.md
+++ b/docs/api/assert/expect.md
@@ -22,7 +22,11 @@ This is most commonly used as `assert.expect(0)`, which indicates that a test ma
 
 This can also be used to explicitly require a certain number of assertions to be recorded in a given test. If afterwards the number of assertions does not match the expected count, the test will fail.
 
-It is recommended to test asynchronous code with [`assert.step()`](./step.md) or [`assert.async()`](./async.md) instead.
+It is recommended to test asynchronous code with the [`assert.verifySteps()`](./verifySteps.md) or [`assert.async()`](./async.md) methods instead. If you're using these stricter methods already, consider removing the `assert.expect()` call. See also the [require-expect "never-except-zero"](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/require-expect.md) rule of the [eslint-plugin-qunit](https://www.npmjs.com/package/eslint-plugin-qunit) package.
+
+## Changelog
+
+| UNRELEASED | `assert.expect()` now counts [`assert.verifySteps()`](./verifySteps.md) as one assertion. Steps no longer count separately.
 
 ## Examples
 
@@ -63,7 +67,9 @@ QUnit.test('example', function (assert) {
 
 ### Example: Explicit count
 
-Require an explicit assertion count.
+Fail the test if the test did not complete an exact assertion count.
+
+It is recommended to test callback code with [`assert.verifySteps()`](./verifySteps.md) instead, as replacement for relying on `assert.expect()`. See also the [require-expect "never-except-zero"](https://github.com/platinumazure/eslint-plugin-qunit/blob/main/docs/rules/require-expect.md) rule of the [eslint-plugin-qunit](https://www.npmjs.com/package/eslint-plugin-qunit) package.
 
 ```js
 QUnit.test('example', function (assert) {

--- a/docs/api/assert/step.md
+++ b/docs/api/assert/step.md
@@ -17,9 +17,13 @@ Record a step for later verification.
 |------|-------------|
 | `value` (string) | Relevant string value, or short description, to mark this step. |
 
-This assertion registers a passing assertion with the provided string. This and any other steps should be verified later in the test via [`assert.verifySteps()`](./verifySteps.md).
+This and any later steps must be verified before the end of the test via [`assert.verifySteps()`](./verifySteps.md).
 
 The Step API provides an easy way to verify execution logic to a high degree of accuracy and precision, whether for asynchronous code, event-driven code, or callback-driven code.
+
+## Changelog
+
+| UNRELEASED | [assert.expect()](./expect.md) now counts [assert.verifySteps()](./verifySteps.md) as one assertion. Steps no longer count separately.
 
 ## Examples
 

--- a/docs/api/assert/verifySteps.md
+++ b/docs/api/assert/verifySteps.md
@@ -28,6 +28,10 @@ Calling `verifySteps()` will clear and reset the internal list of steps. This al
 
 Refer to the below examples and learn how to use the Step API in your test suite.
 
+## Changelog
+
+| UNRELEASED | [assert.expect()](./expect.md) now counts `assert.verifySteps()` as one assertion. Steps no longer count separately.
+
 ## Examples
 
 ### Test event-based interface

--- a/src/assert.js
+++ b/src/assert.js
@@ -30,23 +30,15 @@ class Assert {
   }
 
   // Documents a "step", which is a string value, in a test as a passing assertion
-  step (message) {
-    let assertionMessage = message;
-    let result = !!message;
-
-    this.test.steps.push(message);
-
-    if (typeof message === 'undefined' || message === '') {
-      assertionMessage = 'You must provide a message to assert.step';
-    } else if (typeof message !== 'string') {
-      assertionMessage = 'You must provide a string value to assert.step';
-      result = false;
+  step (value) {
+    if (typeof value === 'undefined' || value === '') {
+      throw new TypeError('You must provide a value to assert.step');
+    }
+    if (typeof value !== 'string') {
+      throw new TypeError('You must provide a string value to assert.step');
     }
 
-    this.pushResult({
-      result,
-      message: assertionMessage
-    });
+    this.test.steps.push(value);
   }
 
   // Verifies the steps in a test match a given array of string values
@@ -54,6 +46,7 @@ class Assert {
     // Since the steps array is just string values, we can clone with slice
     const actualStepsClone = this.test.steps.slice();
     this.deepEqual(actualStepsClone, steps, message);
+    this.test.stepsCount += this.test.steps.length;
     this.test.steps.length = 0;
   }
 

--- a/src/test.js
+++ b/src/test.js
@@ -25,6 +25,9 @@ export default function Test (settings) {
   this.assertions = [];
   this.module = config.currentModule;
   this.steps = [];
+  // Track count in order to detect likely issue when upgrading.
+  // https://github.com/qunitjs/qunit/pull/1775
+  this.stepsCount = 0;
   this.timeout = undefined;
   this.data = undefined;
   this.withData = false;
@@ -342,6 +345,9 @@ Test.prototype = {
     if (config.requireExpects && this.expected === null) {
       this.pushFailure('Expected number of assertions to be defined, but expect() was ' +
         'not called.', this.stack);
+    } else if (this.expected !== null && this.stepsCount && (this.expected === (this.assertions.length + this.stepsCount))) {
+      this.pushFailure('Expected ' + this.expected + ' assertions, but ' +
+        this.assertions.length + ' were run.\nIt looks like you are upgrading from QUnit 2. Steps no longer count as separate assertions. https://qunitjs.com/api/assert/expect/', this.stack);
     } else if (this.expected !== null && this.expected !== this.assertions.length) {
       this.pushFailure('Expected ' + this.expected + ' assertions, but ' +
         this.assertions.length + ' were run', this.stack);

--- a/test/cli/fixtures/assert-expect-failure-step.js
+++ b/test/cli/fixtures/assert-expect-failure-step.js
@@ -1,0 +1,62 @@
+QUnit.test('passing [once]', function (assert) {
+  assert.expect(1);
+
+  assert.step('a');
+  assert.step('b');
+  assert.verifySteps(['a', 'b']);
+});
+
+QUnit.test('passing [twice]', function (assert) {
+  assert.expect(2);
+
+  assert.step('a');
+  assert.step('b');
+  assert.verifySteps(['a', 'b']);
+
+  assert.step('c');
+  assert.step('d');
+  assert.step('e');
+  assert.verifySteps(['c', 'd', 'e']);
+});
+
+QUnit.test('wrong [a little off]', function (assert) {
+  assert.expect(2);
+
+  assert.step('a');
+  assert.step('b');
+  assert.verifySteps(['a', 'b']);
+});
+
+QUnit.test('wrong [way off]', function (assert) {
+  assert.expect(5);
+
+  assert.step('a');
+  assert.step('b');
+  assert.verifySteps(['a', 'b']);
+});
+
+// These were the correct counts in QUnit 2.x
+// https://github.com/qunitjs/qunit/issues/1226
+QUnit.test('previously passing [once]', function (assert) {
+  assert.expect(4);
+
+  assert.step('a');
+  assert.step('b');
+  assert.verifySteps(['a', 'b']);
+  assert.true(true);
+});
+
+QUnit.test('previously passing [twice]', function (assert) {
+  assert.expect(9);
+
+  assert.step('a');
+  assert.true(true);
+  assert.step('b');
+  assert.verifySteps(['a', 'b']);
+
+  assert.false(false);
+  assert.step('c');
+  assert.step('d');
+  assert.step('e');
+  assert.verifySteps(['c', 'd', 'e']);
+});

--- a/test/cli/fixtures/assert-expect-failure-step.tap.txt
+++ b/test/cli/fixtures/assert-expect-failure-step.tap.txt
@@ -1,0 +1,56 @@
+# command: ["qunit", "assert-expect-failure-step.js"]
+
+TAP version 13
+ok 1 passing [once]
+ok 2 passing [twice]
+not ok 3 wrong [a little off]
+  ---
+  message: Expected 2 assertions, but 1 were run
+  severity: failed
+  actual  : null
+  expected: undefined
+  stack: |
+        at /qunit/test/cli/fixtures/assert-expect-failure-step.js:22:7
+        at internal
+  ...
+not ok 4 wrong [way off]
+  ---
+  message: Expected 5 assertions, but 1 were run
+  severity: failed
+  actual  : null
+  expected: undefined
+  stack: |
+        at /qunit/test/cli/fixtures/assert-expect-failure-step.js:30:7
+        at internal
+  ...
+not ok 5 previously passing [once]
+  ---
+  message: |+
+    Expected 4 assertions, but 2 were run.
+    It looks like you are upgrading from QUnit 2. Steps no longer count as separate assertions. https://qunitjs.com/api/assert/expect/
+  severity: failed
+  actual  : null
+  expected: undefined
+  stack: |
+        at /qunit/test/cli/fixtures/assert-expect-failure-step.js:40:7
+        at internal
+  ...
+not ok 6 previously passing [twice]
+  ---
+  message: |+
+    Expected 9 assertions, but 4 were run.
+    It looks like you are upgrading from QUnit 2. Steps no longer count as separate assertions. https://qunitjs.com/api/assert/expect/
+  severity: failed
+  actual  : null
+  expected: undefined
+  stack: |
+        at /qunit/test/cli/fixtures/assert-expect-failure-step.js:49:7
+        at internal
+  ...
+1..6
+# pass 2
+# skip 0
+# todo 0
+# fail 4
+
+# exit code: 1

--- a/test/main/assert-step.js
+++ b/test/main/assert-step.js
@@ -1,54 +1,52 @@
 QUnit.module('assert.step', function () {
-  QUnit.test('pushes a failing assertion if no message is given', function (assert) {
-    var original = assert.pushResult;
-    var pushed = null;
-    assert.pushResult = function (resultInfo) {
-      pushed = resultInfo;
-    };
+  QUnit.test('invalid value', function (assert) {
+    assert.throws(
+      function () {
+        assert.step();
+      },
+      new TypeError('You must provide a value to assert.step'),
+      'no value'
+    );
 
-    assert.step();
+    assert.throws(
+      function () {
+        assert.step('');
+      },
+      new TypeError('You must provide a value to assert.step'),
+      'empty value'
+    );
 
-    assert.pushResult = original;
-    assert.false(pushed.result);
-    assert.equal(pushed.message, 'You must provide a message to assert.step');
+    assert.throws(
+      function () {
+        assert.step(1);
+      },
+      new TypeError('You must provide a string value to assert.step'),
+      'number value'
+    );
 
-    assert.verifySteps([undefined]);
-  });
+    assert.throws(
+      function () {
+        assert.step(1);
+      },
+      new TypeError('You must provide a string value to assert.step'),
+      'number value'
+    );
 
-  QUnit.test('pushes a failing assertion if empty message is given', function (assert) {
-    var original = assert.pushResult;
-    var pushed = null;
-    assert.pushResult = function (resultInfo) {
-      pushed = resultInfo;
-    };
+    assert.throws(
+      function () {
+        assert.step(null);
+      },
+      new TypeError('You must provide a string value to assert.step'),
+      'null value'
+    );
 
-    assert.step('');
-
-    assert.pushResult = original;
-    assert.false(pushed.result);
-    assert.equal(pushed.message, 'You must provide a message to assert.step');
-
-    assert.verifySteps(['']);
-  });
-
-  QUnit.test('pushes a failing assertion if a non string message is given', function (assert) {
-    var original = assert.pushResult;
-    var pushed = [];
-    assert.pushResult = function (resultInfo) {
-      pushed.push(resultInfo);
-    };
-
-    assert.step(1);
-    assert.step(null);
-    assert.step(false);
-
-    assert.pushResult = original;
-    assert.deepEqual(pushed, [
-      { result: false, message: 'You must provide a string value to assert.step' },
-      { result: false, message: 'You must provide a string value to assert.step' },
-      { result: false, message: 'You must provide a string value to assert.step' }
-    ]);
-    assert.verifySteps([1, null, false]);
+    assert.throws(
+      function () {
+        assert.step(false);
+      },
+      new TypeError('You must provide a string value to assert.step'),
+      'false value'
+    );
   });
 
   QUnit.test('pushes a passing assertion if a message is given', function (assert) {
@@ -58,8 +56,9 @@ QUnit.module('assert.step', function () {
     assert.verifySteps(['One step', 'Two step']);
   });
 
-  QUnit.test('step() and verifySteps() count as assertions', function (assert) {
-    assert.expect(3);
+  // https://github.com/qunitjs/qunit/issues/1226
+  QUnit.test('step() does not count as assertions', function (assert) {
+    assert.expect(1);
 
     assert.step('One');
     assert.step('Two');
@@ -94,20 +93,6 @@ QUnit.module('assert.step', function () {
     assert.false(pushed.result);
   });
 
-  QUnit.test('verifies the order and value of failed steps', function (assert) {
-    assert.step('One step');
-
-    var original = assert.pushResult;
-    assert.pushResult = function noop () {};
-    assert.step();
-    assert.step('');
-    assert.pushResult = original;
-
-    assert.step('Two step');
-
-    assert.verifySteps(['One step', undefined, '', 'Two step']);
-  });
-
   QUnit.test('resets the step list after verification', function (assert) {
     assert.step('one');
     assert.verifySteps(['one']);
@@ -117,7 +102,7 @@ QUnit.module('assert.step', function () {
   });
 
   QUnit.test('errors if not called when `assert.step` is used', function (assert) {
-    assert.expect(2);
+    assert.expect(1);
     assert.step('one');
 
     var original = assert.test.pushFailure;

--- a/test/main/modules-es2018.js
+++ b/test/main/modules-es2018.js
@@ -13,7 +13,7 @@ QUnit.module('modules [es2018]', function () {
     });
 
     QUnit.test('all hooks', assert => {
-      assert.expect(4);
+      assert.expect(1);
     });
   });
 
@@ -31,6 +31,6 @@ QUnit.module('modules [es2018]', function () {
   });
 
   QUnit.test('async hooks order', assert => {
-    assert.expect(4);
+    assert.expect(1);
   });
 });


### PR DESCRIPTION
This example is now treated as having one assertion rather than three.

```js
QUnit.test('example', function (assert) {
  // assert.expect(1);
  // Previously:
  // assert.expect(3);

  assert.step('x');
  assert.step('y');

  assert.verifySteps(['x', 'y']);
});
```

This better matches the mental model of building up a buffer of values and then comparing them, just like the following would be:

```js
QUnit.test('example', function (assert) {
  // assert.expect(1);

  var data = [];
  data.push('x');
  data.push('y');

  assert.deepEqual(data, ['x', 'y']);
});
```

In addition to being less surprising to new developers and more intuitive to experienced ones, it also removes the need for busywork in the form of keeping the assertion count up-to-date when merely changing the number of values in the list, before performing the assertion. Updating the verification array should suffice.

I've also taken this moment to turn obvious program errors into exceptions rather than assertion failures, in line with how other QUnit assertion methods validate their arguments.

Fixes https://github.com/qunitjs/qunit/issues/1226.

/cc @getify