### PR TITLE
Demos: Add Rollup and Webpack examples

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "coverage/**",
     "demos/*/qunit/**",
     "demos/*/coverage/**",
+    "demos/*/tmp/**",
     "demos/*/package-lock.json",
     "docs/.jekyll-cache/**",
     "docs/_site/**",
@@ -191,14 +192,14 @@
       }
     },
     {
-      "files": ["demos/**/*.js"],
+      "files": ["demos/**/*.js", "demos/**/*.mjs"],
       "env": {
         "browser": true,
         "es2017": true,
         "node": true
       },
       "parserOptions": {
-        "ecmaVersion": 2018
+        "ecmaVersion": 2022
       },
       "rules": {
         "compat/compat": "off"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /coverage/
 /demos/*/package-lock.json
 /demos/*/node_modules/
+/demos/*/tmp/
 /docs/.jekyll-cache/
 /docs/_site/
 /docs/Gemfile.lock

--- a/demos/bundlers.js
+++ b/demos/bundlers.js
@@ -1,0 +1,145 @@
+const cp = require('child_process');
+const path = require('path');
+const DIR = path.join(__dirname, 'bundlers');
+
+function normalize (str) {
+  return str
+    .replace(/^localhost:\d+/g, 'localhost:8000')
+    .replace(/\b\d+ms\b/g, '42ms');
+}
+
+QUnit.module('bundlers', {
+  before: async (assert) => {
+    assert.timeout(60_000);
+
+    cp.execSync('npm install --no-audit --update-notifier=false', { cwd: DIR, encoding: 'utf8' });
+
+    await import('./bundlers/build.mjs');
+  }
+});
+
+QUnit.test.each('test in Node.js [direct]', [
+  './tmp/import-default.cjs.js',
+  './tmp/import-named.cjs.js',
+  './tmp/require-default.cjs.js'
+], function (assert, fileName) {
+  const actual = cp.execFileSync(process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `import ${JSON.stringify(fileName)}; QUnit.start();`
+    ],
+    { cwd: DIR, env: { qunit_config_reporters_tap: 'true' }, encoding: 'utf8' }
+  );
+  const expected = `
+1..1
+# pass 1
+# skip 0
+# todo 0
+# fail 0`.trim();
+
+  assert.pushResult({ result: actual.includes(expected), actual, expected }, 'stdout');
+});
+
+QUnit.test.each('test in Node.js [indirect]', [
+  './tmp/import-indirect.cjs.js',
+  './tmp/require-indirect.cjs.js'
+], function (assert, fileName) {
+  const actual = cp.execFileSync(process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `import ${JSON.stringify(fileName)}; QUnit.start();`
+    ],
+    { cwd: DIR, env: { qunit_config_reporters_tap: 'true' }, encoding: 'utf8' }
+  );
+  const expected = `
+1..4
+# pass 4
+# skip 0
+# todo 0
+# fail 0`.trim();
+
+  assert.pushResult({ result: actual.includes(expected), actual, expected }, 'stdout');
+});
+
+QUnit.test('test in browser', function (assert) {
+  const expected = `Running "connect:all" (connect) task
+Started connect web server on http://localhost:8000
+
+Running "qunit:all" (qunit) task
+Testing http://localhost:8000/tmp/test-import-default.es.html .OK
+>> passed test "import-default"
+Testing http://localhost:8000/tmp/test-import-default.iife.html .OK
+>> passed test "import-default"
+Testing http://localhost:8000/tmp/test-import-default.umd.html .OK
+>> passed test "import-default"
+Testing http://localhost:8000/tmp/test-import-default.webpack.html .OK
+>> passed test "import-default"
+Testing http://localhost:8000/tmp/test-import-indirect.es.html ....OK
+>> passed test "import-default"
+>> passed test "import-named"
+>> passed test "require-default"
+>> passed test "import-indirect"
+Testing http://localhost:8000/tmp/test-import-indirect.iife.html ....OK
+>> passed test "import-default"
+>> passed test "import-named"
+>> passed test "require-default"
+>> passed test "import-indirect"
+Testing http://localhost:8000/tmp/test-import-indirect.umd.html ....OK
+>> passed test "import-default"
+>> passed test "import-named"
+>> passed test "require-default"
+>> passed test "import-indirect"
+Testing http://localhost:8000/tmp/test-import-indirect.webpack.html ....OK
+>> passed test "import-default"
+>> passed test "import-named"
+>> passed test "require-default"
+>> passed test "import-indirect"
+Testing http://localhost:8000/tmp/test-import-named.es.html .OK
+>> passed test "import-named"
+Testing http://localhost:8000/tmp/test-import-named.iife.html .OK
+>> passed test "import-named"
+Testing http://localhost:8000/tmp/test-import-named.umd.html .OK
+>> passed test "import-named"
+Testing http://localhost:8000/tmp/test-import-named.webpack.html .OK
+>> passed test "import-named"
+Testing http://localhost:8000/tmp/test-require-default.es.html .OK
+>> passed test "require-default"
+Testing http://localhost:8000/tmp/test-require-default.iife.html .OK
+>> passed test "require-default"
+Testing http://localhost:8000/tmp/test-require-default.umd.html .OK
+>> passed test "require-default"
+Testing http://localhost:8000/tmp/test-require-default.webpack.html .OK
+>> passed test "require-default"
+Testing http://localhost:8000/tmp/test-require-indirect.es.html ....OK
+>> passed test "import-default"
+>> passed test "import-named"
+>> passed test "require-default"
+>> passed test "require-indirect"
+Testing http://localhost:8000/tmp/test-require-indirect.iife.html ....OK
+>> passed test "import-default"
+>> passed test "import-named"
+>> passed test "require-default"
+>> passed test "require-indirect"
+Testing http://localhost:8000/tmp/test-require-indirect.umd.html ....OK
+>> passed test "import-default"
+>> passed test "import-named"
+>> passed test "require-default"
+>> passed test "require-indirect"
+Testing http://localhost:8000/tmp/test-require-indirect.webpack.html ....OK
+>> passed test "import-default"
+>> passed test "import-named"
+>> passed test "require-default"
+>> passed test "require-indirect"
+>> 44 tests completed in 42ms, with 0 failed, 0 skipped, and 0 todo.
+
+Done.`;
+
+  const actual = cp.execSync('node_modules/.bin/grunt test', {
+    cwd: DIR,
+    env: { PATH: process.env.PATH },
+    encoding: 'utf8'
+  });
+  assert.equal(normalize(actual).trim(), expected);
+});

--- a/demos/bundlers/Gruntfile.js
+++ b/demos/bundlers/Gruntfile.js
@@ -1,0 +1,39 @@
+/* eslint-env node */
+module.exports = function (grunt) {
+  grunt.loadNpmTasks('grunt-contrib-connect');
+  grunt.loadNpmTasks('grunt-contrib-qunit');
+
+  grunt.initConfig({
+    connect: {
+      all: {
+        options: {
+          useAvailablePort: true,
+          base: '.'
+        }
+      }
+    },
+    qunit: {
+      options: {
+      },
+      all: ['tmp/test-*.html']
+    }
+  });
+
+  grunt.event.once('connect.all.listening', function (_host, port) {
+    grunt.config('qunit.options.httpBase', `http://localhost:${port}`);
+    // console.log(grunt.config()); // DEBUG
+  });
+
+  let results = [];
+  grunt.event.on('qunit.on.testEnd', function (test) {
+    results.push(
+      `>> ${test.status} test "${test.fullName.join(' > ')}"`
+    );
+  });
+  grunt.event.on('qunit.on.runEnd', function () {
+    grunt.log.writeln(results.join('\n'));
+    results = [];
+  });
+
+  grunt.registerTask('test', ['connect', 'qunit']);
+};

--- a/demos/bundlers/README.md
+++ b/demos/bundlers/README.md
@@ -1,0 +1,17 @@
+# QUnit ♥️ Rollup & Webpack
+
+See also <https://rollupjs.org/> and <https://webpack.js.org/>.
+
+```bash
+npm run build
+npm test
+```
+
+```
+Running "qunit:all" (qunit) task
+Testing http://localhost:8000/test.html .OK
+>> passed test "example"
+>> 1 test completed in 0ms, with 0 failed, 0 skipped, and 0 todo.
+
+Done.
+```

--- a/demos/bundlers/build.mjs
+++ b/demos/bundlers/build.mjs
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+import { rollup } from 'rollup';
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import webpack from 'webpack';
+
+const dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const tmpDir = path.join(dirname, 'tmp');
+
+const inputs = [
+  `${dirname}/test/import-default.js`,
+  `${dirname}/test/import-named.js`,
+  `${dirname}/test/import-indirect.js`,
+  `${dirname}/test/require-default.cjs`,
+  `${dirname}/test/require-indirect.cjs`
+];
+
+const htmlTemplate = `<!DOCTYPE html>
+<html>
+<head>
+<title>{{title}}</title>
+<link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
+{{scriptTag}}
+</head>
+<body>
+<div id="qunit"></div>
+</body>
+</html>
+`;
+
+// Rollup configuration
+const rollupOutputs = [
+  {
+    dir: tmpDir,
+    entryFileNames: '[name].[format].js',
+    format: 'es'
+  },
+  {
+    dir: tmpDir,
+    entryFileNames: '[name].[format].js',
+    format: 'cjs'
+  },
+  {
+    dir: tmpDir,
+    entryFileNames: '[name].[format].js',
+    format: 'iife'
+  },
+  {
+    dir: tmpDir,
+    entryFileNames: '[name].[format].js',
+    format: 'umd',
+    name: 'UNUSED'
+  }
+];
+async function * buildRollup () {
+  const plugins = [commonjs(), resolve()];
+
+  for (const input of inputs) {
+    const bundle = await rollup({
+      input,
+      plugins,
+      // Ignore "output.name" warning for require-default.iife.js
+      onwarn: () => {}
+    });
+
+    for (const outputOptions of rollupOutputs) {
+      const { output } = await bundle.write(outputOptions);
+      const fileName = output[0].fileName;
+      yield fileName;
+    }
+  }
+}
+
+// https://webpack.js.org/api/node/#webpack
+async function * buildWebpack () {
+  for (const input of inputs) {
+    const config = {
+      entry: input,
+      output: {
+        filename: path.basename(input).replace(/\.(cjs|js)$/, '.webpack.js'),
+        path: tmpDir
+      }
+    };
+    await new Promise((resolve, reject) => {
+      webpack(config, (err, stats) => {
+        if (err || stats.hasErrors()) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
+    yield config.output.filename;
+  }
+}
+
+await (async function main () {
+  // Clean up
+  fs.rmSync(tmpDir, { force: true, recursive: true });
+
+  const gRollup = buildRollup();
+  const gWebpack = buildWebpack();
+
+  for await (const fileName of gRollup) {
+    console.log('... built ' + fileName);
+
+    if (!fileName.endsWith('.cjs.js')) {
+      const html = htmlTemplate
+        .replace('{{title}}', fileName)
+        .replace('{{scriptTag}}', (
+          fileName.endsWith('.es.js')
+            ? `<script src="./${fileName}" type="module"></script>`
+            : `<script src="./${fileName}"></script>`
+        ));
+
+      fs.writeFileSync(
+        `${tmpDir}/test-${fileName.replace('.js', '')}.html`,
+        html
+      );
+    }
+  }
+  for await (const fileName of gWebpack) {
+    console.log('... built ' + fileName);
+
+    const html = htmlTemplate
+      .replace('{{title}}', fileName)
+      .replace('{{scriptTag}}', (
+          `<script src="./${fileName}"></script>`
+      ));
+
+    fs.writeFileSync(
+      `${tmpDir}/test-${fileName.replace('.js', '')}.html`,
+      html
+    );
+  }
+}());

--- a/demos/bundlers/package.json
+++ b/demos/bundlers/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^26.0.1",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "grunt": "1.6.1",
+    "grunt-contrib-connect": "^5.0.0",
+    "grunt-contrib-qunit": "10.1.1",
+    "qunit": "file:../..",
+    "rollup": "^4.18.0",
+    "webpack": "^5.92.0"
+  },
+  "scripts": {
+    "build": "node build.mjs",
+    "test": "grunt test"
+  }
+}

--- a/demos/bundlers/test/.eslintrc.json
+++ b/demos/bundlers/test/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "es2020": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  }
+}

--- a/demos/bundlers/test/import-default.js
+++ b/demos/bundlers/test/import-default.js
@@ -1,0 +1,10 @@
+import QUnit from 'qunit';
+import { add } from './src.js';
+
+(globalThis.TEST_OBJECTS || (globalThis.TEST_OBJECTS = {})).import_default = QUnit;
+
+QUnit.hello_import_default = QUnit.assert.hello_import_default = 'import-default';
+
+QUnit.test('import-default', function (assert) {
+  assert.equal(add(2, 3), 5);
+});

--- a/demos/bundlers/test/import-indirect.js
+++ b/demos/bundlers/test/import-indirect.js
@@ -1,0 +1,20 @@
+/* global TEST_OBJECTS */
+import './import-default.js';
+import './import-named.js';
+import './require-default.cjs';
+
+import QUnit from 'qunit';
+
+QUnit.test('import-indirect', function (assert) {
+  assert.strictEqual(TEST_OBJECTS.import_default, QUnit, 'identity');
+  assert.strictEqual(QUnit.hello_import_default, 'import-default', 'extend QUnit');
+  assert.strictEqual(assert.hello_import_default, 'import-default', 'extend assert');
+
+  assert.strictEqual(TEST_OBJECTS.import_named, QUnit, 'identity');
+  assert.strictEqual(QUnit.hello_import_named, 'import-named', 'extend QUnit');
+  assert.strictEqual(assert.hello_import_named, 'import-named', 'extend assert');
+
+  assert.strictEqual(TEST_OBJECTS.require_default, QUnit, 'identity');
+  assert.strictEqual(QUnit.hello_require_default, 'require-default', 'extend QUnit');
+  assert.strictEqual(assert.hello_require_default, 'require-default', 'extend assert');
+});

--- a/demos/bundlers/test/import-named.js
+++ b/demos/bundlers/test/import-named.js
@@ -1,0 +1,10 @@
+import { QUnit, assert, test } from 'qunit';
+import { add } from './src.js';
+
+(globalThis.TEST_OBJECTS || (globalThis.TEST_OBJECTS = {})).import_named = QUnit;
+
+QUnit.hello_import_named = assert.hello_import_named = 'import-named';
+
+test('import-named', function (assert) {
+  assert.equal(add(2, 3), 5);
+});

--- a/demos/bundlers/test/package.json
+++ b/demos/bundlers/test/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/demos/bundlers/test/require-default.cjs
+++ b/demos/bundlers/test/require-default.cjs
@@ -1,0 +1,10 @@
+const QUnit = require('qunit');
+const { add } = require('./src.js');
+
+(globalThis.TEST_OBJECTS || (globalThis.TEST_OBJECTS = {})).require_default = QUnit;
+
+QUnit.hello_require_default = QUnit.assert.hello_require_default = 'require-default';
+
+QUnit.test('require-default', function (assert) {
+  assert.equal(add(2, 3), 5);
+});

--- a/demos/bundlers/test/require-indirect.cjs
+++ b/demos/bundlers/test/require-indirect.cjs
@@ -1,0 +1,20 @@
+/* global TEST_OBJECTS */
+const QUnit = require('qunit');
+
+require('./import-default.js');
+require('./import-named.js');
+require('./require-default.cjs');
+
+QUnit.test('require-indirect', function (assert) {
+  assert.strictEqual(TEST_OBJECTS.import_default, QUnit, 'identity');
+  assert.strictEqual(QUnit.hello_import_default, 'import-default', 'extend QUnit');
+  assert.strictEqual(assert.hello_import_default, 'import-default', 'extend assert');
+
+  assert.strictEqual(TEST_OBJECTS.import_named, QUnit, 'identity');
+  assert.strictEqual(QUnit.hello_import_named, 'import-named', 'extend QUnit');
+  assert.strictEqual(assert.hello_import_named, 'import-named', 'extend assert');
+
+  assert.strictEqual(TEST_OBJECTS.require_default, QUnit, 'identity');
+  assert.strictEqual(QUnit.hello_require_default, 'require-default', 'extend QUnit');
+  assert.strictEqual(assert.hello_require_default, 'require-default', 'extend assert');
+});

--- a/demos/bundlers/test/src.js
+++ b/demos/bundlers/test/src.js
@@ -1,0 +1,3 @@
+export function add (a, b) {
+  return a + b;
+}

--- a/demos/grunt-contrib-qunit.js
+++ b/demos/grunt-contrib-qunit.js
@@ -2,10 +2,14 @@ const cp = require('child_process');
 const path = require('path');
 const DIR = path.join(__dirname, 'grunt-contrib-qunit');
 
+// Fast re-runs
+process.env.npm_config_prefer_offline = 'true';
+process.env.npm_config_update_notifier = 'false';
+process.env.npm_config_audit = 'false';
+
 QUnit.module('grunt-contrib-qunit', {
   before: () => {
-    // Let this be quick for re-runs
-    cp.execSync('npm install --prefer-offline --no-audit --update-notifier=false', { cwd: DIR, encoding: 'utf8' });
+    cp.execSync('npm install', { cwd: DIR, encoding: 'utf8' });
   }
 });
 
@@ -29,15 +33,10 @@ QUnit.test.each('failing tests', {
 >>     at file:fail-uncaught.html:16`]
 }, (assert, [command, expected]) => {
   try {
+    // This will use env CI, CHROMIUM_FLAGS, and PUPPETEER_DOWNLOAD_PATH
     const ret = cp.execSync('node_modules/.bin/grunt qunit:' + command, {
       cwd: DIR,
-      encoding: 'utf8',
-      env: {
-        CHROMIUM_FLAGS: process.env.CHROMIUM_FLAGS,
-        CI: process.env.CI,
-        PATH: process.env.PATH,
-        PUPPETEER_DOWNLOAD_PATH: process.env.PUPPETEER_DOWNLOAD_PATH
-      }
+      encoding: 'utf8'
     });
     assert.equal(ret, null);
   } catch (e) {

--- a/demos/karma-qunit.js
+++ b/demos/karma-qunit.js
@@ -11,9 +11,14 @@ function normalize (str) {
     .replace(/^\s+/gm, '  ');
 }
 
+// Fast re-runs
+process.env.npm_config_prefer_offline = 'true';
+process.env.npm_config_update_notifier = 'false';
+process.env.npm_config_audit = 'false';
+
 QUnit.module('karma-qunit', {
   before: () => {
-    cp.execSync('npm install --prefer-offline --no-audit --omit=dev --legacy-peer-deps --update-notifier=false', { cwd: DIR, encoding: 'utf8' });
+    cp.execSync('npm install --omit=dev --legacy-peer-deps', { cwd: DIR, encoding: 'utf8' });
   }
 });
 
@@ -40,11 +45,10 @@ Firefox: Executed 1 of 1 SUCCESS`, { KARMA_QUNIT_CONFIG: '1' }
   try {
     ret = cp.execSync('npm test', {
       cwd: DIR,
-      env: {
-        PATH: process.env.PATH,
+      env: Object.assign({}, process.env, {
         KARMA_FILES: file,
         ...env
-      },
+      }),
       encoding: 'utf8'
     });
   } catch (e) {
@@ -73,10 +77,9 @@ Firefox  example FAILED
   try {
     const ret = cp.execSync('npm test', {
       cwd: DIR,
-      env: {
-        PATH: process.env.PATH,
+      env: Object.assign({}, process.env, {
         KARMA_FILES: file
-      },
+      }),
       encoding: 'utf8'
     });
     assert.equal(ret, null);

--- a/demos/nyc.js
+++ b/demos/nyc.js
@@ -2,9 +2,14 @@ const cp = require('child_process');
 const path = require('path');
 const DIR = path.join(__dirname, 'nyc');
 
+// Fast re-runs
+process.env.npm_config_prefer_offline = 'true';
+process.env.npm_config_update_notifier = 'false';
+process.env.npm_config_audit = 'false';
+
 QUnit.module('nyc', {
   before: () => {
-    cp.execSync('npm install --prefer-offline --no-audit --update-notifier=false', { cwd: DIR, encoding: 'utf8' });
+    cp.execSync('npm install', { cwd: DIR, encoding: 'utf8' });
   }
 });
 
@@ -29,6 +34,12 @@ All files     |   85.71 |      100 |      50 |   85.71 |
 --------------|---------|----------|---------|---------|-------------------
 `.trim();
 
-  const actual = cp.execSync('npm test', { cwd: DIR, env: { PATH: process.env.PATH }, encoding: 'utf8' });
+  const actual = cp.execSync('npm test', {
+    cwd: DIR,
+    env: Object.assign({}, process.env, {
+      FORCE_COLOR: '0'
+    }),
+    encoding: 'utf8'
+  });
   assert.pushResult({ result: actual.includes(expected), actual, expected });
 });

--- a/demos/testem.js
+++ b/demos/testem.js
@@ -9,10 +9,14 @@ function normalize (str) {
     .replace(/(\d+ ms)/g, '0 ms');
 }
 
+// Fast re-runs
+process.env.npm_config_prefer_offline = 'true';
+process.env.npm_config_update_notifier = 'false';
+process.env.npm_config_audit = 'false';
+
 QUnit.module('testem', {
   before: () => {
-    // Let this be quick for re-runs
-    cp.execSync('npm install --prefer-offline --no-audit --update-notifier=false', { cwd: DIR, encoding: 'utf8' });
+    cp.execSync('npm install', { cwd: DIR, encoding: 'utf8' });
   }
 });
 


### PR DESCRIPTION
This is in preparation for adding an ESM distribution to QUnit. Before we do so, let's first observe how and what works today:

* import default: `import QUnit from 'qunit';`
* import named QUnit: `import { QUnit } from 'qunit';`
* import named methods: `import { module, test } from 'qunit';`
* require default: `require('qunit')`

In addition, verify that within a given bundler, a mixture of these across multple files, in indirect ways, always refers to the same object, both functionally (extensions to the object are visible to others), and by object identity (strict equality).

Specifically to satisfy Webpack, I've renamed the fixtures that use `require()` from `.js` to `.cjs` as [Webpack refuses](https://webpack.js.org/api/module-methods/) to compile `require()` calls otherwise in a directory with `{ type: 'module' }` in `package.json`. Rollup does not have this restriction.

Partially based on https://github.com/jquery/jquery/pull/5429 by @mgol.

Ref https://github.com/qunitjs/qunit/issues/1551.

