### PR TITLE
Add viewport meta tag to browser testing example HTML

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -23,6 +23,7 @@ QUnit releases are standalone and require no runtime dependencies for use in the
 <!DOCTYPE html>
 <html>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
 <title>QUnit</title>
 <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.26.0.css">
 <body>


### PR DESCRIPTION
To enable viewing at native size on mobile browsers. This was added to the docs before (https://github.com/qunitjs/qunitjs.com/pull/110 ), but seems to have got lost in a subsequent change.