### PR TITLE
CLI: Upgrade `commander` from 7.2 to 12.1.0

### DIFF
--- a/bin/qunit.js
+++ b/bin/qunit.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const program = require('commander');
+const { program } = require('commander');
 const run = require('../src/cli/run');
 const { displayAvailableReporters } = require('../src/cli/find-reporter');
 const pkg = require('../package.json');

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "commander": "7.2.0",
+        "commander": "12.1.0",
         "node-watch": "0.7.4",
         "tiny-glob": "0.2.9"
       },
@@ -3644,11 +3644,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
-        "node": ">= 10"
+        "node": ">=18"
       }
     },
     "node_modules/commondir": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "commander": "7.2.0",
+    "commander": "12.1.0",
     "node-watch": "0.7.4",
     "tiny-glob": "0.2.9"
   },


### PR DESCRIPTION

1. ✅ Verify package publication metadata.
2. ✅ Review package diffs.
3. ✅ Repeat the above two steps for any changed or added indirect dependencies: None.
4. ✅ What is this package used for: CLI options parsing.
5. ✅ Test relevant use of package (how, if manually, or covered by CI): Covered by CI.

## Verify publication to npm

Previously at https://github.com/qunitjs/qunit/issues/1564:

> ```
> $ npm info commander@7.1.0
>
> commander@7.1.0 | MIT | deps: none
>
> maintainers:
> - zhiyelee <zhiyelee@gmail.com>
> - somekittens <rkoutnik@gmail.com>
> - tjholowaychuk <tj@vision-media.ca>
> - vanesyan <romain.vanesyan@gmail.com>
> - shadowspawn <npm_j@ruru.gen.nz>
> - abetomo <abe@enzou.tokyo>
>
> published 3 weeks ago by abetomo <abe@enzou.tokyo>
> ```

Now:

```
$ npm info commander@12.1.0

commander@12.1.0 | MIT | deps: none

maintainers:
- somekittens <rkoutnik@gmail.com>
- tjholowaychuk <tj@vision-media.ca>
- shadowspawn <npm_j@ruru.gen.nz>
- abetomo <abe@enzou.tokyo>

published 2 months ago by abetomo <abe@enzou.tokyo>
```

* ✅ Published by the same account as a previous release: Yes.
* ✅ New maintainer(s): (none).
* ✅ Added dependencies: (none).
* ✅ Changed dependencies: (none).

## Review package diffs

Review package diffs, use `npm diff ---diff commander@7.2.0 --diff commander@12.1.0 --color=always` or https://diff.intrinsic.com.

* Raise Node.js requirement from 10 to 18.
* Deprecation and removal of methods we don't use.
* Changes to types we don't use.
* Moved most internal code from `index.js` to `lib/command.js`.
* Change export of `program` via require() CommonJS from default to named export.

✅ LGTM.

See also changelog at https://github.com/tj/commander.js/blob/v12.1.0/CHANGELOG.md
