### PR TITLE
HTML Reporter: Add support for early rendering

### DIFF
--- a/demos/qunit-onerror-early.html
+++ b/demos/qunit-onerror-early.html
@@ -6,9 +6,12 @@
   <link rel="stylesheet" href="../src/core/qunit.css">
   <script src="../qunit/qunit.js"></script>
   <script>
+    QUnit.config.urlConfig.push('beginBoom');
     QUnit.begin(function () {
-      // eslint-disable-next-line no-undef
-      beginBoom();
+      if (QUnit.config.beginBoom) {
+        // eslint-disable-next-line no-undef
+        beginBoom();
+      }
     });
 
     // eslint-disable-next-line no-undef

--- a/src/core/browser/browser-runner.js
+++ b/src/core/browser/browser-runner.js
@@ -76,6 +76,28 @@ export function initBrowser (QUnit, window, document) {
   initFixture(QUnit, document);
   initUrlConfig(QUnit);
 
+  // Unless explicitly disabled via preconfig, initialize HtmlReporter now
+  // (i.e. QUnit.config.reporters.html is undefined or true).
+  //
+  // This allows the UI to render instantly (since QUnit 3.0) for cases where the
+  // qunit.js script is after `<div id="qunit">`, which is recommended.
+  //
+  // Otherwise, we'll fallback to waiting with a blank page until window.onload,
+  // which is how it's always been in QUnit 1 and QUnit 2.
+  //
+  // Note that HtmlReporter constructor will only render an initial layout and
+  // listen to 1 event. The final decision on whether to attach event handlers
+  // and render the interactive UI is made from HtmlReporter#onRunStart, which
+  // is also where it will honor QUnit.config.reporters.html if it was set to
+  // false between qunit.js (here) and onRunStart.
+  //
+  // If someone explicitly sets QUnit.config.reporters.html to false via preconfig,
+  // but then changes it at runtime to true, that is unsupported and the reporter
+  // will remain disabled.
+  if (QUnit.config.reporters.html !== false) {
+    QUnit.reporters.html.init(QUnit);
+  }
+
   // NOTE:
   // * It is important to attach error handlers (above) before setting up reporters,
   //   to ensure reliable reporting of error events.

--- a/src/core/start.js
+++ b/src/core/start.js
@@ -22,11 +22,11 @@ export function createStartFunction (QUnit) {
 
     // QUnit.config.reporters is considered writable between qunit.js and QUnit.start().
     // Now, it is time to decide which reporters we'll load.
+    //
+    // For config.reporters.html, refer to browser-runner.js and HtmlReporter#onRunStart.
+    //
     if (config.reporters.console) {
       reporters.console.init(QUnit);
-    }
-    if (config.reporters.html || (config.reporters.html === undefined && window && document)) {
-      reporters.html.init(QUnit);
     }
     if (config.reporters.perf || (config.reporters.perf === undefined && window && document)) {
       reporters.perf.init(QUnit);

--- a/test/config-reporters.html
+++ b/test/config-reporters.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <title>config-reporters</title>
   <link rel="stylesheet" href="../src/core/qunit.css">
+</head>
+<body>
+  <div id="qunit"></div>
   <script src="../qunit/qunit.js"></script>
   <script>
   QUnit.config.reporters.html = false;
@@ -37,8 +40,5 @@
     assert.strictEqual(window.firstConsoleMessage, 'TAP version 13', 'first console message');
   });
   </script>
-</head>
-<body>
-  <div id="qunit"></div>
 </body>
 </html>


### PR DESCRIPTION
For a long time, we've been quietly recommending in documentation examples to have an HTML structure in which `qunit.js` is loaded at the end of the `<body>`. As of this PR, that now renders the UI immediately instead of waiting for all source code and test suites to load first, which can take a while in large projects. Additionally, if a project has only synchronous tests, the page will remain blank for another whole second (or until all tests have completed running).

Minor changes:

* /demos/qunit-onerror-early.html

  Add an "boomBegin" option, to allow separate testing of "normal" early early errors, and errors from QUnit.begin().

* /test/config-reporters.html

  Move `<div id=qunit>` up so that we cover code for disabling QUnit.config.reporters after qunit.js. This code previously existed in QUnit.start(), but now that we've moved to happen earlier, this was now testing a less interesting scenario.

As an example, the `/demos/q4000-qunit.html` is an intentionally large test suite that takes a while to load, and are all synchronous tests. Before this change, the page remains blank for about half a second after the first, final, and singular frame is painted; rendering the entire UI, green completed status bar, and all test results.

After this change, the following renders almost instantly at http://localhost:4000/demos/q4000-qunit.html:
<img width="772" alt="Screenshot 2024-08-07 at 01 57 38 1" src="https://github.com/user-attachments/assets/f09f11b7-e584-4db1-a5ab-b0dcd2712c94">

