### PR TITLE
Core: Exclude or grey internal frames from stack traces in TAP reporter

### DIFF
--- a/src/core/reporters/TapReporter.js
+++ b/src/core/reporters/TapReporter.js
@@ -1,6 +1,7 @@
 import kleur from 'kleur';
 import { errorString } from '../utilities.js';
 import { console } from '../globals.js';
+import { annotateStacktrace } from '../stacktrace.js';
 
 const hasOwn = Object.prototype.hasOwnProperty;
 
@@ -276,7 +277,7 @@ export default class TapReporter {
     out += `\n  message: ${prettyYamlValue(errorString(error))}`;
     out += `\n  severity: ${prettyYamlValue('failed')}`;
     if (error && error.stack) {
-      out += `\n  stack: ${prettyYamlValue(error.stack + '\n')}`;
+      out += `\n  stack: ${prettyYamlValue(annotateStacktrace(error, kleur.grey) + '\n')}`;
     }
     out += '\n  ...';
     this.log(out);

--- a/src/core/stacktrace.js
+++ b/src/core/stacktrace.js
@@ -59,6 +59,40 @@ function qunitFileName () {
 
 const fileName = qunitFileName();
 
+/**
+ * - For internal errors from QUnit itself, remove the first qunit.js frames.
+ * - For errors in Node.js, format any remaining qunit.js and node:internal
+ *   frames as internal (i.e. grey out).
+ */
+export function annotateStacktrace (e, formatInternal) {
+  if (!e || !e.stack) {
+    return String(e);
+  }
+  const frames = e.stack.split('\n');
+  const annotated = [];
+  if (e.toString().indexOf(frames[0]) !== -1) {
+    // In Firefox and Safari e.stack starts with frame 0, but in V8 (Chrome/Node.js),
+    // e.stack starts first stringified message. Preserve this separately,
+    // so that, below, we can distinguish between internal frames on top
+    // (to remove) vs later internal frames (to format differently).
+    annotated.push(frames.shift());
+  }
+  let initialInternal = true;
+  for (let i = 0; i < frames.length; i++) {
+    const frame = frames[i];
+    const isInternal = (frame.indexOf(fileName) !== -1 || frame.indexOf('node:internal/') !== -1);
+    if (!isInternal) {
+      initialInternal = false;
+    }
+    // Remove initial internal frames entirely.
+    if (!initialInternal) {
+      annotated.push(isInternal ? formatInternal(frame) : frame);
+    }
+  }
+
+  return annotated.join('\n');
+}
+
 export function extractStacktrace (e, offset) {
   offset = offset === undefined ? 4 : offset;
 

--- a/test/cli/fixtures/async-module-error-promise.tap.txt
+++ b/test/cli/fixtures/async-module-error-promise.tap.txt
@@ -9,7 +9,6 @@ not ok 1 global failure
   severity: failed
   stack: |
     TypeError: QUnit.module() callback must not be async. For async module setup, use hooks. https://qunitjs.com/api/QUnit/module/#hooks
-        at qunit.js
         at /qunit/test/cli/fixtures/async-module-error-promise.js:1:7
         at internal
   ...

--- a/test/cli/fixtures/async-module-error-thenable.tap.txt
+++ b/test/cli/fixtures/async-module-error-thenable.tap.txt
@@ -9,7 +9,6 @@ not ok 1 global failure
   severity: failed
   stack: |
     TypeError: QUnit.module() callback must not be async. For async module setup, use hooks. https://qunitjs.com/api/QUnit/module/#hooks
-        at qunit.js
         at /qunit/test/cli/fixtures/async-module-error-thenable.js:1:7
         at internal
   ...

--- a/test/cli/fixtures/async-module-error.tap.txt
+++ b/test/cli/fixtures/async-module-error.tap.txt
@@ -9,7 +9,6 @@ not ok 1 global failure
   severity: failed
   stack: |
     TypeError: QUnit.module() callback must not be async. For async module setup, use hooks. https://qunitjs.com/api/QUnit/module/#hooks
-        at qunit.js
         at /qunit/test/cli/fixtures/async-module-error.js:2:7
         at internal
   ...


### PR DESCRIPTION
Internal frames are those from qunit.js, or Node.js runtime.

* Remove any internal frames from the top of the stack.
* Grey out later internal frames anywhere in the stack.

This change is applied to the TAP reporter, which the QUnit CLI uses by default. The benefit of trimming initial qunit.js internal frames also benefits use of the TAP reporter in browser environments.

This change inspired by an upcoming change, which converts our fake "No tests" test failure into a normal error. When we emitted it as a fake test, it benefitted from QUnit.stack() trimming qunit.js frames, thus guruanteeing the stack to start at the QUnit.test() call, skipping the first few frames, and anything after the user code is also by definition not of interest.

For generic errors, we weren't doing this yet. And, while we don't have a clean anchor point like QUnit.test() for uncaught errors, we can do better than dumping it all to the console. We can still safely trim the first frames that are internal. Removing later ones is likely to cause confusion (by wrongly suggesting that `A>C` when it is actually `A>B>C`). We can color those in grey, similar to what Node.js's own error formatter does by default.