### PR TITLE
CLI: Remove confusing `expected: undefined` from TAP for non-assert fail

### DIFF
--- a/docs/api/assert/pushResult.md
+++ b/docs/api/assert/pushResult.md
@@ -18,8 +18,8 @@ Report the result of a custom assertion.
 | name | description |
 |------|-------------|
 | `data.result` (boolean) | Result of the assertion |
-| `data.actual` | Expression being tested |
-| `data.expected` | Known comparison value |
+| `data.actual` | Expression being tested (optional) |
+| `data.expected` | Known comparison value (optional) |
 | `data.message` (string or undefined) | Short description of the assertion |
 
 ## Examples

--- a/docs/resources/example-fail.html
+++ b/docs/resources/example-fail.html
@@ -14,7 +14,7 @@
   });
   QUnit.test('banana', function (assert) {
     assert.true(true, 'foo');
-    var sentence = 'This is actual.';
+    const sentence = 'This is actual.';
     assert.equal(sentence, 'This is expected.', 'example sentence');
     assert.true(true, 'bar');
     assert.true(true, 'baz');

--- a/src/core/on-uncaught-exception.js
+++ b/src/core/on-uncaught-exception.js
@@ -25,6 +25,7 @@ import { emit } from './events.js';
  */
 export default function onUncaughtException (error) {
   if (config.current) {
+    // This omits 'actual' and 'expected' (undefined)
     config.current.assert.pushResult({
       result: false,
       message: `global failure: ${errorString(error)}`,

--- a/src/core/reporters/HtmlReporter.js
+++ b/src/core/reporters/HtmlReporter.js
@@ -842,11 +842,12 @@ export default class HtmlReporter {
     let actual;
 
     // When pushFailure() is called, it is implied that no expected value
-    // or diff should be shown. It does not set details.expected.
+    // or diff should be shown, because both expected and actual as undefined.
     //
     // This must check details.expected existence. If it exists as undefined,
     // that's a regular assertion for which to render actual/expected and a diff.
-    if (!details.result && hasOwn.call(details, 'expected')) {
+    const showAnyValues = !details.result && (details.expected !== undefined || details.actual !== undefined);
+    if (showAnyValues) {
       if (details.negative) {
         expected = 'NOT ' + dump.parse(details.expected);
       } else {

--- a/src/core/reporters/TapReporter.js
+++ b/src/core/reporters/TapReporter.js
@@ -3,8 +3,6 @@ import { errorString } from '../utilities.js';
 import { console } from '../globals.js';
 import { annotateStacktrace } from '../stacktrace.js';
 
-const hasOwn = Object.prototype.hasOwnProperty;
-
 /**
  * Format a given value into YAML.
  *
@@ -259,11 +257,12 @@ export default class TapReporter {
     out += `\n  message: ${prettyYamlValue(error.message || 'failed')}`;
     out += `\n  severity: ${prettyYamlValue(severity || 'failed')}`;
 
-    if (hasOwn.call(error, 'actual')) {
+    // When pushFailure() is used, actual/expected are initially unset but
+    // eventually in Test#logAssertion, for testReport#pushAssertion, these are
+    // forged into existence as undefined.
+    const hasAny = (error.expected !== undefined || error.actual !== undefined);
+    if (hasAny) {
       out += `\n  actual  : ${prettyYamlValue(error.actual)}`;
-    }
-
-    if (hasOwn.call(error, 'expected')) {
       out += `\n  expected: ${prettyYamlValue(error.expected)}`;
     }
 

--- a/src/core/test.js
+++ b/src/core/test.js
@@ -572,7 +572,6 @@ Test.prototype = {
     this.pushResult({
       result: false,
       message: message || 'error',
-      actual: null,
       source
     });
   },

--- a/test/cli/cli-main.js
+++ b/test/cli/cli-main.js
@@ -39,8 +39,6 @@ not ok 2 slow
   ---
   message: Test took longer than 7ms; test timed out.
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at internal
   ...

--- a/test/cli/fixtures/assert-expect-failure-step.tap.txt
+++ b/test/cli/fixtures/assert-expect-failure-step.tap.txt
@@ -7,8 +7,6 @@ not ok 3 wrong [a little off]
   ---
   message: Expected 2 assertions, but 1 were run
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at /qunit/test/cli/fixtures/assert-expect-failure-step.js:22:7
         at internal
@@ -17,8 +15,6 @@ not ok 4 wrong [way off]
   ---
   message: Expected 5 assertions, but 1 were run
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at /qunit/test/cli/fixtures/assert-expect-failure-step.js:30:7
         at internal
@@ -29,8 +25,6 @@ not ok 5 previously passing [once]
     Expected 4 assertions, but 2 were run.
     It looks like you are upgrading from QUnit 2. Steps no longer count as separate assertions. https://qunitjs.com/api/assert/expect/
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at /qunit/test/cli/fixtures/assert-expect-failure-step.js:40:7
         at internal
@@ -41,8 +35,6 @@ not ok 6 previously passing [twice]
     Expected 9 assertions, but 4 were run.
     It looks like you are upgrading from QUnit 2. Steps no longer count as separate assertions. https://qunitjs.com/api/assert/expect/
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at /qunit/test/cli/fixtures/assert-expect-failure-step.js:49:7
         at internal

--- a/test/cli/fixtures/assert-expect-failure.tap.txt
+++ b/test/cli/fixtures/assert-expect-failure.tap.txt
@@ -6,8 +6,6 @@ not ok 1 failing test
   ---
   message: Expected 2 assertions, but 1 were run
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at /qunit/test/cli/fixtures/assert-expect-failure.js:1:7
         at internal

--- a/test/cli/fixtures/assert-expect-no-assertions.tap.txt
+++ b/test/cli/fixtures/assert-expect-no-assertions.tap.txt
@@ -6,8 +6,6 @@ not ok 1 no assertions
   ---
   message: Expected at least one assertion, but none were run - call expect(0) to accept zero assertions.
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at /qunit/test/cli/fixtures/assert-expect-no-assertions.js:1:7
         at internal

--- a/test/cli/fixtures/async-test-throw.tap.txt
+++ b/test/cli/fixtures/async-test-throw.tap.txt
@@ -5,8 +5,6 @@ not ok 1 throw early
   ---
   message: "Promise rejected during \"throw early\": boo"
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: boo
         at /qunit/test/cli/fixtures/async-test-throw.js:2:9
@@ -15,8 +13,6 @@ not ok 2 throw late
   ---
   message: "Promise rejected during \"throw late\": boo"
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: boo
         at /qunit/test/cli/fixtures/async-test-throw.js:8:9
@@ -25,8 +21,6 @@ not ok 3 test with bad thenable
   ---
   message: "Promise rejected during \"test with bad thenable\": boo"
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: boo
         at /qunit/test/cli/fixtures/async-test-throw.js:16:13

--- a/test/cli/fixtures/config-noglobals-add.tap.txt
+++ b/test/cli/fixtures/config-noglobals-add.tap.txt
@@ -6,8 +6,6 @@ not ok 1 adds global var
   ---
   message: Introduced global variable(s): dummyGlobal
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at qunit.js
   ...

--- a/test/cli/fixtures/config-noglobals-remove.tap.txt
+++ b/test/cli/fixtures/config-noglobals-remove.tap.txt
@@ -6,8 +6,6 @@ not ok 1 deletes global var
   ---
   message: Deleted global variable(s): dummyGlobal
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at qunit.js
   ...

--- a/test/cli/fixtures/config-notrycatch-hook-rejection.tap.txt
+++ b/test/cli/fixtures/config-notrycatch-hook-rejection.tap.txt
@@ -6,16 +6,12 @@ not ok 1 example > passing test
   ---
   message: global failure: bad things happen
   severity: failed
-  actual  : undefined
-  expected: undefined
   stack: |
         at internal
   ...
   ---
   message: Test took longer than 1000ms; test timed out.
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at internal
   ...

--- a/test/cli/fixtures/config-notrycatch-test-rejection.tap.txt
+++ b/test/cli/fixtures/config-notrycatch-test-rejection.tap.txt
@@ -6,16 +6,12 @@ not ok 1 example > returns a rejected promise
   ---
   message: global failure: bad things happen
   severity: failed
-  actual  : undefined
-  expected: undefined
   stack: |
         at internal
   ...
   ---
   message: Test took longer than 1000ms; test timed out.
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at internal
   ...

--- a/test/cli/fixtures/config-requireExpects.tap.txt
+++ b/test/cli/fixtures/config-requireExpects.tap.txt
@@ -6,8 +6,6 @@ not ok 1 passing test
   ---
   message: Expected number of assertions to be defined, but expect() was not called.
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at /qunit/test/cli/fixtures/config-requireExpects.js:3:7
         at internal

--- a/test/cli/fixtures/config-testTimeout.tap.txt
+++ b/test/cli/fixtures/config-testTimeout.tap.txt
@@ -6,8 +6,6 @@ not ok 1 slow
   ---
   message: Test took longer than 10ms; test timed out.
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at internal
   ...

--- a/test/cli/fixtures/done-after-timeout.tap.txt
+++ b/test/cli/fixtures/done-after-timeout.tap.txt
@@ -6,8 +6,6 @@ not ok 1 times out before scheduled done is called
   ---
   message: Test took longer than 10ms; test timed out.
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at internal
   ...

--- a/test/cli/fixtures/drooling-done.tap.txt
+++ b/test/cli/fixtures/drooling-done.tap.txt
@@ -9,8 +9,6 @@ not ok 1 Test A
         at /qunit/test/cli/fixtures/drooling-done.js:5:7
         at internal
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: this is an intentional error
         at /qunit/test/cli/fixtures/drooling-done.js:8:9

--- a/test/cli/fixtures/drooling-extra-done.tap.txt
+++ b/test/cli/fixtures/drooling-extra-done.tap.txt
@@ -11,8 +11,6 @@ not ok 2 Test B
         at /qunit/test/cli/fixtures/drooling-extra-done.js:13:7
         at internal
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: Unexpected release of async pause during a different test.
     > Test: Test A [async #1]

--- a/test/cli/fixtures/hanging-test.tap.txt
+++ b/test/cli/fixtures/hanging-test.tap.txt
@@ -1,13 +1,11 @@
 # name: test that hangs
-# command: ["qunit","hanging-test.js"]
+# command: ["qunit", "hanging-test.js"]
 
 TAP version 13
 not ok 1 hanging
   ---
   message: Test took longer than 3000ms; test timed out.
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at internal
   ...

--- a/test/cli/fixtures/hooks-global-throw.tap.txt
+++ b/test/cli/fixtures/hooks-global-throw.tap.txt
@@ -5,8 +5,6 @@ not ok 1 global hook throws
   ---
   message: Global beforeEach failed on global hook throws: Error: banana
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: banana
         at /qunit/test/cli/fixtures/hooks-global-throw.js:3:11
@@ -14,8 +12,6 @@ not ok 1 global hook throws
   ---
   message: Global afterEach failed on global hook throws: Error: apple
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: apple
         at /qunit/test/cli/fixtures/hooks-global-throw.js:17:11
@@ -24,8 +20,6 @@ not ok 2 global hook rejects
   ---
   message: "Promise rejected before \"global hook rejects\": banana"
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: banana
         at /qunit/test/cli/fixtures/hooks-global-throw.js:5:27
@@ -33,8 +27,6 @@ not ok 2 global hook rejects
   ---
   message: "Promise rejected after \"global hook rejects\": apple"
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: apple
         at /qunit/test/cli/fixtures/hooks-global-throw.js:19:27
@@ -43,8 +35,6 @@ not ok 3 global hook with bad thenable
   ---
   message: "Promise rejected before \"global hook with bad thenable\": global brocoli"
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: global brocoli
         at /qunit/test/cli/fixtures/hooks-global-throw.js:9:15
@@ -52,8 +42,6 @@ not ok 3 global hook with bad thenable
   ---
   message: "Promise rejected after \"global hook with bad thenable\": global artichoke"
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: global artichoke
         at /qunit/test/cli/fixtures/hooks-global-throw.js:23:15

--- a/test/cli/fixtures/pending-async-after-timeout.tap.txt
+++ b/test/cli/fixtures/pending-async-after-timeout.tap.txt
@@ -1,13 +1,11 @@
 # name: test with pending async after timeout
-# command: ["qunit","pending-async-after-timeout.js"]
+# command: ["qunit", "pending-async-after-timeout.js"]
 
 TAP version 13
 not ok 1 example
   ---
   message: Test took longer than 10ms; test timed out.
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at internal
   ...

--- a/test/cli/fixtures/timeout.tap.txt
+++ b/test/cli/fixtures/timeout.tap.txt
@@ -6,8 +6,6 @@ not ok 1 timeout > first
   ---
   message: Test took longer than 10ms; test timed out.
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
         at internal
   ...

--- a/test/cli/fixtures/too-many-done-calls.tap.txt
+++ b/test/cli/fixtures/too-many-done-calls.tap.txt
@@ -10,8 +10,6 @@ not ok 1 Test A
         at /qunit/test/cli/fixtures/too-many-done-calls.js:1:7
         at internal
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: Tried to release async pause that was already released.
     > Test: Test A [async #1]

--- a/test/cli/fixtures/uncaught-error-after-assert-async.tap.txt
+++ b/test/cli/fixtures/uncaught-error-after-assert-async.tap.txt
@@ -9,8 +9,6 @@ not ok 1 contains a hard error after using assert.async()
         at /qunit/test/cli/fixtures/uncaught-error-after-assert-async.js:1:7
         at internal
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: expected error thrown in test
         at /qunit/test/cli/fixtures/uncaught-error-after-assert-async.js:4:9

--- a/test/cli/fixtures/uncaught-error-in-hook.tap.txt
+++ b/test/cli/fixtures/uncaught-error-in-hook.tap.txt
@@ -6,8 +6,6 @@ not ok 1 contains a hard error in hook > contains a hard error
   ---
   message: before failed on contains a hard error: expected error thrown in hook
   severity: failed
-  actual  : null
-  expected: undefined
   stack: |
     Error: expected error thrown in hook
         at /qunit/test/cli/fixtures/uncaught-error-in-hook.js:3:11

--- a/test/cli/fixtures/unhandled-rejection.tap.txt
+++ b/test/cli/fixtures/unhandled-rejection.tap.txt
@@ -18,8 +18,6 @@ not ok 2 Unhandled Rejections > test passes just fine, but has a rejected promis
   ---
   message: global failure: Error: Error thrown in non-returned promise!
   severity: failed
-  actual  : undefined
-  expected: undefined
   stack: |
     Error: Error thrown in non-returned promise!
         at /qunit/test/cli/fixtures/unhandled-rejection.js:10:13


### PR DESCRIPTION
### pushFailure

This was setting `actual: null` and, left expected unset/undefined. In HtmlReporter this idom was recognised to mean "don't show values", based on hasOwn for `expected`. This worked because QUnit.log() passes the internal assert result object as-is.

In TAP output, this was not skipped because Test.js#logAssertion copies the object for the testEnd.errors array, and in doing so forges an `expected` property to exist no matter what, thus with an implied value of undefined. The hasOwn checks in TapReporter thus always evaluate to true.

This meant TAP output for pushFailure() calls not only showed redundant actual/expected entries, but actively created confusion by setting them to different values, drawing attention to a supposed difference that has no meaning

> actual: null
> expected: undefined

Fix by changing pushFailure to omit both actual and expected, and change the condition in both reporters to skip rendering of values based on both being strictly equal to `undefined`, instead of based on `hasOwn('expected')`.

Before:
```tap
TAP version 13
not ok 1 example
  ---
  message: Expected 2 assertions, but 1 were run
  severity: failed
  actual  : null
  expected: undefined
  stack: |
        at /test/example.test.js:1:7
```

After:
```tap
TAP version 13
not ok 1 example
  ---
  message: Expected 2 assertions, but 1 were run
  severity: failed
  stack: |
        at /test/example.test.js:1:7
```

### onUncaughtException / `QUnit.on('error')`

For uncaught errors, we already omitted both actual and undefined, the HtmlReporter thus already skipped them (for the reason above), but in TAP output they showed, for the same reason as above as:

> actual: undefined
> expected: undefined

Which, while not as actively confusing, is at least redundant. This is naturally fixed by the same change, which now omits this.

Before:

```tap
TAP version 13
Bail out! Error: boo example
  ---
  message: Error: boo example
  severity: failed
  actual  : undefined
  expected: undefined
  stack: |
        at /test.js:3:7
  ...
```

After:

```tap
TAP version 13
Bail out! Error: boo example
  ---
  message: Error: boo example
  severity: failed
  stack: |
        at /test.js:3:7
  ...
```